### PR TITLE
Security fixes for library/ (SACGF/variantgrid_private#3833)

### DIFF
--- a/library/preview_request.py
+++ b/library/preview_request.py
@@ -223,7 +223,7 @@ class PreviewData:
             try:
                 internal_url = obj.get_absolute_url()
             except NoReverseMatch:
-                internal_url = "javascript:alert('Could not load a view for this type of result')"
+                internal_url = None
 
         if genome_builds is None:
             if hasattr(obj, "genome_build") and (genome_build := obj.genome_build):

--- a/library/utils/database_utils.py
+++ b/library/utils/database_utils.py
@@ -126,7 +126,7 @@ def sql_delete_qs(qs, batch_size: Optional[int] = None) -> int:
     pk_qs = qs.values_list("pk", flat=True)
     meta = qs.model._meta
     if batch_size:
-        limit = f"LIMIT {batch_size}"
+        limit = f"LIMIT {int(batch_size)}"
     else:
         limit = ""
 

--- a/library/utils/diff_utils.py
+++ b/library/utils/diff_utils.py
@@ -189,7 +189,7 @@ class MultiDiffOutput:
         #     return SafeString(f"<span class='diff-text'>{escape(self.input.text)}</span>")
         # else:
         return SafeString("<span class='diff-text'>" + "".join(
-            f"<span class='diff-text-{diff.operation_name}'>{escape(diff.text)}</span>" for diff in self.diffs
+            f"<span class='diff-text-{escape(diff.operation_name)}'>{escape(diff.text)}</span>" for diff in self.diffs
         ) + "</span>")
 
     def append(self, op: str, segment: str) -> 'MultiDiffOutput':

--- a/library/utils/file_utils.py
+++ b/library/utils/file_utils.py
@@ -144,7 +144,7 @@ def add_permissions_to_file(filename: str, add_stat: int):
     try:
         os.chmod(filename, st.st_mode | add_stat)
     except Exception as e:
-        logging.error("Path '%s' stat is %s", filename, st)
+        logging.debug("Path '%s' stat is %s", filename, st)
         raise e
 
 

--- a/library/utils/html_utils.py
+++ b/library/utils/html_utils.py
@@ -1,11 +1,10 @@
-import html
 import re
 import uuid
 from html import escape
 from typing import Optional
 
 from bs4 import BeautifulSoup
-from django.utils.safestring import mark_safe, SafeString
+from django.utils.safestring import SafeString
 
 
 def html_id_safe(text: str) -> str:
@@ -20,12 +19,6 @@ def html_id_safe(text: str) -> str:
     if not text[0].isalpha():
         text = "x" + text
     return text
-
-
-def html_link(url: str, title: str) -> SafeString:
-    if not url:
-        return mark_safe(title)
-    return mark_safe(f"<a href='{url}'>{html.escape(title)}</a>")
 
 
 # note this tags expected in a single line of text

--- a/uicore/templates/uicore/tags/preview_tag.html
+++ b/uicore/templates/uicore/tags/preview_tag.html
@@ -1,7 +1,7 @@
 {% load classification_tags %}
 <div class="preview-data">
     <i class="{{ preview.icon }} preview-icon"></i>
-    <span class="preview-category">{{ preview.category }}</span>&nbsp;<a class="preview-identifier" href="{{ preview.internal_url }}" target="_blank" class="hover-link">{{ preview.identifier }}</a>
+    <span class="preview-category">{{ preview.category }}</span>&nbsp;{% if preview.internal_url %}<a class="preview-identifier hover-link" href="{{ preview.internal_url }}" target="_blank">{{ preview.identifier }}</a>{% else %}<span class="preview-identifier preview-no-link" title="No view available for this result">{{ preview.identifier }}</span>{% endif %}
     {% if preview.title %}<span class="preview-title">{{ preview.title }}</span>{% endif %}
     {% if preview.summary_all %}
         <div class="preview-key-values">


### PR DESCRIPTION
## Summary

Security hardening for the shared `library/` utilities, addressing findings from SACGF/variantgrid_private#3833.

- Remove unused `html_link()` which had an unescaped URL in its href attribute
- `preview_request`: replace `javascript:alert(...)` fallback with `None` on `NoReverseMatch`
- `database_utils`: `int()` cast on `batch_size` before SQL string interpolation in `sql_delete_qs`
- `diff_utils`: `escape(diff.operation_name)` in generated CSS class attribute
- `file_utils`: downgrade path+stat logging on `chmod` failure from `ERROR` to `DEBUG`

None of these are currently exploitable via user input — see the issue for the full exploitability assessment. These are defence-in-depth fixes.

## Test plan

- [ ] Run existing test suite (`python3 manage.py test --keepdb`)
- [ ] Verify preview cards still render for objects whose `get_absolute_url()` raises `NoReverseMatch` (no link shown, no JS executed)
- [ ] Confirm diff views render correctly (no visible change expected)