### PR TITLE
Security fixes for variantopedia app #3817

### DIFF
--- a/library/health_check.py
+++ b/library/health_check.py
@@ -6,6 +6,7 @@ from typing import Union, Optional, Type
 
 import django.dispatch
 from django.db.models import Model, Q
+from django.utils.html import format_html
 from django.utils.timezone import localtime
 
 from library.log_utils import NotificationBuilder
@@ -84,14 +85,15 @@ class HealthCheckRecentActivity(HealthCheckStat):
         return result
 
     def as_html(self):
-        amount_str = self.amount
         if self.amount:
-            amount_str = f"<span class='health-value'>{amount_str}</span>"
-        result = f"{amount_str} {self.name}"
+            amount_html = format_html("<span class='health-value'>{}</span>", self.amount)
+        else:
+            amount_html = format_html("{}", self.amount)
+        result = format_html("{} {}", amount_html, self.name)
         if self.sub_type:
-            result = f"{result} {self.sub_type}"
+            result = format_html("{} {}", result, self.sub_type)
         if self.extra:
-            result = f"{result} {self.extra}"
+            result = format_html("{} {}", result, self.extra)
         return result
 
     @classmethod
@@ -200,12 +202,13 @@ class HealthCheckTotalAmount(HealthCheckStat):
         return result
 
     def as_html(self):
-        amount_str = self.amount
         if self.amount:
-            amount_str = f"<span class='health-value'>{amount_str:,}</span>"
-        result = f"{amount_str} {self.name}"
+            amount_html = format_html("<span class='health-value'>{:,}</span>", self.amount)
+        else:
+            amount_html = format_html("{}", self.amount)
+        result = format_html("{} {}", amount_html, self.name)
         if self.extra:
-            result = f"{result} - {self.extra}"
+            result = format_html("{} - {}", result, self.extra)
         return result
 
     @classmethod
@@ -226,7 +229,7 @@ class HealthCheckCapacity(HealthCheckStat):
         return f"{emoji} {self.name} ({self.used} used, {self.available} available)"
 
     def as_html(self):
-        return f"{self.name} ({self.used} used, {self.available} available)"
+        return format_html("{} ({} used, {} available)", self.name, self.used, self.available)
 
     @classmethod
     def sort_order(cls):
@@ -269,8 +272,8 @@ class HealthCheckAge(HealthCheckStat):
 
     def as_html(self):
         if not self.last_performed_tz:
-            return f"<span class='health-value'>Never Run</span> {self.name}"
-        return f"<span class='health-value'><b>{self.age_in_days}</b> days old</span> {self.name}"
+            return format_html("<span class='health-value'>Never Run</span> {}", self.name)
+        return format_html("<span class='health-value'><b>{}</b> days old</span> {}", self.age_in_days, self.name)
 
     _MULTIPLIER_TO_FACE = {
         0: ":simple_smile:",

--- a/variantopedia/grids.py
+++ b/variantopedia/grids.py
@@ -352,5 +352,6 @@ class VariantTagDetailColumns(DatatableConfig[VariantTag]):
         # Not going to use anything build specific so don't care about build
         genome_build = variant.any_genome_build
         qs = VariantTag.get_for_build(genome_build, variant_qs=variant.equivalent_variants)
+        qs = VariantTag.filter_for_user(self.user, queryset=qs)
         qs = qs.filter(tag=tag)
         return qs

--- a/variantopedia/views.py
+++ b/variantopedia/views.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
 from django.db import connection
 from django.forms import model_to_dict
 from django.shortcuts import get_object_or_404, render, redirect
@@ -362,8 +363,10 @@ def database_statistics(request):
 def variant_tag_detail(request, variant_id, tag):
     """ Loaded via tags grid on variant page """
 
-    variant = Variant.objects.get(pk=variant_id)
+    variant = get_object_or_404(Variant, pk=variant_id)
     tag = get_object_or_404(Tag, pk=tag)
+    if not VariantTag.filter_for_user(request.user).filter(variant=variant, tag=tag).exists():
+        raise PermissionDenied
     context = {
         "variant": variant,
         "tag": tag,
@@ -610,7 +613,7 @@ def export_classifications_allele(request, allele_id: int):
     """
     CSV export of what is currently filtered into the classification grid
     """
-    allele = Allele.objects.get(pk=allele_id)
+    allele = get_object_or_404(Allele, pk=allele_id)
     return ClassificationExportFormatterCSV(
         ClassificationFilter(
             user=request.user,
@@ -657,7 +660,7 @@ def variant_details_annotation_version(request, variant_id, annotation_version_i
                                        extra_context: dict = None):
     """ Main Variant Details page """
     variant = get_object_or_404(Variant, pk=variant_id)
-    annotation_version = AnnotationVersion.objects.get(pk=annotation_version_id)
+    annotation_version = get_object_or_404(AnnotationVersion, pk=annotation_version_id)
     genome_build = annotation_version.genome_build
     latest_annotation_version = AnnotationVersion.latest(genome_build)
     variant_annotation = None
@@ -784,7 +787,7 @@ def nearby_variants_tab(request, variant_id, annotation_version_id):
 
 def nearby_variants(request, variant_id, annotation_version_id):
     variant = get_object_or_404(Variant, pk=variant_id)
-    annotation_version = AnnotationVersion.objects.get(pk=annotation_version_id)
+    annotation_version = get_object_or_404(AnnotationVersion, pk=annotation_version_id)
 
     variant_annotation_version = annotation_version.variant_annotation_version
     variant_annotation = variant.variantannotation_set.filter(version=variant_annotation_version).first()


### PR DESCRIPTION
🤖 Written by Claude

Fixes from security review of the `variantopedia` app (SACGF/variantgrid_private#3817).

## Changes

**Finding #1 — Replace `.objects.get()` with `get_object_or_404()`**
- `variant_tag_detail()` — `Variant`
- `export_classifications_allele()` — `Allele`
- `variant_details_annotation_version()` — `AnnotationVersion`
- `nearby_variants()` — `AnnotationVersion`

**Finding #3 — XSS via `|safe` in health check template**
- All `as_html()` methods in `library/health_check.py` now use `format_html()` so user-controlled content (usernames, HGVS strings, email subjects in `extra` fields) is properly escaped before being marked safe.

**Finding #4 — Missing authorization check in `variant_tag_detail`**
- View: raises `PermissionDenied` if the user has no readable `VariantTag` for the requested variant+tag.
- Grid (`VariantTagDetailColumns`): applies `VariantTag.filter_for_user()` to the queryset so the datatable only returns tags the user has permission to see.