### PR TITLE
Security: vcauth admin permission check and exception handling

### DIFF
--- a/vcauth/user_admin.py
+++ b/vcauth/user_admin.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.contrib import messages
 from django.contrib.auth.admin import UserAdmin
 
 from classification.views.classification_email_view import send_summary_email_to_user
+
+logger = logging.getLogger(__name__)
 
 
 class CustomUserAdmin(UserAdmin):
@@ -19,10 +23,12 @@ class CustomUserAdmin(UserAdmin):
                                       f"Email Server Issue or Emails disabled for sending {user.username} at {user.email} an email",
                                       messages.WARNING)
 
-            except Exception as ex:
-                self.message_user(request, f"Error {ex} when sending {user.username} at {user.email} an email", messages.ERROR)
+            except Exception:
+                logger.exception("Failed to send summary email to %s", user.username)
+                self.message_user(request, f"Failed to send email to {user.username}. Check server logs.", messages.ERROR)
 
         self.message_user(request, 'Emailed %i users' % count)
 
+    email_discordance.allowed_permissions = ['change']
     email_discordance.short_description = "Email weekly summary"
     actions = [email_discordance]


### PR DESCRIPTION
## Summary

Fixes two security issues identified in the `vcauth` admin (see SACGF/variantgrid_private#3822):

- **HIGH:** Added `allowed_permissions = ['change']` to the `email_discordance` action. Without this, any staff user with Django admin access could trigger bulk summary emails regardless of their actual permissions.
- **MEDIUM:** Replaced raw exception exposure in admin messages with server-side logging + a generic error message, preventing internal infrastructure details from leaking to admin users.

## Test plan

- [ ] Log in as a staff user without User `change` permission — confirm "Email weekly summary" action is not available
- [ ] Log in as a staff user with User `change` permission — confirm action works as before
- [ ] Simulate a send failure — confirm generic error message appears in admin UI and exception is logged server-side