### PR TITLE
ontology: cap MONDO search term length sent to external API

### DIFF
--- a/ontology/views_rest.py
+++ b/ontology/views_rest.py
@@ -37,7 +37,8 @@ class SearchMondoText(APIView):
     )
     def get(self, request, **kwargs) -> Response:
 
-        search_term = request.GET.get('search_term') or ''
+        # Cap the length of free text forwarded to the external Monarch search API
+        search_term = (request.GET.get('search_term') or '')[:200]
         gene_symbol = request.GET.get('gene_symbol')
 
         selected = [term.strip() for term in (request.GET.get('selected') or '').split(",") if term.strip()]


### PR DESCRIPTION
🤖 Written by Claude

Cap the length of the free-text `search_term` forwarded from the MONDO search endpoint to the external Monarch search API. Small robustness improvement; no behaviour change for normal-length queries.