### PR TITLE
JS linting round 3: fix remaining no-undef findings #1588

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,17 +45,72 @@ export default [
                 loadNodeData: "readonly", // analysis.js
                 getGridAndEditorWindow: "readonly", // analysis.js
                 lockNodeField: "readonly", // analysis.js
+                replaceEditorWindow: "readonly", // analysis.js
+                loadGridAndEditorForNode: "readonly", // analysis.js
+                analysisVariable: "readonly", // analysis.js
+                addAnalysisVariableButton: "readonly", // analysis.js
+                _getAnalysisWindow: "readonly", // analysis.js
+                createJSEvent: "readonly", // analysis.js
+                addVariantTag: "readonly", // analysis.js
+                removeVariantTag: "readonly", // analysis.js
+                hideLoadingOverlay: "readonly", // analysis.js
                 getAnalysisWindow: "readonly", // grid.js
+                createIgvUrl: "readonly", // grid.js (typeof-guarded use in vc_links.js)
                 deleteNodesFromDOM: "readonly", // analysis_nodes.js
                 unselectActive: "readonly", // analysis_nodes.js
+                addNodesToDOM: "readonly", // analysis_nodes.js
+                attatchAnalysisNodeConnections: "readonly", // analysis_nodes.js
+                checkAndMarkDirtyNodes: "readonly", // analysis_nodes.js
+                getNode: "readonly", // analysis_nodes.js
+                loggedOutHandler: "readonly", // analysis_nodes.js
                 createSampleNode: "readonly", // samplenode.js
+                createTrioNode: "readonly", // pedigree_node.js
+                createQuadNode: "readonly", // pedigree_node.js
+                venn2: "readonly", // venn_intersect.js
+                venn_select: "readonly", // venn_intersect.js
+                getValue: "readonly", // global.js
+                removeItemFromArray: "readonly", // global.js
+                checkLoggedIn: "readonly", // global.js
+                convertTimestamp: "readonly", // global.js
+                JS_DATE_FORMAT_SECONDS: "readonly", // global.js
+                JS_DATE_FORMAT_SCIENTIFIC: "readonly", // global.js
+                loadAjaxBlock: "readonly", // global.js
+                formatJson: "readonly", // global.js
+                createTimestampDom: "readonly", // global.js
+                setupModalAnimationForWebTesting: "readonly", // global.js
+                EncodeQueryData: "readonly", // global.js
+                deleteItemClickHandler: "readonly", // global.js
+                createModal: "readonly", // global.js
+                highlightTextAsDom: "readonly", // global.js
+                limitLengthSpan: "readonly", // global.js
+                DataTableDefinition: "readonly", // datatable_definition.js
+                VCTable: "readonly", // vc_form.js
+                Flags: "readonly", // flags.js
+                VCLinks: "readonly", // vc_links.js
+                // cross-execution state in fragment-loaded files: these scripts are
+                // re-executed on AJAX load, so the state must stay a plain assignment
+                // (a top-level let/const would throw on re-execution)
+                seen_igv_error: "writable", // grid.js
+                RAISED_GET_ANALYSIS_WINDOW_JS_ERROR: "writable", // grid.js
+                VENN_TOGGLE_WIDGET_CLASS: "writable", // venn_intersect.js, read by analysis_nodes.js
+                venn_id: "writable", // venn_intersect.js
+                freq: "writable", // cached_generated_files.js
                 // globals injected by Django templates (inline <script> blocks)
                 ANALYSIS_ID: "readonly", // analysis.html
                 ANALYSIS_SETTINGS: "readonly", // analysis_settings_node_counts_tab.html
+                ANALYSIS_TAGS_NODE_ID: "readonly", // analysis.html
                 NODE_HELP: "readonly", // analysis.html
                 messagePoller: "readonly", // analysis.html
                 analysisNodeVariables: "readonly", // analysis.html
                 saveSettingsOnResize: "writable", // analysis.html, assigned in analysis.js
+                secondWindow: "writable", // analysis.html, assigned in analysis.js
+                panelResizeTimeout: "writable", // analysis.html, assigned in analysis.js
+                panelResizeUpdateDelay: "readonly", // analysis.html
+                variantTags: "readonly", // analysis.html
+                loadInitialGridEditor: "readonly", // analysis.html
+                registerComponent: "readonly", // analysis_editor_and_grid.html
+                EDITOR: "readonly", // analysis_editor_and_grid.html
+                reloadNodes: "readonly", // analysis_settings.html
             },
         },
         rules: {

--- a/variantgrid/static_files/default_static/js/analysis_nodes.js
+++ b/variantgrid/static_files/default_static/js/analysis_nodes.js
@@ -178,7 +178,7 @@ function setupHideInvalidConnectionsOnDrag() {
 			const endpoint = getEndpoint(id, 'target');
 			if (endpoint) {
 				for (let i=0 ; i<endpoint.connections.length ; ++i) {
-					source = endpoint.connections[i].sourceId;
+					const source = endpoint.connections[i].sourceId;
 					ancestors = ancestors.concat(getAncestors(source));
 				}
 			}

--- a/variantgrid/static_files/default_static/js/citations.js
+++ b/variantgrid/static_files/default_static/js/citations.js
@@ -145,7 +145,7 @@ const CitationsManager = (function() {
             if (!citation.error) {
                 $('<a>', {'class':'d-block', 'data-toggle':'ajax-modal', 'data-href':Urls.view_citation_detail(citation.id), 'data-title': prettyId, 'text':'Show Detail'}).appendTo(citDom);
             } else {
-                $('<p>', {class: 'abstract', text: citation.abstract && citation.abstract.length ? citation.abstract : 'Could not fetch abstract'}).appendTo(detailContainer);
+                $('<p>', {class: 'abstract', text: citation.abstract && citation.abstract.length ? citation.abstract : 'Could not fetch abstract'}).appendTo(citDom);
             }
             return citDom;
         },

--- a/variantgrid/static_files/default_static/js/datatable_definition.js
+++ b/variantgrid/static_files/default_static/js/datatable_definition.js
@@ -433,7 +433,7 @@ TableFormat.list_codes = (data, type, row) => {
     }
     const elements = [];
     let isFirst = true;
-    for (value of data) {
+    for (const value of data) {
         if (!isFirst) {
             elements.push(", ");
         }
@@ -579,7 +579,7 @@ TableFormat.combine = function(formatters, settings, data, type, columns) {
             part = eval(formatter)(data[index], type, columns);
         }
         if (settings.separator) {
-            dom.append($(separator));
+            dom.append($(settings.separator));
             dom.append(part);
         } else {
             dom.append($('<div>', {'html': part}));

--- a/variantgrid/static_files/default_static/js/flags.js
+++ b/variantgrid/static_files/default_static/js/flags.js
@@ -148,7 +148,7 @@ const Flags = (function () {
                     });
             },
             raisableFlags() {
-                flagTypes = this.flagTypes().filter(ft => {
+                const flagTypes = this.flagTypes().filter(ft => {
                     const userPermission = this.user_permission;
                     const requiredPermission = ft.raise_permission;
                     return userPermission >= requiredPermission;
@@ -340,7 +340,7 @@ const Flags = (function () {
                 }
                 this.setPosting();
 
-                sendParams = {
+                const sendParams = {
                     comment: comment || null,
                 };
                 if (resolution) {
@@ -402,7 +402,7 @@ const Flags = (function () {
 
             updateComments() {
                 // fixme, don't re-render comments already rendered
-                shouldScroll = (isScrolledToBottom(this.scrollablePanel) && !this.firstUpdate) || this.justPosted;
+                const shouldScroll = (isScrolledToBottom(this.scrollablePanel) && !this.firstUpdate) || this.justPosted;
                 
                 let lastEntry = this.lastEntry;
                 let reachedStart = lastEntry == null;
@@ -721,7 +721,7 @@ const Flags = (function () {
                 } else {
                     this.applyActiveContent(new FlagCollectionSummaryContent(this.collection, this));
                 }
-                modalDialog = modalContent.modal({focus:true, show:true});
+                const modalDialog = modalContent.modal({focus:true, show:true});
                 if (params.triggerDom) {
                     $(params.triggerDom).LoadingOverlay('hide');
                 }
@@ -940,7 +940,7 @@ const Flags = (function () {
                 
                 if (this.data && this.data.transcript) {
                     const transcript = this.data.transcript;
-                    parts = /^([_A-Z0-9]+)(?:[.]([0-9]+))?$/i;
+                    const parts = /^([_A-Z0-9]+)(?:[.]([0-9]+))?$/i;
                     const match = parts.exec(transcript);
                     if (match) {
                         let transcriptUrl = null;
@@ -1052,7 +1052,7 @@ const Flags = (function () {
 
                 let timestamp = moment(this.created * 1000).format('DD-MMM-YYYY');
                 if (lastEntry) {
-                    oldTimestamp = moment(lastEntry.created * 1000).format('DD-MMM-YYYY');
+                    const oldTimestamp = moment(lastEntry.created * 1000).format('DD-MMM-YYYY');
                     if (oldTimestamp === timestamp) {
                         timestamp = null;
                     }
@@ -1081,7 +1081,7 @@ const Flags = (function () {
                 }
 
                 const actionCommentDom = $('<div>', { class: 'action-text' }).appendTo(content);
-                action = this.action();
+                const action = this.action();
 
                 if (params.includeTitle) {
                     $('<div>', {

--- a/variantgrid/static_files/default_static/js/panel_app.js
+++ b/variantgrid/static_files/default_static/js/panel_app.js
@@ -4,19 +4,19 @@ function getEvidenceHover(geneSymbol, evidence, confidence) {
     container.append(geneTitle);
     const modeOfInheritance = evidence["mode_of_inheritance"];
     if (modeOfInheritance) {
-        mohDiv = $("<div />").append("<b>Mode of inheritance</b> " + modeOfInheritance);
+        const mohDiv = $("<div />").append("<b>Mode of inheritance</b> " + modeOfInheritance);
         container.append(mohDiv);
     }
     const penetrance = evidence["penetrance"];
     if (penetrance) {
-        penetranceDiv = $("<div />").append("<b>Penetrance</b> " + penetrance);
+        const penetranceDiv = $("<div />").append("<b>Penetrance</b> " + penetrance);
         container.append(penetranceDiv);
     }
 
     const evidences = evidence["evidence"];
     if (evidences) {
         container.append($("<h3 />").text("Sources"));
-        evidencesUl = $("<ul />");
+        const evidencesUl = $("<ul />");
         for (let i=0 ; i<evidences.length ; ++i) {
             evidencesUl.append($("<li />").text(evidences[i]));
         }
@@ -26,7 +26,7 @@ function getEvidenceHover(geneSymbol, evidence, confidence) {
     const phenotypes = evidence["phenotypes"];
     if (phenotypes) {
         container.append($("<h3 />").text("Phenotypes"));
-        phenotypesUl = $("<ul />");
+        const phenotypesUl = $("<ul />");
         for (let i=0 ; i<phenotypes.length ; ++i) {
             phenotypesUl.append($("<li />").text(phenotypes[i]));
         }

--- a/variantgrid/static_files/default_static/js/samplenode.js
+++ b/variantgrid/static_files/default_static/js/samplenode.js
@@ -1,5 +1,5 @@
-SIDE_LENGTH = 60;
-DEFAULT_SHADOW_COLOR = "#aaa";
+const SIDE_LENGTH = 60;
+const DEFAULT_SHADOW_COLOR = "#aaa";
 
 
 function maleSVG(svg, sideLength) {

--- a/variantgrid/static_files/default_static/js/vc_diff.js
+++ b/variantgrid/static_files/default_static/js/vc_diff.js
@@ -305,7 +305,7 @@ const Diff = (function() {
                 }
                 let content = null;
 
-                clinSigText = [];
+                const clinSigText = [];
 
                 const clin_sig_key = this.eKeys.key(SpecialEKeys.CLINICAL_SIGNIFICANCE);
                 const clin_sig = clin_sig_key.prettyValue((v.clinical_significance || {}).value);
@@ -532,7 +532,7 @@ const Diff = (function() {
                                 diffBreakdown.push(`${hasBlank} <span style="color:#888;font-size:smaller">x</span> <span style="color:#888">blank</span>`);
                             }
                         }
-                        valueCounts = Object.values(uniqueValues);
+                        const valueCounts = Object.values(uniqueValues);
                         valueCounts.sort((vc1,vc2) => {
                             if (vc1.count !== vc2.count) {
                                 return vc1.count - vc2.count;

--- a/variantgrid/static_files/default_static/js/vc_form.js
+++ b/variantgrid/static_files/default_static/js/vc_form.js
@@ -59,6 +59,7 @@ const VCForm = (function() {
     let jShareButtons = null;
 
     let eKeys = null;
+    let eKeysBase = null;
     let vcLinks = null;
 
     const VCForm = function() {};
@@ -672,12 +673,6 @@ const VCForm = (function() {
 
                 $(`#label-${error.key}`).prepend(inlineError);
 
-                switch (error.severity) {
-                    case 'error': icon = '<i class="fas fa-exclamation-circle text-danger"></i>'; break;
-                    case 'warning': icon = '<i class="fas fa-exclamation-triangle text-warning"></i>'; break;
-                    case 'info': icon = '<i class="fas fa-info-circle text-primary"></i>'; break;
-                }
-
                 const listItem = $('<a>', {class: 'list-group-item list-group-item-action',  target: '_blank', click: () => {
                     jFilterBox.val('#' + eKey.key);
                     jFilterBox.keyup();
@@ -1043,7 +1038,7 @@ const VCForm = (function() {
         },
 
         cHGVS() {
-            vc_value = this.value(SpecialEKeys.C_HGVS);
+            const vc_value = this.value(SpecialEKeys.C_HGVS);
             if (vc_value) {
                 return vc_value;
             }
@@ -1576,7 +1571,7 @@ const VCForm = (function() {
                     ])
                 );
             } else {
-                descriptionSpan = eKey.description ? EKeys.fixDescription(eKey.description) : $('<i>', {text:'No help is provided for this field'});
+                const descriptionSpan = eKey.description ? EKeys.fixDescription(eKey.description) : $('<i>', {text:'No help is provided for this field'});
                 if (this.isEditMode()) {
                     if (eKey.hide === true) {
                         descriptionSpan.append($('<br/><br/><i>This field is not shown by default for your lab.</i>'));

--- a/variantgrid/static_files/default_static/js/vc_links.js
+++ b/variantgrid/static_files/default_static/js/vc_links.js
@@ -55,7 +55,7 @@ const VCLink = (function() {
 
 })();
 
-EMPTY_LINK = new VCLink({
+const EMPTY_LINK = new VCLink({
     text: null,
     href: null,
     missing: true,

--- a/variantgrid/static_files/default_static/js/venn_intersect.js
+++ b/variantgrid/static_files/default_static/js/venn_intersect.js
@@ -9,20 +9,20 @@ function venn_select(selector, venn_flag) {
 }
 
 function vennAddToggleCallbacks(selector, callback) {
-	get_venn_flag = function() {
+	const get_venn_flag = function() {
 		let venn_flag = 0;
 		$('.' + VENN_TOGGLE_WIDGET_CLASS, selector).each(function() {
 			const widget = d3.select(this);
-			toggled = widget.attr("toggled");
+			const toggled = widget.attr("toggled");
 			if (toggled == "true") {
 				venn_flag |= widget.attr("venn_bit");
 			}
 		});
 		return venn_flag;
 	};
-	toggleColor = function() {
+	const toggleColor = function() {
 		toggleSelect(d3.select(this));
-		venn_flag = get_venn_flag();
+		const venn_flag = get_venn_flag();
 		callback(venn_flag);
 	};
 
@@ -34,7 +34,7 @@ function vennAddToggleCallbacks(selector, callback) {
 
 // Either set to value (if provided) or toggle (if not)
 function toggleSelect(select, value) {
-	toggled = value;
+	let toggled = value;
 	if (toggled == null) {
 		toggled = select.attr('toggled');
 		toggled = toggled != "true";
@@ -122,7 +122,7 @@ function venn2(selector, w, h) {
 
 
 function venn3(selector, w, h) {
-	radius = w * 0.3;
+	const radius = w * 0.3;
 
 	const svg = d3.select(selector).append("svg:svg")
 	    .attr("width", w)


### PR DESCRIPTION
🤖 Written by Claude

Addresses #1588 (stacked on #1585 — diff shows only this round's changes).

Triages all 149 remaining `no-undef` warnings: ESLint is now clean apart from the 29 intentionally-kept errors (json2csv.js, include_jqgrid.js, global.js debounce, phenotype.js).

**Bug fixes**
- `citations.js`: error-branch abstract appended to undefined `detailContainer` → `citDom`
- `datatable_definition.js`: `$(separator)` → `$(settings.separator)` in `TableFormat.combine`
- `vc_form.js`: removed dead `switch` assigning unused undeclared `icon`

**Missing local declarations** (added `const`/`let`, verified no cross-file/template readers): `flags.js`, `vc_form.js`, `vc_diff.js`, `panel_app.js`, `venn_intersect.js`, `analysis_nodes.js`, `datatable_definition.js`

**Shared state given a proper home**
- `eKeysBase` → declared in VCForm IIFE scope beside `eKeys`
- `SIDE_LENGTH` / `DEFAULT_SHADOW_COLOR` → top-level `const` (samplenode.js is page-loaded everywhere)
- `EMPTY_LINK` → top-level `const` (note: currently unused, deletion candidate)
- Fragment-file cross-execution state (`seen_igv_error`, `RAISED_GET_ANALYSIS_WINDOW_JS_ERROR`, `VENN_TOGGLE_WIDGET_CLASS`, `venn_id`, `freq`) kept as plain assignments, declared `writable` in eslint.config.mjs

**eslint.config.mjs**: declared cross-file first-party functions and template-injected globals (analysis.html and related), each annotated with its defining file.

All touched files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)