### PR TITLE
patients: return generic error message from patient_file_upload

### DIFF
--- a/patients/views.py
+++ b/patients/views.py
@@ -110,7 +110,7 @@ def patient_file_upload(request, patient_id):
         file_dict = patient_attachment.get_file_dict()
     except Exception as e:
         log_traceback()
-        file_dict = {"error": str(e)}
+        file_dict = {"error": "Upload failed"}
 
     return UploadResponse(request, file_dict)
 


### PR DESCRIPTION
## Summary

- Exception detail from `patient_file_upload()` was being returned directly to the client as `{"error": str(e)}`
- Changed to return a generic `"Upload failed"` message; full exception is still logged server-side via `log_traceback()`

Related: SACGF/variantgrid_private#3829

## Test plan

- [ ] Upload a valid patient file — confirm success response unchanged
- [ ] Trigger an upload failure (e.g. invalid patient ID) — confirm response contains generic error, not exception detail
- [ ] Confirm full traceback still appears in server logs