### PR TITLE
review app - permission and validation hardening

### DIFF
--- a/review/models/review_models.py
+++ b/review/models/review_models.py
@@ -133,7 +133,7 @@ class ReviewedObject(TimeStampedModel):
         # or by us directly going through the
         foreign_sets = [m for m in dir(self) if m.endswith('_set') and not m.startswith('reviews')]
         for foreign_set in foreign_sets:
-            source_object = getattr(self, foreign_set).first()
+            source_object = getattr(self, foreign_set).order_by('pk').first()
             if source_object:
                 return source_object
 

--- a/review/templates/review/review.html
+++ b/review/templates/review/review.html
@@ -23,7 +23,7 @@
 {% block content %}
     <div class="container">
         <form method="post">
-            {% csrf_token action="{{ request.path }}" %}
+            {% csrf_token %}
 
             {% if not review.pk %}<h4>Step 1 of 2</h4>{% endif %}
 

--- a/review/views/review_views.py
+++ b/review/views/review_views.py
@@ -131,7 +131,9 @@ def _handle_review(request, review: Review, reviewing: Optional[ReviewableModelM
     else:
         initial = {}
         if not review.pk:
-            initial["reviewing_labs"] = {UserSettings.get_for_user(request.user).default_lab}
+            default_lab = UserSettings.get_for_user(request.user).default_lab
+            if default_lab in review.reviewing.source_object.reviewing_labs:
+                initial["reviewing_labs"] = {default_lab}
         discussion_form = ReviewForm(review=review, initial=initial)
 
     return render(request, 'review/review.html', {
@@ -144,9 +146,9 @@ def _handle_review(request, review: Review, reviewing: Optional[ReviewableModelM
 
 def new_review(request, reviewed_object_id: int, topic_id: str):
     reviewed_object = ReviewedObject.objects.get(pk=reviewed_object_id)
-
     topic = ReviewTopic.objects.get(pk=topic_id)
     review = reviewed_object.new_review(topic=topic, user=request.user)
+    review.check_can_view(request.user)
 
     return _handle_review(request=request, review=review, reviewing=reviewed_object)
 

--- a/review/widgets/multi_lab_selector.py
+++ b/review/widgets/multi_lab_selector.py
@@ -1,5 +1,7 @@
 from typing import Iterable, Any
 
+from django.core.exceptions import ValidationError
+
 from snpdb.models import Lab
 from uicore.widgets.radio_other_widget import MultiChoiceFieldWithOther, CheckboxOtherWidget
 
@@ -20,5 +22,11 @@ class MultiChoiceLabField(MultiChoiceFieldWithOther):
 
     def to_python(self, value):
         if isinstance(value, (set, list, tuple)):
-            return [self.labs[int(v)] for v in value]
+            result = []
+            for v in value:
+                try:
+                    result.append(self.labs[int(v)])
+                except (KeyError, ValueError):
+                    raise ValidationError("Invalid lab selection.")
+            return result
         return []


### PR DESCRIPTION
Closes part of SACGF/variantgrid_private#3827.

## Changes

- **`new_review()` permission check**: `new_review()` now calls `review.check_can_view(request.user)` before rendering, making it consistent with `edit_review()` which already did this.
- **Default lab filtering**: The default lab pre-selection on a new review is now filtered to only include labs that are valid for the reviewed object, preventing a misleading pre-selection that would fail on submit.
- **`MultiChoiceLabField` validation**: `to_python()` now raises a `ValidationError` on unrecognised lab PKs instead of a bare `KeyError` (which would produce a 500).
- **Deterministic `source_object` resolution**: Added `order_by('pk')` to the `.first()` call so the result is stable rather than database-ordering-dependent.
- **Template `{% csrf_token %}` cleanup**: Removed a spurious `action="{{ request.path }}"` attribute that Django silently ignores — the form already defaults to the current URL.