### PR TITLE
variantopedia: use escapejs for values in inline JS string literals

### DIFF
--- a/variantopedia/templates/variantopedia/variant_details.html
+++ b/variantopedia/templates/variantopedia/variant_details.html
@@ -410,14 +410,14 @@ $(document).ready(function() {
             error: function() {
                 console.log("Error retrieving allele");
                 // Can't retrieve, just show basics
-                let variantString = "{{ variant|safe }}";
+                let variantString = "{{ variant|escapejs }}";
                 let linkData = {variant_string: variantString, variant_coordinate: variantString};
                 populateVariantAllele({link_data: linkData});
             }
         });
     }
 
-    handlePubMedLinks("{{ variant_annotation.pubmed|default_if_none:''|safe }}");
+    handlePubMedLinks("{{ variant_annotation.pubmed|default_if_none:''|escapejs }}");
     let dbSNP = $("#dbsnp_rs_id").text();
     if (dbSNP && dbSNP !== '-') {
         formatField($("#dbsnp_rs_id"), formatDBSNP);


### PR DESCRIPTION
🤖 Written by Claude

Switch the two values embedded in inline `<script>` string literals in `variant_details.html` from `|safe` to `|escapejs`, so they are always correctly encoded for a JavaScript-string context regardless of their source. No visible change for current data.