### PR TITLE
Make annotation overwrite-guard actionable; keep scratch cleanup retry-only (#1596)

### DIFF
--- a/annotation/vcf_files/bulk_vep_vcf_annotation_inserter.py
+++ b/annotation/vcf_files/bulk_vep_vcf_annotation_inserter.py
@@ -844,7 +844,8 @@ class BulkVEPVCFAnnotationInserter:
     def remove_processing_files(self):
         import_processing_dir = get_import_processing_dir(self.annotation_run.pk, prefix=self.PREFIX)
         logging.info("********* Deleting '%s' *******", import_processing_dir)
-        shutil.rmtree(import_processing_dir)
+        # ignore_errors so a missing dir (eg cleaned-up retry) doesn't blow up - we just want it gone
+        shutil.rmtree(import_processing_dir, ignore_errors=True)
 
     @cached_property
     def gene_identifiers(self):

--- a/annotation/vcf_files/import_vcf_annotations.py
+++ b/annotation/vcf_files/import_vcf_annotations.py
@@ -34,6 +34,11 @@ def import_vcf_annotations(
     infos = header_types["INFO"]
     bulk_inserter = BulkVEPVCFAnnotationInserter(annotation_run, infos, insert_variants)
     if annotation_run.upload_attempts > 1:
+        # Genuine retry of an existing run - clear any scratch files left by the previous attempt so
+        # write_sql_copy_csv doesn't abort on "We don't want to overwrite ...". We deliberately only do
+        # this on a real retry (upload_attempts > 1) - a first attempt that finds existing scratch files
+        # means the import-processing dir is out of sync with the DB (eg moved dump / restored backup),
+        # which the overwrite guard is meant to surface rather than silently delete. See #1596.
         logging.warning(f"Upload attempt {annotation_run.upload_attempts} - deleting data")
         bulk_inserter.remove_processing_files()
 

--- a/upload/vcf/sql_copy_files.py
+++ b/upload/vcf/sql_copy_files.py
@@ -90,7 +90,10 @@ def gene_coverage_canonical_transcript_sql_copy_csv(input_filename, table_name):
 
 def write_sql_copy_csv(data, filename, **kwargs):
     if os.path.exists(filename):
-        msg = f"We don't want to overwrite '{filename}'"
+        msg = (f"We don't want to overwrite '{filename}' - a file from a previous run already exists. "
+               f"If the import-processing directory is out of sync with the database (eg a dump moved "
+               f"to a new system or a restored backup), remove the stale file/directory to retry. "
+               f"Otherwise this may indicate a real error or race condition - investigate before deleting.")
         raise ValueError(msg)
 
     with open(filename, "w") as f:


### PR DESCRIPTION
## What

The `write_sql_copy_csv` "We don't want to overwrite '...'" check (`upload/vcf/sql_copy_files.py`) is a **deliberate safety guard**: a leftover scratch `.tsv` almost always means the import-processing directory is out of sync with the database — e.g. a dump moved to a new system, or a restored backup. Silently deleting it would destroy that signal (and could mask a real error/race).

Genuine annotation-run retries are **already handled**: `import_vcf_annotations` increments `upload_attempts` and clears scratch when `upload_attempts > 1`, and a full `annotation_run_retry` creates a fresh run pk with a fresh directory. So instead of deleting unconditionally, this PR:

- keeps the scratch cleanup gated on `upload_attempts > 1` (real retry only), with a comment documenting why we deliberately do **not** delete on a first attempt;
- makes the overwrite-guard error message **actionable** — it now explains the likely moved-dump / restored-backup cause and the manual remedy, while noting it could be a real error/race worth investigating before deleting;
- uses `shutil.rmtree(ignore_errors=True)` so the retry cleanup is robust to an already-missing directory.

## Why

An earlier revision of this PR deleted the scratch dir unconditionally before writing, which removed the guard entirely. Per review, the guard protects against import-dir/DB mismatch and must stay; G202 firing is usually that guard working as intended (a forgotten/leftover directory), not a stuck retry.

Addresses #1596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)