### PR TITLE
eventlog: add field length limits in create_event view

### DIFF
--- a/eventlog/views.py
+++ b/eventlog/views.py
@@ -50,6 +50,11 @@ def create_event(request):
     if severity not in valid_severities:
         return HttpResponseBadRequest("Invalid severity")
 
+    app_name = app_name[:100]
+    event_name = event_name[:200]
+    if details:
+        details = details[:10_000]
+
     Event.objects.create(user=request.user,
                          app_name=app_name,
                          name=event_name,

--- a/eventlog/views.py
+++ b/eventlog/views.py
@@ -52,8 +52,8 @@ def create_event(request):
 
     app_name = app_name[:100]
     event_name = event_name[:200]
-    if details:
-        details = details[:10_000]
+    if details and len(details) > 10_000:
+        details = details[:10_000] + "\n[trimmed to 10000 characters]"
 
     Event.objects.create(user=request.user,
                          app_name=app_name,

--- a/eventlog/views.py
+++ b/eventlog/views.py
@@ -50,17 +50,19 @@ def create_event(request):
     if severity not in valid_severities:
         return HttpResponseBadRequest("Invalid severity")
 
-    fields = {"app_name": app_name, "event_name": event_name, "details": details}
-    max_lengths = {"app_name": 100, "event_name": 200, "details": 10_000}
-    for name, max_length in max_lengths.items():
-        value = fields[name]
+    event_kwargs = {
+        "user": request.user,
+        "app_name": app_name,
+        "name": event_name,
+        "date": timezone.now(),
+        "details": details,
+        "severity": severity,
+    }
+    max_lengths = {"app_name": 100, "name": 200, "details": 10_000}
+    for field, max_length in max_lengths.items():
+        value = event_kwargs[field]
         if value and len(value) > max_length:
-            fields[name] = value[:max_length] + f"\n[trimmed to {max_length} characters]"
+            event_kwargs[field] = value[:max_length] + f"\n[trimmed to {max_length} characters]"
 
-    Event.objects.create(user=request.user,
-                         app_name=fields["app_name"],
-                         name=fields["event_name"],
-                         date=timezone.now(),
-                         details=fields["details"],
-                         severity=severity)
+    Event.objects.create(**event_kwargs)
     return HttpResponse()

--- a/eventlog/views.py
+++ b/eventlog/views.py
@@ -50,15 +50,17 @@ def create_event(request):
     if severity not in valid_severities:
         return HttpResponseBadRequest("Invalid severity")
 
-    app_name = app_name[:100]
-    event_name = event_name[:200]
-    if details and len(details) > 10_000:
-        details = details[:10_000] + "\n[trimmed to 10000 characters]"
+    fields = {"app_name": app_name, "event_name": event_name, "details": details}
+    max_lengths = {"app_name": 100, "event_name": 200, "details": 10_000}
+    for name, max_length in max_lengths.items():
+        value = fields[name]
+        if value and len(value) > max_length:
+            fields[name] = value[:max_length] + f"\n[trimmed to {max_length} characters]"
 
     Event.objects.create(user=request.user,
-                         app_name=app_name,
-                         name=event_name,
+                         app_name=fields["app_name"],
+                         name=fields["event_name"],
                          date=timezone.now(),
-                         details=details,
+                         details=fields["details"],
                          severity=severity)
     return HttpResponse()


### PR DESCRIPTION
Truncates user-supplied fields in the `create_event` POST endpoint before writing to the database:

- `app_name`: 100 characters
- `event_name`: 200 characters
- `details`: 10,000 characters

Relates to SACGF/variantgrid_private#3819