### PR TITLE
email_manager - render email body in sandboxed iframe

### DIFF
--- a/email_manager/templates/email_detail.html
+++ b/email_manager/templates/email_detail.html
@@ -19,5 +19,5 @@
 <label class="my-4">Content</label>:
 <a href="{% url 'email_pure' email.pk %}">See in stand-alone window with accurate styling</a>
 <div class="border rounded p-4" style="background-color:#fdfdfd">
-{{ email.html | safe }}
+    <iframe srcdoc="{{ email.html | escape }}" sandbox style="width:100%; height:600px; border:none;"></iframe>
 </div>

--- a/email_manager/templates/email_pure.html
+++ b/email_manager/templates/email_pure.html
@@ -4,6 +4,6 @@
     Subject: {{ email.subject }}<br/>
 
     <div style="padding:30px; margin-top: 20px; border: 1px solid #444; border-radius: 10px;">
-        {{ email.html | safe }}
+        <iframe srcdoc="{{ email.html | escape }}" sandbox style="width:100%; height:800px; border:none;"></iframe>
     </div>
 </div>


### PR DESCRIPTION
## Summary

Render email body HTML inside a sandboxed `<iframe srcdoc="...">` in both `email_pure.html` and `email_detail.html`, rather than injecting it directly into the page DOM via `| safe`.

This prevents any script content in stored email bodies from executing in the viewer's browser.

Relates to SACGF/variantgrid_private#3828.

## Test plan
- [x] Open a logged email via the email_manager detail view — body renders correctly inside the iframe
- [x] Open `/email_manager/pure/<id>` — body renders correctly in the standalone window
- [x] Confirm that email styling (inline CSS) is preserved inside the iframe