### PR TITLE
Accept the 'a' allele shortcut in classification export allele= param (#1615)

### DIFF
--- a/classification/views/exports/classification_export_filter.py
+++ b/classification/views/exports/classification_export_filter.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User
 from django.db.models import QuerySet, Q
 from django.http import HttpRequest
 from guardian.shortcuts import get_objects_for_user
+from rest_framework.exceptions import ParseError
 from threadlocals.threadlocals import get_current_request
 
 from annotation.annotation_version_querysets import get_variant_queryset_for_latest_annotation_version
@@ -473,7 +474,13 @@ class ClassificationFilter:
         # just for debugging purposes allows us to download a single allele
         allele: Optional[int] = None
         if allele_str := request.query_params.get('allele'):
-            allele = int(allele_str)
+            # Accept the "a" allele shortcut used in search (eg "a9678" - see ALLELE_ID_SEARCH_PATTERN),
+            # as well as a bare numeric id, rather than 500ing on a non-numeric value.
+            allele_id_str = allele_str[1:] if allele_str[:1].lower() == 'a' else allele_str
+            try:
+                allele = int(allele_id_str)
+            except ValueError:
+                raise ParseError(f"Invalid 'allele' parameter: '{allele_str}' - expected an allele id (eg 9678 or a9678)")
 
         ## Have removed the ability to provide record filters in general from_request
         # record_filters: Optional[str] = None


### PR DESCRIPTION
## What

The debug `allele=` query param on the classification export API was parsed with a bare `int(allele_str)` (`classification/views/exports/classification_export_filter.py`), so a value like `a9678` raised `ValueError` and **500**'d the export endpoint.

Since `a` is the allele shortcut used in search (`ALLELE_ID_SEARCH_PATTERN = ^a(\d+)$` — the id as it appears in URLs prefixed with `a`), this accepts the same form on the export param:

- strip an optional leading `a` (case-insensitive), so `a9678`, `A9678` and `9678` all resolve to allele 9678;
- raise DRF `ParseError` (HTTP **400**) for a genuinely non-numeric value instead of a 500.

`ParseError` is used (rather than the project's `InvalidExportParameter`) because importing the latter here would create a circular import; it maps cleanly to 400 via the DRF view that serves the export.

Split out of #1601.

Addresses #1615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)