### PR TITLE
Guard get_remaining_annotation_runs against None max_variant

### DIFF
--- a/upload/views/views.py
+++ b/upload/views/views.py
@@ -117,6 +117,9 @@ def uploadedfile_dict(uploaded_file) -> dict:
 
 
 def get_remaining_annotation_runs(uploaded_vcf, genome_build) -> int:
+    if uploaded_vcf.max_variant_id is None:
+        # VCF not fully imported yet, so highest known variant is unknown - no remaining runs to report
+        return 0
     ar_qs = AnnotationRun.get_active_runs(genome_build)
     return ar_qs.filter(annotation_range_lock__max_variant__lte=uploaded_vcf.max_variant).count()
 


### PR DESCRIPTION
## What
`get_remaining_annotation_runs` in `upload/views/views.py` builds a queryset filter `annotation_range_lock__max_variant__lte=uploaded_vcf.max_variant`. When the VCF has not been fully imported yet, `UploadedVCF.max_variant` is `None`, and Django raises `ValueError: Cannot use None as a query value`, returning a 500 from `view_sample`.

## Why
The highest known variant for a partially-imported VCF is unknown, so there is no meaningful upper bound to count active annotation runs against. We now return `0` early when `max_variant` is unset. This is consistent with `UploadedVCFPendingAnnotation.attempt_schedule_annotation_stage_steps`, which already treats a `None` `max_variant` as having nothing left to annotate.

The value is only used for a progress display, so returning 0 in this transient state is safe and self-corrects once import progresses and `max_variant` is set.

Addresses #1600

🤖 Generated with [Claude Code](https://claude.com/claude-code)