### PR TITLE
Gracefully abort import tasks when UploadStep/UploadPipeline deleted (#1593)

### DIFF
--- a/upload/tasks/vcf/import_vcf_step_task.py
+++ b/upload/tasks/vcf/import_vcf_step_task.py
@@ -54,7 +54,13 @@ class ImportVCFStepTask(Task):
         def load_upload_step():
             return UploadStep.objects.get(pk=upload_step_id)
 
-        upload_step = load_upload_step()
+        try:
+            upload_step = load_upload_step()
+        except UploadStep.DoesNotExist:
+            # UploadStep was deleted while this task was queued/running (retry/delete race) - nothing to do
+            logging.warning("ImportVCFStepTask: UploadStep %s no longer exists (deleted/retried) - aborting",
+                            upload_step_id)
+            return
         upload_pipeline = upload_step.upload_pipeline
         upload_pipeline_qs = UploadPipeline.objects.filter(id=upload_pipeline.pk)
 
@@ -168,7 +174,13 @@ def schedule_pipeline_stage_steps(upload_pipeline_id, pipeline_stage):
     """ Only want to do this once per VCF import, so run in own task on single queue to avoid race conditions.
         May be executed multiple times but will only run jobs the 1st time """
 
-    upload_pipeline = UploadPipeline.objects.get(pk=upload_pipeline_id)
+    try:
+        upload_pipeline = UploadPipeline.objects.get(pk=upload_pipeline_id)
+    except UploadPipeline.DoesNotExist:
+        # UploadPipeline was deleted while this task was queued/running (retry/delete race) - nothing to do
+        logging.warning("schedule_pipeline_stage_steps: UploadPipeline %s no longer exists (deleted/retried) - aborting",
+                        upload_pipeline_id)
+        return
 
     try:
         logging.info("schedule_pipeline_stage_steps: %s", pipeline_stage)


### PR DESCRIPTION
## What

Make the VCF import Celery tasks no-op gracefully when the `UploadStep` or `UploadPipeline` they reference has been deleted while the task was still queued or running (a retry/delete race).

In `upload/tasks/vcf/import_vcf_step_task.py`:
- `ImportVCFStepTask.run()` -> `load_upload_step()` now catches `UploadStep.DoesNotExist`, logs a clear warning, and returns instead of raising (the `UploadStep.objects.get(pk)` was the source of ~80 unhandled `DoesNotExist` on prod).
- `schedule_pipeline_stage_steps()` now catches `UploadPipeline.DoesNotExist` on its `.get()` and returns the same way.

## Why

When a pipeline is deleted or retried, in-flight Celery tasks may still hold a now-stale step/pipeline id. The unguarded `.get()` calls raised `DoesNotExist`, producing noisy unhandled exceptions for what is actually expected behaviour. Aborting quietly (with a logged warning) is correct for a deleted/retried pipeline, and matches the existing "UploadPipeline was deleted" log-and-return handling already present in `run()`.

## Scope / follow-up

This PR is deliberately conservative and only covers the `DoesNotExist` task-abort handling:
- G192 (`load_upload_step` in `import_vcf_step_task.py`)
- G193 (`schedule_pipeline_stage_steps` in `import_vcf_step_task.py`)

The remaining races under the same issue need deeper transactional work and are left as follow-up:
- G223 / G224 — FK-violation insert paths (`vcf_import.py`, `bulk_genotype_vcf_processor.py`)
- G208 — duplicate-key COPY (`sql_copy_files.py`)

Addresses #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)