### PR TITLE
Guard limit_length_with_tooltip against None text

### DIFF
--- a/uicore/templatetags/js_tags.py
+++ b/uicore/templatetags/js_tags.py
@@ -91,7 +91,7 @@ def limit_length(text, limit=100):
 @register.inclusion_tag("uicore/tags/limit_length_with_tooltip.html")
 def limit_length_with_tooltip(text, limit=100):
     tooltip = ""
-    if limit and len(text) > limit:
+    if limit and text and len(text) > limit:
         tooltip = text
         text = text[0:(limit-3)] + '...'
     return {"tooltip": tooltip, "text": text}


### PR DESCRIPTION
## What
Add an `and text` guard to the `limit_length_with_tooltip` inclusion tag in `uicore/templatetags/js_tags.py` so a `None`/empty value renders empty instead of calling `len(None)`.

## Why
`limit_length_with_tooltip` called `len(text)` without checking that `text` was not `None`, raising `TypeError: object of type 'NoneType' has no len()`. The sibling `limit_length` filter already guards with `and text`; this mirrors that behaviour.

Addresses #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)