### PR TITLE
Tolerate incomplete zygosity counts when removing soft-deleted VCFs (#1595)

### DIFF
--- a/snpdb/tasks/soft_delete_tasks.py
+++ b/snpdb/tasks/soft_delete_tasks.py
@@ -47,7 +47,10 @@ def remove_soft_deleted_vcfs_task():
             vcf = qs.get()
             logging.info("Deleting vcfs %s", vcf)
             try:
-                update_all_variant_zygosity_counts_for_vcf(vcf, '-')
+                # skip_if_cannot_delete: an old/incomplete VCF may have a zygosity count that never
+                # completed (count_complete is None) or was already subtracted - skip it with a
+                # warning rather than aborting the subtraction for this VCF (see #1595)
+                update_all_variant_zygosity_counts_for_vcf(vcf, '-', skip_if_cannot_delete=True)
             except:  # Already logged etc
                 pass
 


### PR DESCRIPTION
## What

Pass `skip_if_cannot_delete=True` when subtracting global zygosity counts in `remove_soft_deleted_vcfs_task` (`snpdb/tasks/soft_delete_tasks.py`), so an old/incomplete VCF whose count never completed (`count_complete` is `None`) is skipped with a warning instead of raising `ValueError: GlobalZygosityCount ...: count_complete was None (never completed)`.

## Why (G021)

This fixes the `count_complete`-None archive/delete crash from #1595.

The archive flow already passes `skip_if_cannot_delete=True` (added in the `sacgf/variantgrid_com#79` work on `snpdb/archive.py`), so archiving a VCF with an incomplete count no longer aborts. The sibling soft-delete removal path, however, still called `update_all_variant_zygosity_counts_for_vcf(vcf, '-')` without the flag. There the same incomplete count raised the `count_complete was None` `ValueError` internally; it was swallowed by the surrounding bare `except: pass`, but that aborted the whole subtraction for that VCF and buried the error rather than gracefully skipping it. This change routes that path through the existing, proven skip mechanism (`AbstractVariantZygosityCountRecord.check_can_delete` + the `skip_if_cannot_delete` branch in `update_variant_zygosity_count_for_vcf`).

This is a conservative, minimal change: it only relaxes the behaviour of a delete (`-`) operation when there is nothing safe to subtract; the happy path (a completed, not-yet-deleted count) is unchanged.

## Remaining follow-up — deadlock (G022)

The `DeadlockDetected` on the bare `run_sql` UPDATE of the global counts (`snpdb/variant_zygosity_count.py`, the `run_sql(sql, params)` inside `update_variant_zygosity_count_for_vcf`) is **not** addressed here. As the existing code comment notes, these count updates must run serially to avoid deadlocks; a correct fix involves the locking/serialisation strategy and is intentionally left as follow-up rather than risk a speculative concurrency change. This is a recurrence of long-closed #1085.

Addresses #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)