### PR TITLE
Security: fix XSS and path traversal in uicore templatetags

### DIFF
--- a/uicore/templates/uicore/menus/menu_bar_main.html
+++ b/uicore/templates/uicore/menus/menu_bar_main.html
@@ -14,7 +14,7 @@
 {% menu_top 'variant_tags' app_name='variantopedia|variants|manual_variant_entry' title='Variants' %}
 {% menu_top 'annotation' app_name='annotation' title='Annotation' %}
 <a class="nav-link" target="_blank" href="{{ help_url }}">Help</a>
-<a id="suggestion" class="nav-link" data-toggle="tooltip" title="Suggestion / Bug Report" href="javascript:suggestionDialog('{{ user.username }}')"><i class="fas fa-bug mt-1"></i></a>
+<a id="suggestion" class="nav-link" data-toggle="tooltip" title="Suggestion / Bug Report" href="javascript:suggestionDialog('{{ user.username|escapejs }}')"><i class="fas fa-bug mt-1"></i></a>
 <!--
 <button type="button" style="color:#866" class="btn bg-transparent" data-toggle="modal" data-target="#vgReportModal"><i class="fas fa-bug mt-1"></i></button>
 -->

--- a/uicore/templatetags/ui_help.py
+++ b/uicore/templatetags/ui_help.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Optional
 
 from django import template
@@ -34,6 +35,9 @@ def page_help(page_id: str = None, title=None, show_title=True, header_tag="h3")
 
     help_url = settings.HELP_URL
     page_help_html = None
+    if page_id and not re.fullmatch(r'[\w\-]+', page_id):
+        report_message(f"page_help: invalid page_id {page_id!r}")
+        page_id = None
     page_help_path = f"page_help/{page_id}.html"
     page_help_filename = finders.find(page_help_path)
     file_exists = False

--- a/uicore/templatetags/ui_utils.py
+++ b/uicore/templatetags/ui_utils.py
@@ -398,7 +398,7 @@ def severity_icon(severity: str, title: Optional[str] = None) -> str:
     title_html = ""
     if title:
         classes.append('hover-detail')
-        title_html = f' title="{title}"'
+        title_html = f' title="{escape(title)}"'
 
     def severity_for(severity_part: str) -> Optional[list[str]]:
         match severity_part:


### PR DESCRIPTION
Fixes items from security review SACGF/variantgrid_private#3832.

## Changes

- **`menu_bar_main.html`** — `{{ user.username|escapejs }}` in JS string context; prevents XSS if a username ever contains a single quote
- **`ui_utils.py` `severity_icon`** — `html.escape(title)` for the `title` HTML attribute; prevents attribute breakout
- **`ui_help.py` `page_help`** — validates `page_id` against `[\w\-]+` before using it in a file path; prevents path traversal

## Items not fixed (already safe or out of scope)

- **`tabs.html` open redirect** — `resolved_url` is only set when `content.startswith('/')` (see `ui_tabs_builder.py:222`), so external URLs are already rejected
- **`admin_link.html` info disclosure** — the tag already returns `{}` for non-superusers before `is_admin` is ever set; the warning is superuser-only
- **`help.html` `| safe`** — intentional; content is from static files or rendered template nodelists (developer-controlled), not user input
- **Inline `<script>` blocks** — CSP backlog item, no immediate security impact