### PR TITLE
Skip weekly summary email for users with no accessible lab

### DIFF
--- a/classification/views/classification_email_view.py
+++ b/classification/views/classification_email_view.py
@@ -107,6 +107,12 @@ def send_summary_emails():
 def send_summary_email_to_user(user: User) -> bool:
     discordance_email = settings.DISCORDANCE_EMAIL
     if discordance_email:
+        if not Lab.valid_labs_qs(user=user, admin_check=True).exclude(organization__active=False).exists():
+            # User has no accessible lab, so there's nothing to summarise - skip rather than raise
+            report_message("Skipping weekly summary email - user has no accessible lab", level="debug",
+                           extra_data={"user": user.username})
+            return False
+
         content = summary_email_content(LabPickerData.for_user(user))
 
         return EmailLog.send_mail(subject=content.subject,

--- a/classification/views/classification_email_view.py
+++ b/classification/views/classification_email_view.py
@@ -107,7 +107,7 @@ def send_summary_emails():
 def send_summary_email_to_user(user: User) -> bool:
     discordance_email = settings.DISCORDANCE_EMAIL
     if discordance_email:
-        if not Lab.valid_labs_qs(user=user, admin_check=True).exclude(organization__active=False).exists():
+        if not Lab.has_active_lab(user, admin_check=True):
             # User has no accessible lab, so there's nothing to summarise - skip rather than raise
             report_message("Skipping weekly summary email - user has no accessible lab", level="debug",
                            extra_data={"user": user.username})

--- a/snpdb/models/models.py
+++ b/snpdb/models/models.py
@@ -642,6 +642,11 @@ class Lab(models.Model, PreviewModelMixin):
         group_names = list(user.groups.values_list('name', flat=True))
         return Lab.objects.select_related('organization').filter(group_name__in=group_names).order_by('name')
 
+    @staticmethod
+    def has_active_lab(user: User, admin_check=False) -> bool:
+        """ Whether the user has access to any lab belonging to an active organization """
+        return Lab.valid_labs_qs(user=user, admin_check=admin_check).filter(organization__active=True).exists()
+
     """
     # these methods have been superseeded by having full classification activity by lab
     def classifications_activity(self, time_period: timedelta):


### PR DESCRIPTION
## What

`send_summary_email_to_user` now skips users who have no accessible lab instead of crashing.

## Why

The weekly summary email task (`send_summary_emails` → `send_summary_email_to_user`) called `LabPickerData.for_user(user)` with no lab selection. For a user with no accessible lab, `LabSelection.from_user` produces an empty `selected_lab_set` and raises `ValueError: You do not have access to lab selection : None`. This crashed the task per-user and accounted for 237 occurrences across shariant prod/demo/test.

The fix adds an early guard in `send_summary_email_to_user`: if the user has no valid (active-organization) lab, it logs a `debug` message and returns `False` rather than attempting to build the summary. Placing the guard in `send_summary_email_to_user` protects all three callers (the celery task, the `send_weekly_emails` management command, and the vcauth admin action).

Behaviour for users who do have a lab is unchanged.

Addresses #1602

🤖 Generated with [Claude Code](https://claude.com/claude-code)