### PR TITLE
Feature/pydantic

### DIFF
--- a/annotation/clinvar_xml_parser.py
+++ b/annotation/clinvar_xml_parser.py
@@ -38,7 +38,7 @@ CLINVAR_REVIEW_STATUS_TO_STARS = {
 }
 
 
-@dataclass
+@dataclass(frozen=True)
 class ClinVarXmlParserOutput:
     """
     When we retrieve from ClinVar, this is our result.

--- a/annotation/templatetags/clinvar_tags.py
+++ b/annotation/templatetags/clinvar_tags.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass
 from typing import Optional, Union
-
 from django.template import Library
 from more_itertools import first
+import pydantic
+from pydantic import ConfigDict
 
 from annotation.models import ClinVar, AnnotationVersion
 from annotation.utils.clinvar_constants import CLINVAR_REVIEW_EXPERT_PANEL_STARS_VALUE
@@ -21,8 +21,9 @@ def clinvar_stars(stars, review_status: Optional[str] = None):
     return {"stars": star_bools, "review_status": review_status}
 
 
-@dataclass
-class ClinVarDetails:
+class ClinVarDetails(pydantic.BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True, strict=True)
+
     """
     All the data that we have from ClinVar based on the pre-loaded annotations.
     If we don't have a ClinVar instance, then we have access to the g_hgvs so we can prompt the user to search
@@ -37,7 +38,7 @@ class ClinVarDetails:
 
     genome_build: GenomeBuild
     annotation_version: AnnotationVersion
-    g_hgvs: str
+    g_hgvs: Optional[str]
 
     @property
     def is_expert_panel_or_greater(self) -> bool:

--- a/classification/tests/models/test_classification_modifications.py
+++ b/classification/tests/models/test_classification_modifications.py
@@ -274,20 +274,6 @@ class ClassificationTestCaseModifications(TestCase):
         self.assertEqual('Big bold Toe', vc.get(SpecialEKeys.CONDITION))
         self.assertEqual('Some <i>italic</i> literature', vc.get(SpecialEKeys.LITERATURE))
 
-    def test_test_mode(self):
-        lab, user = ClassificationTestUtils.lab_and_user()
-        vc = Classification.create(
-            user=user,
-            lab=lab,
-            lab_record_id=None,
-            data={
-                SpecialEKeys.C_HGVS: 'g.301A>C',
-                SpecialEKeys.ZYGOSITY: 'zany'
-            },
-            save=False,
-            source=SubmissionSource.API,
-            make_fields_immutable=True)
-        self.assertEqual(vc.id, None)
 
     def test_regexes(self):
         """

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,8 @@ dependencies:
   - Unidecode=1.3
   - boto3=1.26
   - pyspellchecker=0.6
-
+  - pydantic=2.3.0
+  - deepdiff=6.5.0
   - gdal=3.7  # needed for geo
   - pip:
       - cdot==0.2.21

--- a/genes/hgvs/hgvs_matcher.py
+++ b/genes/hgvs/hgvs_matcher.py
@@ -114,8 +114,12 @@ class HGVSMatcher:
             variant_coord = ca.get_variant_coordinate(self.genome_build)
             # Was converted to internal, need to return raw strings so standard base validation is OK
             if variant_coord.alt == Variant.REFERENCE_ALT:
-                variant_coord = VariantCoordinate(variant_coord.chrom, variant_coord.start, variant_coord.end,
-                                                  variant_coord.ref, variant_coord.ref)  # ref == alt
+                variant_coord = VariantCoordinate(
+                    chrom=variant_coord.chrom,
+                    start=variant_coord.start,
+                    end=variant_coord.end,
+                    ref=variant_coord.ref,
+                    alt=variant_coord.ref)  # ref == alt
             return variant_coord
         except ClinGenAlleleAPIException:
             self.attempt_clingen = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,3 +78,5 @@ django-storages==1.12.3
 django_threadlocals==0.10
 pyspellchecker==0.6.3
 frozendict==2.3.4
+pydantic==2.3.0
+deepdiff==6.5.0

--- a/upload/models/models.py
+++ b/upload/models/models.py
@@ -587,7 +587,7 @@ class ModifiedImportedVariant(models.Model):
         for ov in ModifiedImportedVariant._split_old_variant(old_variant):
             vc = ModifiedImportedVariant._to_variant_coordinate(ov)
             contig = genome_build.chrom_contig_mappings[vc.chrom]
-            variant_coordinate = VariantCoordinate(contig.name, vc.start, vc.end, vc.ref, vc.alt)
+            variant_coordinate = VariantCoordinate(chrom=contig.name, start=vc.start, end=vc.end, ref=vc.ref, alt=vc.alt)
             formatted_old_variants.append(ModifiedImportedVariant.get_old_variant_from_variant_coordinate(variant_coordinate))
         return formatted_old_variants
 

--- a/upload/tasks/vcf/unknown_variants_task.py
+++ b/upload/tasks/vcf/unknown_variants_task.py
@@ -50,7 +50,7 @@ class BulkUnknownVariantInserter:
         # Pre-processed by vcf_filter_unknown_contigs so only recognised contigs present
         # This has been decomposed (only be 1 alt per line)
         ref, alt, end = vcf_get_ref_alt_end(variant)
-        variant_coordinate = VariantCoordinate(variant.CHROM, variant.POS, end, ref, alt)
+        variant_coordinate = VariantCoordinate(chrom=variant.CHROM, start=variant.POS, end=end, ref=ref, alt=alt)
         self.variant_pk_lookup.add(variant_coordinate)
         self.batch_process_check()
 
@@ -162,7 +162,7 @@ class InsertUnknownVariantsTask(ImportVCFStepTask):
             # Python CSV reader dies with extremely long lines, so we just do by hand (not quoted or anything)
             for line in f:
                 chrom, start, end, ref, alt = line.strip().split(",")  # Not quoted, exactly 5 columns
-                variant_coordinate = VariantCoordinate(chrom, int(start), int(end), ref, alt)
+                variant_coordinate = VariantCoordinate(chrom=chrom, start=int(start), end=int(end), ref=ref, alt=alt)
                 variant_pk_lookup.add(variant_coordinate)
                 variant_pk_lookup.batch_check(settings.SQL_BATCH_INSERT_SIZE, insert_unknown=True)
                 items_processed += 1

--- a/upload/vcf/bulk_genotype_vcf_processor.py
+++ b/upload/vcf/bulk_genotype_vcf_processor.py
@@ -321,7 +321,7 @@ class BulkGenotypeVCFProcessor(AbstractBulkVCFProcessor):
         phred_likelihood_str = self.get_phred_likelihood_str(variant)
         samples_filters_str = self.get_samples_filters_str(variant)
 
-        variant_coordinate = VariantCoordinate(variant.CHROM, variant.POS, end, ref, alt)
+        variant_coordinate = VariantCoordinate(chrom=variant.CHROM, start=variant.POS, end=end, ref=ref, alt=alt)
         alt_hash = self.variant_pk_lookup.get_variant_coordinate_hash(variant_coordinate)
         format_json = self._get_format_json(self.num_samples, variant)
         info_json = self._get_info_json(variant)

--- a/upload/vcf/bulk_minimal_vcf_processor.py
+++ b/upload/vcf/bulk_minimal_vcf_processor.py
@@ -28,7 +28,7 @@ class BulkMinimalVCFProcessor(AbstractBulkVCFProcessor):
 
     def process_entry(self, variant):
         ref, alt, end = vcf_get_ref_alt_end(variant)
-        variant_coordinate = VariantCoordinate(variant.CHROM, variant.POS, end, ref, alt)
+        variant_coordinate = VariantCoordinate(chrom=variant.CHROM, start=variant.POS, end=end, ref=ref, alt=alt)
         variant_hash = self.variant_pk_lookup.get_variant_coordinate_hash(variant_coordinate)
         self.variant_hashes.append(variant_hash)
         self.add_modified_imported_variant(variant, variant_hash)

--- a/upload/vcf/bulk_no_genotype_vcf_processor.py
+++ b/upload/vcf/bulk_no_genotype_vcf_processor.py
@@ -48,7 +48,7 @@ class BulkNoGenotypeVCFProcessor(BulkGenotypeVCFProcessor):
     def process_entry(self, variant):
         # Pre-processed by vcf_filter_unknown_contigs so only recognised contigs present
         ref, alt, end = vcf_get_ref_alt_end(variant)
-        variant_coordinate = VariantCoordinate(variant.CHROM, variant.POS, end, ref, alt)
+        variant_coordinate = VariantCoordinate(chrom=variant.CHROM, start=variant.POS, end=end, ref=ref, alt=alt)
         alt_hash = self.variant_pk_lookup.get_variant_coordinate_hash(variant_coordinate)
 
         # Don't need to worry about processing all loci - go straight onto variant lists for insert


### PR DESCRIPTION
So pydantic:

Has an implementation of @dataclass but if you want to do anything remotely complicated, you need to extend pydantic.BaseModel

I always make sure to extend "pydantic.BaseModel" instead of "BaseModel" so to reduce confusion with django models.

Another issue is pydantic only works with keyword constructors. So have a look through the code changes and see if it's worth it here. The advantage of pydantic is you can start to get more precise with the validation, e.g. the int must be over zero etc.