### PR TITLE
Minor code hardening and template cleanups

### DIFF
--- a/library/django_utils/django_secret_key.py
+++ b/library/django_utils/django_secret_key.py
@@ -1,31 +1,13 @@
 import os
-import random
-from base64 import urlsafe_b64encode as b64encode
 
-random.seed()
-
-
-def generate_key(max_length, seed_length):
-    """
-    Generate a Base64-encoded 'random' key by hashing the data.
-    data is a tuple of seeding values. Pass arbitrary encoder and
-    digester for specific hashing and formatting of keys
-
-    From: https://gist.github.com/airtonix/6204802
-
-    """
-    PATTERN = "%%0%dX"
-    JUNK_LEN = 1024
-    junk = (PATTERN % (JUNK_LEN * 2)) % random.getrandbits(JUNK_LEN * seed_length)
-    key = str(junk).encode()
-    return b64encode(key)[:max_length]
+from django.core.management.utils import get_random_secret_key
 
 
 def get_or_create_django_secret_key(key_dir):
     key_filename = os.path.join(key_dir, "django_secret_key.txt")
     if not os.path.exists(key_filename):
-        secret_key = generate_key(50, 128)
-        with open(key_filename, "wb") as f:
+        secret_key = get_random_secret_key()
+        with open(key_filename, "w", encoding="utf-8") as f:
             f.write(secret_key)
     else:
         with open(key_filename, encoding="utf-8") as f:

--- a/library/utils/html_utils.py
+++ b/library/utils/html_utils.py
@@ -1,10 +1,9 @@
 import re
 import uuid
-from html import escape
 from typing import Optional
 
 from bs4 import BeautifulSoup
-from django.utils.safestring import SafeString
+from django.utils.html import format_html
 
 
 def html_id_safe(text: str) -> str:
@@ -86,10 +85,9 @@ class IconWithTooltip:
         self.tooltip = tooltip
 
     def __str__(self):
-        title = ""
-        if tooltip := self.tooltip:
-            title = f'title="{escape(tooltip)}"'
-        return SafeString(f'<i class="{escape(self.icon)}" {title}></i>')
+        if self.tooltip:
+            return format_html('<i class="{}" title="{}"></i>', self.icon, self.tooltip)
+        return format_html('<i class="{}"></i>', self.icon)
 
     def as_json(self) -> dict:
         return {

--- a/oidc_auth/backend.py
+++ b/oidc_auth/backend.py
@@ -166,8 +166,9 @@ class VariantGridOIDCAuthenticationBackend(OIDCAuthenticationBackend):
         added_groups = groups.difference(django_groups)
 
         for removed_group in removed_groups:
-            group = Group.objects.get(name=removed_group)
-            user.groups.remove(group)
+            # Group may have been deleted out-of-band between logins - skip if gone
+            if group := Group.objects.filter(name=removed_group).first():
+                user.groups.remove(group)
 
         for added_group in added_groups:
             # note that we trust the OIDC connector as it can already make admins

--- a/ontology/views_rest.py
+++ b/ontology/views_rest.py
@@ -37,7 +37,8 @@ class SearchMondoText(APIView):
     )
     def get(self, request, **kwargs) -> Response:
 
-        search_term = request.GET.get('search_term') or ''
+        # Cap the length of free text forwarded to the external Monarch search API
+        search_term = (request.GET.get('search_term') or '')[:200]
         gene_symbol = request.GET.get('gene_symbol')
 
         selected = [term.strip() for term in (request.GET.get('selected') or '').split(",") if term.strip()]

--- a/variantopedia/templates/variantopedia/variant_details.html
+++ b/variantopedia/templates/variantopedia/variant_details.html
@@ -410,14 +410,14 @@ $(document).ready(function() {
             error: function() {
                 console.log("Error retrieving allele");
                 // Can't retrieve, just show basics
-                let variantString = "{{ variant|safe }}";
+                let variantString = "{{ variant|escapejs }}";
                 let linkData = {variant_string: variantString, variant_coordinate: variantString};
                 populateVariantAllele({link_data: linkData});
             }
         });
     }
 
-    handlePubMedLinks("{{ variant_annotation.pubmed|default_if_none:''|safe }}");
+    handlePubMedLinks("{{ variant_annotation.pubmed|default_if_none:''|escapejs }}");
     let dbSNP = $("#dbsnp_rs_id").text();
     if (dbSNP && dbSNP !== '-') {
         formatField($("#dbsnp_rs_id"), formatDBSNP);


### PR DESCRIPTION
🤖 Written by Claude

A handful of small, self-contained code-quality improvements.

- **SECRET_KEY generation** — generate the Django `SECRET_KEY` with the standard `django.core.management.utils.get_random_secret_key()` instead of the bespoke `random`-based `generate_key()` helper. Only affects fresh deployments where `django_secret_key.txt` does not yet exist; existing keys are untouched.
- **`IconWithTooltip`** — build the `<i>` markup with `format_html()` instead of hand-assembling a `SafeString`, removing the manual escaping and dropping now-unused imports.
- **`variant_details.html`** — use the `escapejs` filter (instead of `|safe`) for the two values embedded in inline `<script>` string literals, so they are always correctly encoded for a JS-string context.
- **MONDO search** — cap the length of the free-text `search_term` forwarded to the external Monarch search API.
- **OIDC group sync** — when removing a group a user has left, look it up with `.filter(...).first()` so a group deleted out-of-band between logins no longer raises during login.

No behaviour change for normal inputs; py_compile clean.