### PR TITLE
Handle missing CohortGenotypeCollection when opening node grid (#1594)

### DIFF
--- a/analysis/models/nodes/cohort_mixin.py
+++ b/analysis/models/nodes/cohort_mixin.py
@@ -48,9 +48,11 @@ class CohortMixin:
         if cohort:
             try:
                 cdc = cohort.cohort_genotype_collection
-            except DataArchivedError:
+            except (DataArchivedError, CohortGenotypeCollection.DoesNotExist):
                 # Surface via _get_configuration_errors → ERROR_CONFIGURATION;
                 # keep node-internal "no source" code paths working.
+                # A missing CGC (mid-reload / version mismatch) is treated the same
+                # as archived data so the node shows a config error instead of 500ing.
                 cdc = None
         else:
             cdc = None


### PR DESCRIPTION
## What

Catch `CohortGenotypeCollection.DoesNotExist` (alongside the existing `DataArchivedError`) in `CohortMixin.cohort_genotype_collection` in `analysis/models/nodes/cohort_mixin.py`, returning `None` instead of letting the exception propagate.

## Why

Opening a node grid could 500 with `CohortGenotypeCollection.DoesNotExist` when the underlying CGC is genuinely missing (mid-reload, or a cohort/CGC version mismatch). The property only caught `DataArchivedError`, so `DoesNotExist` — raised by the `.get()` in `Cohort.cohort_genotype_collection` (`snpdb/models/models_cohort.py`) — propagated and crashed the grid.

By returning `None` we mirror the existing archived-data handling: node-internal "no source" code paths keep working, and the condition is surfaced as a node configuration error via `_get_configuration_errors` (which already catches `DoesNotExist` and adds a "Source data missing" message) → `NodeStatus.ERROR_CONFIGURATION`, shown clearly in the UI instead of a 500.

## Risk / notes

Minimal, defensive change (one `except` clause widened). No happy-path behaviour change: when the CGC exists, the property returns it exactly as before. The configuration-error surfacing path was already present, so this only redirects the previously-uncaught exception into it.

Addresses #1594

🤖 Generated with [Claude Code](https://claude.com/claude-code)