### PR TITLE
flags app security hardening

### DIFF
--- a/flags/admin.py
+++ b/flags/admin.py
@@ -24,8 +24,6 @@ class FlagAdmin(ModelAdminBasics):
     inlines = (FlagCommentAdminTabular,)
 
     def is_readonly_field(self, f) -> bool:
-        if f.name == 'flag_type':
-            return False
         return super().is_readonly_field(f)
 
     def has_add_permission(self, request):

--- a/flags/models/models.py
+++ b/flags/models/models.py
@@ -163,7 +163,7 @@ class Flag(TimeStampedModel):
         if resolution is not None:
             if permission_check:
                 if current_permission < self.flag_type.permission_enum:
-                    raise PermissionError(f"User does not have permission to {resolution.label} flag")
+                    raise PermissionError("Insufficient permissions to change flag resolution")
 
             # don't need to save the flag on creation as it will be created with the correct resolution
             if not first_comment:
@@ -509,11 +509,11 @@ class FlagCollection(models.Model, GuardianPermissionsMixin):
 
         if permission_check:
             if flag_type.context_id != self.context_id:
-                raise PermissionError(f"Flag type {flag_type.id} not available in flag context {self.context.label}")
+                raise PermissionError("Flag type not available in this context")
             current_level = self.permission_level(user)
             required_level = flag_type.raise_permission
             if current_level < required_level:
-                raise PermissionError(f"User does not have {required_level} permissions on flag collection")
+                raise PermissionError("Insufficient permissions to raise this flag type")
 
         if resolution is None:
             resolution = flag_type.default_resolution()

--- a/flags/views/views.py
+++ b/flags/views/views.py
@@ -389,8 +389,8 @@ class FlagsView(APIView):
 
         try:
             flag_helper.add_flag(data=request.data)
-        except ValueError as e:
-            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except ValueError:
+            return Response({'error': 'Invalid flag data'}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(flag_helper.to_json())
 

--- a/flags/views/views.py
+++ b/flags/views/views.py
@@ -5,6 +5,7 @@ from typing import Iterable, Any, Union, Optional
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils import timezone
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -103,11 +104,15 @@ class FlagHelper:
         comment = data.pop('comment', None)
         user_private = data.pop('user_private', False)
         resolution = data.pop('resolution', None)
-        if resolution:
-            resolution = FlagResolution.objects.get(pk=resolution)
+        try:
+            if resolution:
+                resolution = FlagResolution.objects.get(pk=resolution)
+            flag_type_obj = FlagType.objects.get(pk=flag_type)
+        except (FlagResolution.DoesNotExist, FlagType.DoesNotExist) as e:
+            raise ValueError(f"Invalid flag data: {e}") from e
 
         flag = flag_collection.add_flag(
-            FlagType.objects.get(pk=flag_type),
+            flag_type_obj,
             user=self.user,
             comment=comment,
             user_private=user_private,
@@ -221,8 +226,9 @@ class FlagHelper:
                 'name': avatar.preferred_label,
                 'avatar': avatar.url,
                 'color': avatar.background_color,
-                'lab': self.lab_text(user)
             }
+            if user == self.user:
+                json_entry['lab'] = self.lab_text(user)
             users_json.append(json_entry)
         json_data['users'] = users_json
 
@@ -352,11 +358,17 @@ class FlagsView(APIView):
 
         if history:
             # user has now seen the flags, mark them as such
-            history = int(history)
+            try:
+                history = int(history)
+            except (ValueError, TypeError):
+                return Response({'error': 'Invalid history parameter'}, status=400)
             flag_helper.include_history(history)
 
         if since:
-            since = ensure_timezone_aware(datetime.datetime.fromtimestamp(float(since)))
+            try:
+                since = ensure_timezone_aware(datetime.datetime.fromtimestamp(float(since)))
+            except (ValueError, OSError, TypeError):
+                return Response({'error': 'Invalid since parameter'}, status=400)
             flag_helper.include_comments_since(since)
 
         if not history and not since:
@@ -375,12 +387,10 @@ class FlagsView(APIView):
 
         flag_helper = FlagHelper(flag_collections=fc, user=request.user)
 
-        watch = request.data.get('watch')
-        if watch is not None:
-            fc.set_watcher(user=request.user, watch=watch)
-            flag_helper.include_collections()
-        else:
+        try:
             flag_helper.add_flag(data=request.data)
+        except ValueError as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(flag_helper.to_json())
 
@@ -401,8 +411,11 @@ class FlagView(APIView):
         f = Flag.objects.get(pk=pk)  # type: Flag
         data = request.data
         resolution = data.get('resolution', None)
-        if resolution:
-            resolution = FlagResolution.objects.get(pk=resolution)
+        try:
+            if resolution:
+                resolution = FlagResolution.objects.get(pk=resolution)
+        except FlagResolution.DoesNotExist:
+            return Response({'error': 'Invalid resolution'}, status=400)
 
         f.flag_action(
             user=request.user,


### PR DESCRIPTION
Addresses SACGF/variantgrid_private#3830.

## Changes

- Validate `history` and `since` query parameters; return HTTP 400 on invalid input instead of raising an unhandled exception
- Remove dead `set_watcher()` call — the method does not exist on `FlagCollection` and would raise `AttributeError` on any POST with a `watch` parameter
- Handle `FlagType.DoesNotExist` and `FlagResolution.DoesNotExist` in flag creation and resolution update paths; return HTTP 400 instead of 500
- Use generic `PermissionError` messages in `flags/models/models.py` to avoid leaking internal implementation details
- Omit lab affiliation from API user entries for users other than the requester
- Make `flag_type` read-only in `FlagAdmin` — it should be immutable after flag creation