### PR TITLE
Security hardening: genes app

### DIFF
--- a/genes/panel_app.py
+++ b/genes/panel_app.py
@@ -1,4 +1,5 @@
 import logging
+import urllib.parse
 from typing import Optional, Union
 
 import requests
@@ -28,7 +29,7 @@ def get_request(url):
 
 
 def get_panel_app_results_by_gene_symbol_json(server: PanelAppServer, gene_symbol: Union[str, GeneSymbol]) -> Optional[dict]:
-    url = server.url + PANEL_APP_SEARCH_BY_GENES_BASE_PATH + str(gene_symbol)
+    url = server.url + PANEL_APP_SEARCH_BY_GENES_BASE_PATH + urllib.parse.quote(str(gene_symbol), safe="")
     r = get_request(url)
     results = None
     if r.ok:
@@ -44,7 +45,8 @@ def _get_panel_app_panel_api_json(panel_app_panel):
     # Panel App isn't very REST-ful - returns 200 for missing data, but we'll return 404
     if detail := json_data.get("detail"):
         if detail == "Not found.":
-            raise NotFound(detail=f"PanelApp couldn't find {panel_app_panel.panel_id} ({r.url})")
+            logging.warning("PanelApp couldn't find panel %s at %s", panel_app_panel.panel_id, r.url)
+            raise NotFound(detail=f"PanelApp couldn't find panel {panel_app_panel.panel_id}")
 
     return json_data
 

--- a/genes/templates/genes/hotspot_graph.html
+++ b/genes/templates/genes/hotspot_graph.html
@@ -284,7 +284,10 @@
                     let barClicked = data.points[0];
                     let i = barClicked.data.x.indexOf(String(barClicked.x));
                     let text = "Hotspot click " + barClicked.data.text[i];
-                    eval(hotspot_graph_click_func + "('{{ transcript_version.pk }}', text, barClicked.x);");
+                    const fn = window[hotspot_graph_click_func];
+                    if (typeof fn === 'function') {
+                        fn('{{ transcript_version.pk }}', text, barClicked.x);
+                    }
                 }
             });
         }

--- a/genes/views/views_rest.py
+++ b/genes/views/views_rest.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections import defaultdict
 
 from django.http.response import Http404
@@ -20,11 +21,12 @@ from genes.panel_app import get_panel_app_panel_as_gene_list_json
 from genes.panel_app import get_panel_app_results_by_gene_symbol_json
 from genes.serializers import GeneInfoSerializer, GeneListGeneSymbolSerializer, GeneListSerializer, \
     GeneAnnotationReleaseSerializer, SampleGeneListSerializer
-from library.constants import WEEK_SECS
+from library.constants import HOUR_SECS, WEEK_SECS
 from library.django_utils.django_rest_utils import MultipleFieldLookupMixin
 from library.guardian_utils import DjangoPermission
-from library.log_utils import get_traceback
 from snpdb.models.models_enums import ImportStatus
+
+log = logging.getLogger(__name__)
 
 
 def is_owner_or_has_permission_factory(django_permission):
@@ -46,6 +48,7 @@ WriteGeneListPermission = is_owner_or_has_permission_factory(DjangoPermission.WR
 class PanelAppGeneListView(APIView):
     """ Tunnels through to panel app (can't make cross site requests) """
 
+    @method_decorator(cache_page(HOUR_SECS))
     def get(self, request, *args, **kwargs):
         panel_app_id = self.kwargs['pk']
         data = get_panel_app_panel_as_gene_list_json(panel_app_id)
@@ -124,7 +127,8 @@ class CreateGeneListView(APIView):
             gene_matcher.create_gene_list_gene_symbols(gene_list, gene_symbols, modification_info)
             import_status = ImportStatus.SUCCESS
         except Exception:
-            gene_list.error_message = get_traceback()
+            log.exception("Error creating gene list %d for user %s", gene_list.pk, request.user)
+            gene_list.error_message = "An error occurred while importing the gene list."
             import_status = ImportStatus.ERROR
 
         gene_list.import_status = import_status


### PR DESCRIPTION
Fixes security findings from SACGF/variantgrid_private#3826 (private issue — low/medium severity, no immediately exploitable vulnerabilities).

## Changes

- **`genes/panel_app.py`** — URL-encode gene symbol before appending to outbound PanelApp API URL (`urllib.parse.quote`) to prevent path/query manipulation in the external request
- **`genes/panel_app.py`** — On PanelApp 404, log the internal request URL server-side only; remove it from the user-facing error response to avoid leaking configured server URLs
- **`genes/views/views_rest.py`** — In `CreateGeneListView`, log gene list import errors server-side (`log.exception`) and return a generic message to the client instead of a full Python traceback (which could expose server filesystem paths)
- **`genes/views/views_rest.py`** — Add 1-hour `cache_page` to `PanelAppGeneListView` to throttle repeated outbound proxy requests
- **`genes/templates/genes/hotspot_graph.html`** — Replace `eval()` in hotspot graph click handler with `window[fn]` function dispatch (defence-in-depth against DOM-based XSS)

## Exploitability notes

None of these findings are immediately exploitable by an authenticated attacker:
- The PanelApp URL injection only affects outbound requests to an external API (not SSRF — server URL is DB-managed)
- The traceback is only visible to the user who created their own gene list
- The `eval()` uses a hardcoded function name set in trusted server-side templates
- The PanelApp URL exposure reveals only a configured server base URL

All changes are safe to include in a public PR.