### PR TITLE
Specimen -> Extraction -> Sample #1704

### DIFF
--- a/classification/autopopulate_evidence_keys/evidence_from_sample_and_patient.py
+++ b/classification/autopopulate_evidence_keys/evidence_from_sample_and_patient.py
@@ -4,7 +4,8 @@ from typing import Optional
 from classification.autopopulate_evidence_keys.evidence_from_variant import AutopopulateData
 from classification.enums import SpecialEKeys
 from patients.models_enums import Sex, Zygosity
-from snpdb.models import Sample, SampleGenotype, Specimen
+from patients.models import Extraction
+from snpdb.models import Sample, SampleGenotype
 from snpdb.models.models_variant import Variant
 
 
@@ -40,8 +41,8 @@ def get_evidence_fields_for_sample_and_patient(variant: Variant, sample: Sample)
         if patient.family_code:
             data[SpecialEKeys.FAMILY_ID] = patient.family_code
 
-    if sample.specimen:
-        data.update(get_evidence_fields_for_specimen(sample.specimen))
+    if sample.extraction:
+        data.update(get_evidence_fields_for_extraction(sample.extraction))
 
     if variant and sample:
         if sample_genotype := sample.get_genotype(variant):
@@ -83,13 +84,14 @@ def get_evidence_fields_for_sample_and_patient(variant: Variant, sample: Sample)
     return data
 
 
-def get_evidence_fields_for_specimen(specimen: Specimen) -> AutopopulateData:
+def get_evidence_fields_for_extraction(extraction: Extraction) -> AutopopulateData:
     data = AutopopulateData("specimen")
+    specimen = extraction.specimen
     data[SpecialEKeys.SPECIMEN_ID] = specimen.reference_id
     data[SpecialEKeys.ALLELE_ORIGIN] = specimen.get_mutation_type_display()
     data[SpecialEKeys.SAMPLE_TYPE] = str(specimen.tissue)
     data[SpecialEKeys.AGE] = specimen.age_at_collection_date
-    data[SpecialEKeys.NUCLEIC_ACID_SOURCE] = specimen.get_nucleic_acid_source_display()
+    data[SpecialEKeys.NUCLEIC_ACID_SOURCE] = extraction.get_nucleic_acid_source_display()
 
     return data
 

--- a/claude/plans/tso500_overall_plan.md
+++ b/claude/plans/tso500_overall_plan.md
@@ -1,0 +1,376 @@
+# TSO 500 — order of work
+
+Sequencing plan for [SACGF/variantgrid_sapath#431](https://github.com/SACGF/variantgrid_sapath/issues/431)
+and the issues under it. Covers what to build in what order and why, not how to build each piece —
+each issue carries its own design.
+
+The file-level ingestion analysis is in [`tso500_ingestion_plan.md`](tso500_ingestion_plan.md); the
+test data and its gotchas are in [`upload/test_data/tso500/README.md`](../../upload/test_data/tso500/README.md).
+
+---
+
+## Where things stand
+
+Test data landed in `ed5e15a33` — one de-identified run, one specimen, DNA and RNA arms, five files.
+Running each through the real pipe stages gave:
+
+| File | Today | Blocked on |
+|---|---|---|
+| `hard-filtered.vcf` | loads, 93 records | — |
+| `cnv.vcf` | loads, 25 records | copy-neutral rows and `SM` are refinements |
+| `SpliceVariants.vcf` | loads, 17 records | `AD`/`DP` mean something else; filter dropped |
+| `_DragenExonCNV.vcf` | dies at first pipe stage | PyVCF FILTER parse; no `##contig` lines |
+| `AllFusions.csv` | errors during file-type detection | no parser, and nowhere to put the rows |
+
+So three of five files already load, and the two that don't are blocked by different things — one by a
+small pipeline bug, one by a missing model. That split is what sets the order below.
+
+## The single most useful thing to fix first
+
+Everything downstream keys on the same thing: **the identifier pair that says these two arms are one
+specimen**. In the test run that is accession `2600000001` with container suffixes `C` (DNA) and `B`
+(RNA). Four separate pieces of work need that join to exist:
+
+- the DNA and RNA arms have to be recognisable as one specimen at all (#431's "C- ID / Pair ID")
+- specimen-level measures arrive by API keyed on it, not on a vendor pair-ID string
+  ([#1559](https://github.com/SACGF/variantgrid/issues/1559))
+- the analysis node selects on it
+  ([variantgrid_private#223](https://github.com/SACGF/variantgrid_private/issues/223) — settled on
+  Extraction/Specimen as the grouping level, since Patient is too coarse and SequencingSample too fine)
+- multi-variant reporting groups by it ([#444](https://github.com/SACGF/variantgrid/issues/444))
+
+That join key is [#1704](https://github.com/SACGF/variantgrid/issues/1704). It is the right next step,
+and the reason is not just that other issues block on it — it is that `Sample.specimen` is barely
+wired in today (five consumers, listed in the issue's R7) and every month of somatic work makes that
+surface larger. It is the one change here that gets more expensive by waiting.
+
+## Dependency map
+
+```
+  Phase 0  pipeline fixes ─────────────────┐
+           chase TAU files ────────────┐   │
+                                       │   │
+  Phase 1  #1704 Specimen→Extraction   │   │
+             │                         │   │
+      ┌──────┼───────────────┐         │   │
+      │      │               │         │   │
+  P2  │  TSO500 linking ◄────┼─────────┼───┘
+      │      + loader refinements       │
+      │                                 │
+  P3  │  #1559 specimen measures (API)  │
+      │                                 │
+  P4  #1506 GeneFusion ──► AllFusions parser ◄──┘   (independent of #1704 — can run in parallel)
+      │
+  P5  #1558 grid display
+      │
+  P6  private#223 analysis grouping node
+      │
+  P7  sapath#246 ──► #444 multi-variant reporting
+```
+
+Only two things are genuinely on a critical path: #1704 before anything that groups samples, and
+#1506 before the fusion parser has a destination. Everything else is ordered by value, not by
+necessity.
+
+---
+
+## Phase 0 — unblock the remaining test data, and start the long-lead requests
+
+Two small pipeline fixes, both worth doing regardless of TSO 500, both prerequisites for exercising
+the test data end to end.
+
+1. **Read declared FILTER IDs off the raw header lines** in `upload/management/commands/vcf_clean_and_filter.py`.
+   Illumina's LrCalculator writes `##FILTER` lines with keys beyond `ID`/`Description`, which PyVCF
+   rejects outright, killing the whole import at the first pipe stage. This is the last PyVCF use in the pipe.
+2. **`get_processing_ability` returns 0 for unreadable input** —
+   `upload/import_task_factories/import_task_factories.py:127` calls `pd.read_csv` bare, so one CSV
+   shape it cannot parse breaks file-type detection for every other CSV type.
+
+**Done** — `vcf_header_filter_ids()` in `library/genomics/vcf_utils.py`, tests in
+`library/tests/test_vcf_header_filter_ids.py`. Note this went to a regex over the header lines rather
+than cyvcf2 as originally sketched: cyvcf2 needs a real file descriptor (`StringIO`/`BytesIO` both raise
+`UnsupportedOperation: fileno`), and this command is a streaming stdin filter, so spilling the header to
+a temp file just to read it back would be worse than the hand-rolled parse the rest of the command
+already uses — which exists precisely because strict parsers choke on real-world headers.
+
+In parallel, and starting now because they have lead time, **request the missing files from TAU**:
+
+- `Logs_Intermediates/Gis/<sample>/<sample>.abcn_annotated.vcf` + `<sample>.abcn_genes.tsv` — per-gene
+  absolute and minor copy number, the latter being where gene-level LOH comes from. The only genuinely
+  CVO-only data, and a VCF, so it is in ingestion scope. Illumina names the path but publishes no
+  INFO/FORMAT spec, so it cannot be mocked up.
+- `MetricsOutput.tsv` / the run-level TMB summary — feeds Phase 3.
+- A run with a real BRCA1/2 large rearrangement. Both `_DragenExonCNV.vcf` records in the test data are
+  constructed, and no published TSO 500 output has a populated one either. Until one arrives the field
+  spelling in that file stays provisional.
+
+**Done when** all five test files at least reach the importer without erroring, and the requests are out.
+
+## Phase 1 — `Specimen → Extraction → Sample` (#1704)
+
+The foundational model change. Read the issue for R1-R8; the shape is:
+
+```
+Patient └── Specimen └── Extraction └── [SequencingSample] └── Sample
+```
+
+Points worth holding onto while implementing:
+
+- **`Extraction` goes in `patients`, not `seqauto`** (R1). VCFs arrive by hand, and some deployments
+  never run seqauto, so grouping has to work without it.
+- **`nucleic_acid_source` moves to `Extraction`** (R3). It sitting on `Specimen` is the direct cause of
+  the DNA and RNA arms becoming two unrelated specimens. `mutation_type` stays on `Specimen` — it
+  describes the material. `Sample.variants_type` is a third, genuinely different thing and stays put.
+- **`Specimen` needs a surrogate PK** (R4). `reference_id` is a `TextField` primary key today, so
+  specimen references are globally unique across all patients and any FK drags text keys around.
+- **Both levels extend `ExternallyManagedModel`** (`patients/models.py:85`) (R5) — this is what lets VG
+  and the LIMS agree on a specimen without string surgery on sample names, and it is what Phase 3 keys on.
+
+Consumer surface, all of it: `patients/import_records.py`, `snpdb/forms.py:366`, `snpdb/grids.py:161`,
+`patients/views_autocomplete.py`, and `get_evidence_fields_for_specimen()` in
+`classification/autopopulate_evidence_keys/evidence_from_sample_and_patient.py:86`. Patient CSV import
+has to keep round-tripping `PatientColumns.SPECIMEN_NUCLEIC_ACID_SOURCE` (R6) — decide whether the
+existing column implies an extraction or the CSV format grows one.
+
+**Settled** (2026-08-10), closing the open questions on the issue:
+
+- **Name it `Extraction`.** The LIMS-side collision noted on #1704 is real but lives in documentation,
+  not in the model.
+- **No QC fields on `Extraction`** (yield, concentration, 260/280). R5's `external_pk` keeps QC
+  reconcilable in the tracking system, and VG never generates those numbers — a second copy would only
+  drift. Nullable columns stay cheap to add if a consumer appears.
+- **No parent above `Specimen`.** A block (tumour FFPE) *is* a specimen, so several blocks from one
+  clinical case are several `Specimen` rows on one `Patient`, already told apart by `tissue` and
+  `collection_date`. A case level would only earn its place if one case needed its blocks analysed
+  together, which TSO 500 does not.
+- **The existing patient CSV column implies a single extraction** — `SPECIMEN_NUCLEIC_ACID_SOURCE`
+  creates/updates one `Extraction` under the `Specimen`, so existing CSVs keep working untouched (R6).
+  Those files describe one extraction per specimen anyway.
+
+Existing `Specimen` rows need a data migration creating one `Extraction` each, carrying the specimen's
+current `nucleic_acid_source`, and repointing their samples onto it.
+
+**Done when** a `Sample` reaches its specimen via `sample.extraction.specimen`, one specimen holds a DNA
+and an RNA extraction, and the existing patient CSV import still round-trips.
+
+**Built** on branch `issue_1704_specimen_extraction_sample` — models, the four migrations, R7's consumers,
+and an `Extraction` formset on the patient specimens tab so DNA/RNA stays settable now that it has left
+the specimen form. Two surfaces stayed specimen-shaped and are worth revisiting as consumers appear: the
+patient CSV columns are all `SPECIMEN_*`, so a CSV can name one extraction per specimen but not the DNA
+and RNA arms of one block; and `specimen_autocomplete` no longer has a caller, the sample form having
+moved to `extraction_autocomplete` (kept, since the sapath and private repos may use it).
+
+## Phase 2 — TSO 500 linking, and the per-file loader refinements
+
+With the model in place, make the run's files land against the right extractions. #431's decision is
+**upload the files separately and join later** — not concatenate before import — so this is mostly
+assignment, not a new bulk-import path. That is the cheap version and it is the right one: concatenating
+destroys per-caller cutoffs (which sapath#301 requires), the FORMAT fields across the DRAGEN outputs are
+disjoint so any merge is lossy, DNA and RNA are different libraries so a shared sample column makes
+VAF/depth meaningless, and fusions are not VCF at all.
+
+- **Parse accession + container suffix into `Specimen` + `Extraction`.** `2600000001` is the specimen,
+  the trailing `C`/`B` name the two extractions. Match on external identifiers where the tracking system
+  supplies them rather than trusting the name parse.
+- **Supply the genome build explicitly.** `_DragenExonCNV.vcf` has no `##contig` lines and only
+  `##reference=file:resource_bundle/hg19_decoy/`, so `vcf_detect_genome_build_from_header` finds nothing
+  and `upload/tasks/vcf/genotype_vcf_tasks.py:63` sets `REQUIRES_USER_INPUT` and stops. The loader knows
+  the build; pass it alongside the file.
+- **`VCFSourceSettings` mapping for SpliceGirl.** The `##source` line (`SpliceGirl 1.0.0.614`) is already
+  the hook. In this file `AD` is `Number=1` splice-supporting reads and `DP` is *reference* reads, so
+  binding them by name silently gives empty allele depth, missing VAF, and a read-depth column showing
+  reference counts. Derive VAF from `ALTDEDUP`/`REFDEDUP`.
+- **Preserve `LowUniqueAlignments`.** The splice header declares `LowQ` only, so `vcf_clean_and_filter`
+  strips the undeclared code from 15 of 17 records — and that is the filter separating the two `PASS`
+  oncology calls from the background. The genotype processor already copes via `_add_undeclared_filter_code`;
+  either let undeclared values through the header stage or have the loader add the `##FILTER` line.
+- **Skip copy-neutral `cnv.vcf` rows.** `ALT=.` is 406 of 500 in a real run; they carry no call and
+  currently import as reference variants with the segment span discarded.
+- **Carry `Specimen`/`Extraction` through the seqauto API as text beside the FKs.** Phase 1 added
+  `SequencingSample.extraction`, but `SequencingSampleSerializer`
+  (`seqauto/serializers/sequencing_serializers.py:232`) does not list the field, so the FK is
+  unreachable from the lab client that posts sample sheets — the only ways to set an extraction today
+  are the sample form, the patient CSV and the admin.
+
+  **Settled**: `SequencingSample` grows plain-text specimen and extraction reference columns alongside
+  the model FKs. The client sends the text, and the API stores whatever it was sent — the payload is
+  always accepted. Where a `Specimen`/`Extraction` already exists the serializer links it; where one
+  does not, the text is kept and the FK stays null for a later matching pass. The lab client owns the
+  identifiers, VG owns the objects, and a run posts successfully whether or not the tracking system got
+  there first. This is the shape `PatientRecord` already uses (`patients/models.py:635`) — raw columns
+  from the file beside the matched FK — so the matching pass has a precedent to follow.
+
+  Because nothing is created, the API needs no `Patient`, which is what would otherwise have blocked
+  this: `Specimen.patient` is non-null and nothing in the seqauto payload names a patient.
+
+  **Deferred to later work**: the matching pass itself — reconciling stored text against specimens and
+  extractions that arrive afterwards, on the R5 external identifiers where the tracking system supplies
+  them and the accession/container-suffix parse above where it does not.
+
+Note `SEGID=MYCL1` uses an older symbol than the rest of the pipeline (`MYCL`) — resolve gene symbols
+through `GeneSymbol` rather than trusting what the caller wrote. The same argument recurs in Phase 4.
+
+**Decide before starting:** where the loader lives. Upload is strictly per-file today and has no
+directory concept; seqauto already models runs, sample sheets and file discovery. Given "upload
+separately, join later", the lightest answer is probably that the lab client posts the linkage and the
+files go through normal upload — which also matches Phase 3's direction. Worth settling explicitly
+rather than by default.
+
+**Done when** the whole test run imports with both arms attached to one specimen, splice VAF is right,
+and no copy-neutral rows are inserted.
+
+## Phase 3 — specimen-level measures (#1559)
+
+Small, and it proves Phase 1's identifiers work across the LIMS boundary. Direction is already settled:
+**these arrive by API from the lab client, not by VG parsing pipeline output.** The measures are
+scattered across the run — TMB summary in one place, MSI in a separate JSON, GIS with tumour fraction
+and ploidy in another written by a different tool — and none of that structure is worth VG knowing about.
+When Illumina moves a file between releases it becomes a client change, not a VG release.
+
+Four things to hold to, from the issue:
+
+- **The client transcribes, it never computes.** Lifting a value out of vendor output is fine; deriving
+  one moves a clinical calculation into an unversioned client nobody reviews.
+- **Store the raw payload beside the parsed fields**, so "which file and which pipeline version produced
+  this number" is answerable at report time. `HelixNGSOrder.raw_data` in Mocha is the existing pattern.
+- **Key on the specimen/extraction external identifiers from #1704**, not a vendor pair-ID string.
+- **Keep the schema vendor-neutral** — `SpecimenMeasure(specimen, measure_type, value, unit, method,
+  source_payload)` rather than a TSO500-shaped table.
+
+Store the **score as well as the call**. HRD gives a genomic instability score and no positive/negative
+call — the threshold is lab policy, not vendor output. Same for MSI and TMB high/low. Without the raw
+value plus the threshold applied and by whom, a later re-interpretation is unreconstructable. This
+mirrors the evidence keys already in `classification/migrations/0164_somatic_hrd_msi_tmb_ekeys.py` —
+`somatic:tmb_value` beside `somatic:tmb_status`, `somatic:msi_value` beside `somatic:msi_status`.
+`somatic:hrd_status` has no value counterpart yet; a score field is the equivalent.
+
+Per-gene absolute and minor copy number are *not* in scope here — they are per-gene rather than
+per-specimen and arrive as a VCF, so they are ingestion. They land whenever Phase 0's request produces
+`abcn_annotated.vcf`.
+
+**Done when** the client can post TMB/MSI/GIS for a specimen and it shows on the specimen page.
+
+## Phase 4 — `GeneFusion` and the `AllFusions.csv` parser (#1506, phase 1 only)
+
+Independent of Phases 1-3, so this can run in parallel with a second person from Phase 0 onward.
+
+**Scope it to ingestion, storage and identity. Leave fusion classification equivalence alone.** The
+design on #1506 already does this deliberately: a `GeneFusion` model keyed on a canonical gene pair with
+a one-to-one *bare* `Allele` (no `ClinGenAllele`, no `VariantAllele` — purely a grouping key), plus an
+`ImportedAlleleInfo.gene_fusion` FK that short-circuits HGVS resolution. Because the bare Allele slots
+into the existing infrastructure, `ClinicalContext`, `DiscordanceReport`, the VCF pipeline, annotation
+and ClinGen all need no changes; range queries just exclude `genefusion__isnull=False`.
+
+This matters for sequencing, because the user-group feedback on #1506 — "very difficult to implement,
+needs more thinking and likely more resourcing, likely a research level project" — is about **fusion
+equivalence and discordance**, not about ingesting and displaying them. Somatic classifications already
+land on `MULTIPLE_RECORDS_DISCORDANCE_NOT_SUPPORTED`, so phase 1 gets that for free and the research-level
+part stays deferred. Breakend coordinates (#1506 phase 2) and BND VCF export (phase 3) are also deferred.
+
+The parser then needs a fusion import task factory claiming the file — recognisable from the
+`# Source = FusionProcessor` first line and the `Caller,Gene A,Gene B,…` header row — with a processing
+ability above `GeneListImportTaskFactory`'s 1, which would otherwise win and import the fusions as a
+gene list. Real-file properties it has to survive, all present in the test data:
+
+- **Multi-gene partners are routine**, not edge cases — `ROS1;GOPC`, `RP11-458D21.5;NOTCH2NL`. The
+  per-gene annotation columns are correspondingly semicolon-delimited. **Open question:** for a partner
+  that is one HGNC gene plus one clone-based identifier, reject the row or resolve to the HGNC member?
+- **`SEPT14`** (EGFR-SEPT14) — HGNC renamed it `SEPTIN14`, and spreadsheets date-mangle it. A direct test
+  of keying on HGNC ID rather than symbol.
+- **Mixed delimiters** — `PPARG/AC016683.6` uses a slash alongside the `;` and `-` forms.
+- **Direction is reported, not inferred** — `Fusion Directionality Known` plus `Gene A Sense`/`Gene B Sense`
+  populate `is_ordered` from data.
+- **Breakpoint context** — `Gene A Location`/`Gene B Location` carry `IntactExon`/`BrokenExon`/`Intronic`/
+  `Intergenic`. Keep in `source_data`; a later breakend representation wants exactly this and it costs
+  nothing now.
+- **Two callers in one file** (`DRAGEN`, `SpliceGirl`) whose scores and filters the header warns are not
+  comparable — carry caller per row.
+- **Ingest unfiltered.** 1 of 149 rows passed the caller's own filter. Same posture as the CNV and
+  small-variant VCFs: take everything, apply our own thresholds.
+
+**Done when** all 33 rows of the test file import, `EGFR-SEPTIN14` resolves despite the file saying
+`SEPT14`, and the same fusion from both callers resolves to one `GeneFusion`.
+
+## Phase 5 — showing non-variants on the grids (#1558)
+
+Less outstanding than the issue title suggests. Per its own comment table, SV already works in the grid
+and CNV works as SV — what is missing is surfacing `CohortGenotype.info["CN"]` (and TSO 500's `FORMAT/SM`
+linear copy ratio, which importer v21+ already keeps in the format JSON blob but which is not queryable).
+That part is independent and could be pulled forward any time.
+
+Fusions are the genuinely new case, and only exist to display after Phase 4. The single-grid vs
+multiple-grids question is worth deciding on real fusion rows rather than in the abstract — with a
+`GeneFusion`-keyed `Allele` in hand, "sort by gene brings the fusions together" is testable instead of
+hypothetical.
+
+## Phase 6 — analysis grouping node (variantgrid_private#223)
+
+Consumes Phase 1 directly. The grouping level is settled: **Extraction, then Specimen** — Patient is too
+coarse (same patient sequenced at multiple timepoints, wanted independently) and SequencingSample too
+fine (one library/index, so it cannot unite the DNA and RNA arms).
+
+Build the **extraction level first** — same nucleic acid, different callers. That is the VarDict/Mutect
+case from sapath#301 and the DRAGEN snv+cnv split, and it has no genome-build complication. Layer
+specimen on top after.
+
+Likely less new machinery than it looks: `Cohort.vcf` is already nullable and spans VCFs
+(`snpdb/models/models_cohort.py:53`), `CohortNode` consumes it today, and the per-caller-cutoff case is
+already expressible as N× `SampleNode` with their own `min_ad`/`min_dp` into a `MergeNode`. So this is
+largely an entry-point problem — auto-selecting the right samples and wiring the template — and
+`analysis_templates_tag` (`analysis/templatetags/related_analyses_tags.py:134`) takes exactly one of
+sample/cohort/trio/quad/pedigree today, with extraction and specimen the natural extension. Preserve
+caller/VCF identity rather than unioning: sapath#301 requires different cutoffs per caller, and a node
+that merges everything solves neither that nor the FFPE-vs-germline case.
+
+`Cohort` has a `genome_build` FK, so a cross-VCF cohort is single-build by construction — fine at
+extraction and specimen level, and only a problem if this ever goes up to Patient.
+
+## Phase 7 — reporting (sapath#246, then #444)
+
+Last, because it consumes everything above. #431 notes #246 is old and may be worth rolling into #444.
+
+- **sapath#246** — keep tagging `SomaticReportable` as now, but launch the classification as AMP/somatic
+  from the grid's tags button rather than exporting CSV. Small and independent of the rest; could be
+  pulled forward if it is blocking the diagnostic team.
+- **#444** — multi-variant classification and reporting. Grouped by gene, launched from the sample or
+  specimen page, pulling in Phase 3's TMB/MSI measures. `ClassificationReportTemplate` exists; the vue
+  template needs to take an array.
+
+---
+
+## Parallelism
+
+With two people: one takes Phase 1 → 2 → 3 (the model spine), the other takes Phase 0 → 4 (fusions), and
+they meet at Phase 5. Phase 4 touches `classification` and `upload`; Phases 1-3 touch `patients` and
+`snpdb`, so the conflict surface is small.
+
+With one person, the order above is the order.
+
+## Decisions worth settling before their phase starts
+
+| Decision | Phase | Why it is cheaper now |
+|---|---|---|
+| ~~Extraction QC, Specimen parent, patient CSV, naming~~ | 1 | Settled — see Phase 1 |
+| Where does the run loader live — upload, seqauto, or lab-client API? | 2 | Settle explicitly; the API answer lines up with Phase 3 |
+| ~~May the seqauto API create specimens/extractions, or only match them?~~ | 2 | Settled — text beside the FKs, link what exists, match the rest later. See Phase 2 |
+| Multi-gene partner with one HGNC and one clone identifier — reject or resolve? | 4 | Determines whether `GeneFusion` identity can be non-null on both sides |
+| Single grid or multiple grids for non-variants? | 5 | Best answered against real fusion rows, so genuinely wait for Phase 4 |
+
+## Deferred, deliberately
+
+- **Matching stored seqauto text to specimens and extractions** — Phase 2 keeps the client's references
+  as text whenever the objects are absent, so the reconciliation pass can land whenever the tracking
+  system integration is ready, against real unmatched rows rather than hypothetical ones.
+- **Fusion equivalence and discordance** — the research-level part of #1506. Somatic classifications get
+  `MULTIPLE_RECORDS_DISCORDANCE_NOT_SUPPORTED` today, so nothing regresses by waiting.
+- **Breakend coordinates and BND VCF export** — #1506 phases 2 and 3.
+- **`abcn_annotated.vcf` / gene-level LOH** — cannot start until TAU supplies a file; the format is
+  undocumented and not usefully mockable.
+- **`_DragenExonCNV.vcf` exact field spelling** — provisional until a run with a real large rearrangement
+  arrives. Note the CombinedVariantOutput reports these as `<LOSS>` where the VCF header declares `<DEL>`.
+- **`CombinedVariantOutput.tsv`** — settled as not worth ingesting. It is exactly a filtered subset of the
+  individual files (`PASS` small variants, `PASS` non-reference CNV) and discards 148 of 149 fusion calls
+  and every splice call.
+- **Fold-change → DEL/DUP conversion** (sapath#304's open question) — moot for v2.6.2, which emits
+  `<DUP>`/`<DEL>` directly with `SM` as the linear copy ratio. The `cnv_tsv_to_vcf.py` command in the
+  sapath repo predates that.

--- a/patients/admin.py
+++ b/patients/admin.py
@@ -23,8 +23,8 @@ class SpecimenAdmin(ModelAdminBasics):
 
 @admin.register(models.Extraction)
 class ExtractionAdmin(ModelAdminBasics):
-    list_display = ("id", "specimen", "nucleic_acid_source")
-    search_fields = ("specimen__reference_id",)
+    list_display = ("id", "specimen", "reference_id", "nucleic_acid_source", "extraction_date")
+    search_fields = ("reference_id", "specimen__reference_id")
 
 
 @admin.register(models.PatientImport)

--- a/patients/admin.py
+++ b/patients/admin.py
@@ -17,7 +17,14 @@ class TissueAdmin(ModelAdminBasics):
 
 @admin.register(models.Specimen)
 class SpecimenAdmin(ModelAdminBasics):
-    pass
+    list_display = ("id", "reference_id", "patient", "tissue", "mutation_type", "collection_date")
+    search_fields = ("reference_id",)
+
+
+@admin.register(models.Extraction)
+class ExtractionAdmin(ModelAdminBasics):
+    list_display = ("id", "specimen", "reference_id", "nucleic_acid_source")
+    search_fields = ("reference_id", "specimen__reference_id")
 
 
 @admin.register(models.PatientImport)

--- a/patients/admin.py
+++ b/patients/admin.py
@@ -23,8 +23,8 @@ class SpecimenAdmin(ModelAdminBasics):
 
 @admin.register(models.Extraction)
 class ExtractionAdmin(ModelAdminBasics):
-    list_display = ("id", "specimen", "reference_id", "nucleic_acid_source")
-    search_fields = ("reference_id", "specimen__reference_id")
+    list_display = ("id", "specimen", "nucleic_acid_source")
+    search_fields = ("specimen__reference_id",)
 
 
 @admin.register(models.PatientImport)

--- a/patients/forms.py
+++ b/patients/forms.py
@@ -1,11 +1,12 @@
 from dal import forward
 from django import forms
-from django.forms.models import ALL_FIELDS, inlineformset_factory
+from django.forms.models import inlineformset_factory, modelformset_factory
 from django.forms.widgets import TextInput
 
 from library.django_utils.autocomplete_utils import ModelSelect2
 from library.guardian_utils import assign_permission_to_user_and_groups
 from patients.models import (
+    Extraction,
     ExternalPK,
     Patient,
     PatientModification,
@@ -120,7 +121,7 @@ class PatientSearchForm(forms.Form):
 PatientSpecimenFormSet = inlineformset_factory(Patient,
                                                Specimen,
                                                can_delete=True,
-                                               fields=ALL_FIELDS,
+                                               exclude=['external_pk'],
                                                widgets={'name': TextInput(),
                                                         'description': TextInput(),
                                                         'reference_id': TextInput(),
@@ -128,6 +129,13 @@ PatientSpecimenFormSet = inlineformset_factory(Patient,
                                                         'collection_date': TextInput(attrs={'class': 'date-picker'}),
                                                         'received_date': TextInput(attrs={'class': 'date-picker'})},
                                                extra=1)
+
+# Not an inline formset as Extraction hangs off Specimen - the view restricts it to one patient
+PatientExtractionFormSet = modelformset_factory(Extraction,
+                                                can_delete=True,
+                                                fields=['specimen', 'reference_id', 'nucleic_acid_source'],
+                                                widgets={'reference_id': TextInput()},
+                                                extra=1)
 
 
 def external_pk_autocomplete_form_factory(external_type):

--- a/patients/forms.py
+++ b/patients/forms.py
@@ -130,6 +130,7 @@ PatientSpecimenFormSet = inlineformset_factory(Patient,
                                                         'received_date': TextInput(attrs={'class': 'date-picker'})},
                                                extra=1)
 
+
 def patient_extraction_formset_factory(patient):
     """ Not an inline formset as Extraction hangs off Specimen rather than Patient, so the patient is
         forwarded as a constant to narrow the specimen autocomplete. The view sets the queryset,
@@ -139,8 +140,9 @@ def patient_extraction_formset_factory(patient):
                                    attrs={'data-placeholder': 'Specimen...'})
     return modelformset_factory(Extraction,
                                 can_delete=True,
-                                fields=['specimen', 'nucleic_acid_source', 'extraction_date'],
+                                fields=['specimen', 'reference_id', 'nucleic_acid_source', 'extraction_date'],
                                 widgets={'specimen': specimen_widget,
+                                         'reference_id': TextInput(),
                                          'extraction_date': TextInput(attrs={'class': 'date-picker'})},
                                 extra=1)
 

--- a/patients/forms.py
+++ b/patients/forms.py
@@ -130,11 +130,19 @@ PatientSpecimenFormSet = inlineformset_factory(Patient,
                                                         'received_date': TextInput(attrs={'class': 'date-picker'})},
                                                extra=1)
 
-# Not an inline formset as Extraction hangs off Specimen - the view restricts it to one patient
-PatientExtractionFormSet = modelformset_factory(Extraction,
-                                                can_delete=True,
-                                                fields=['specimen', 'nucleic_acid_source'],
-                                                extra=1)
+def patient_extraction_formset_factory(patient):
+    """ Not an inline formset as Extraction hangs off Specimen rather than Patient, so the patient is
+        forwarded as a constant to narrow the specimen autocomplete. The view sets the queryset,
+        which is what actually restricts what can be saved """
+    specimen_widget = ModelSelect2(url='specimen_autocomplete',
+                                   forward=(forward.Const(patient.pk, 'patient'),),
+                                   attrs={'data-placeholder': 'Specimen...'})
+    return modelformset_factory(Extraction,
+                                can_delete=True,
+                                fields=['specimen', 'nucleic_acid_source', 'extraction_date'],
+                                widgets={'specimen': specimen_widget,
+                                         'extraction_date': TextInput(attrs={'class': 'date-picker'})},
+                                extra=1)
 
 
 def external_pk_autocomplete_form_factory(external_type):

--- a/patients/forms.py
+++ b/patients/forms.py
@@ -133,8 +133,7 @@ PatientSpecimenFormSet = inlineformset_factory(Patient,
 # Not an inline formset as Extraction hangs off Specimen - the view restricts it to one patient
 PatientExtractionFormSet = modelformset_factory(Extraction,
                                                 can_delete=True,
-                                                fields=['specimen', 'reference_id', 'nucleic_acid_source'],
-                                                widgets={'reference_id': TextInput()},
+                                                fields=['specimen', 'nucleic_acid_source'],
                                                 extra=1)
 
 

--- a/patients/import_records.py
+++ b/patients/import_records.py
@@ -57,22 +57,22 @@ def assign_patient_to_sample(patient_import, user, sample, patient, origin):
                                        patient_import=patient_import)
 
 
-def assign_specimen_to_sample(patient_import, user, sample, specimen, origin):
+def assign_extraction_to_sample(patient_import, user, sample, extraction, origin):
     """ Creates patient modification record """
 
-    if sample.specimen == specimen:
+    if sample.extraction == extraction:
         return
 
-    old_specimen = sample.specimen
+    old_extraction = sample.extraction
 
-    sample.specimen = specimen
+    sample.extraction = extraction
     sample.save()
 
-    description = f"Assigned specimen to {sample=}"
-    if old_specimen:
-        description += f" (previously specimen was: {old_specimen})"
+    description = f"Assigned extraction to {sample=}"
+    if old_extraction:
+        description += f" (previously extraction was: {old_extraction})"
 
-    PatientModification.objects.create(patient=specimen.patient,
+    PatientModification.objects.create(patient=extraction.specimen.patient,
                                        user=user,
                                        description=description,
                                        origin=origin,
@@ -337,17 +337,17 @@ def process_record(patient_records, record_id, row):
         patient.save(check_patient_text_phenotype=False)  # Will do bulk at the end
 
     specimen = None
-    # print("specimen_reference_id=%s" %(specimen_reference_id))
+    extraction = None
     if specimen_reference_id:
-        # print("process specimen id=%s" %(specimen_reference_id))
-        try:
-            specimen = Specimen.objects.get(reference_id=specimen_reference_id)
-            if specimen.patient != patient:
-
-                msg = f"{specimen} had patient {patient}, tried to assign to patient {specimen.patient}"
-                raise ValueError(msg)
+        specimen = Specimen.objects.filter(patient=patient, reference_id=specimen_reference_id).first()
+        if specimen:
             specimen_match_type = PatientRecordMatchType.EXACT
-        except Specimen.DoesNotExist:
+        else:
+            other_patients_specimen = Specimen.objects.filter(reference_id=specimen_reference_id).first()
+            if other_patients_specimen:
+                msg = f"{other_patients_specimen} has patient {other_patients_specimen.patient}, " \
+                      f"tried to assign to patient {patient}"
+                raise ValueError(msg)
             specimen = Specimen.objects.create(reference_id=specimen_reference_id,
                                                patient=patient)
             specimen_match_type = PatientRecordMatchType.CREATED
@@ -361,22 +361,22 @@ def process_record(patient_records, record_id, row):
             "collection_date": specimen_collection_date,
             "received_date": specimen_received_date,
             "mutation_type": specimen_mutation_type,
-            "nucleic_acid_source": specimen_nucleic_acid_source,
             "_age_at_collection_date": specimen_age_at_collection
         }
         changed = set_fields_if_blank(specimen, field_values)
         if changed:
-            # print("save specimen id=%s" %(specimen_reference_id))
             specimen.description = specimen_description
             specimen.collected_by = specimen_collected_by
             specimen.patient = patient
             specimen.collection_date = specimen_collection_date
             specimen.received_date = specimen_received_date
             specimen.mutation_type = specimen_mutation_type
-            specimen.nucleic_acid_source = specimen_nucleic_acid_source
             specimen._age_at_collection_date = specimen_age_at_collection
 
             specimen.save()
+
+        # The CSV has one nucleic acid source column, so it describes a single extraction per specimen
+        extraction = specimen.get_or_create_extraction(specimen_nucleic_acid_source)
     else:
         specimen_match_type = None
 
@@ -384,8 +384,8 @@ def process_record(patient_records, record_id, row):
         origin = PatientRecordOriginType.UPLOADED_CSV
         assign_patient_to_sample(patient_records.patient_import, user, sample, patient, origin)
 
-        if specimen:
-            assign_specimen_to_sample(patient_records.patient_import, user, sample, specimen, origin)
+        if extraction:
+            assign_extraction_to_sample(patient_records.patient_import, user, sample, extraction, origin)
 
     validation_message = '\n'.join(validation_messages)
     valid = not validation_messages

--- a/patients/migrations/0013_extraction_specimen_surrogate_pk.py
+++ b/patients/migrations/0013_extraction_specimen_surrogate_pk.py
@@ -1,0 +1,148 @@
+"""
+#1704 - Specimen -> Extraction -> Sample.
+
+Specimen swaps its TextField primary key for a surrogate one (reference_id becomes unique per
+patient rather than globally), gains ExternallyManagedModel's external_pk, and hands
+nucleic_acid_source down to the new Extraction. Every existing Specimen gets one Extraction
+carrying whatever nucleic_acid_source it had.
+
+FKs into Specimen are dropped and rebuilt around the key change - snpdb.0201 does that for Sample,
+this does it for PatientRecord.
+"""
+import django.db.models.deletion
+import django_extensions.db.fields
+from django.db import migrations, models
+from django.db.models import F
+from django.utils import timezone
+
+
+def _flush_deferred_constraints(schema_editor):
+    """ Postgres refuses ALTER TABLE while deferred FK trigger events from a data change are pending """
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
+def _stash_specimen_reference(apps, schema_editor):
+    PatientRecord = apps.get_model("patients", "PatientRecord")
+    PatientRecord.objects.filter(specimen__isnull=False).update(_specimen_reference_id=F("specimen_id"))
+    _flush_deferred_constraints(schema_editor)
+
+
+def _create_extractions(apps, schema_editor):
+    Specimen = apps.get_model("patients", "Specimen")
+    Extraction = apps.get_model("patients", "Extraction")
+    extractions = [Extraction(specimen=specimen, nucleic_acid_source=specimen.nucleic_acid_source)
+                   for specimen in Specimen.objects.all().iterator()]
+    Extraction.objects.bulk_create(extractions, batch_size=2000)
+    _flush_deferred_constraints(schema_editor)
+
+
+def _restore_specimen_reference(apps, schema_editor):
+    """ reference_id was globally unique while it was the primary key, so it identifies the row """
+    PatientRecord = apps.get_model("patients", "PatientRecord")
+    Specimen = apps.get_model("patients", "Specimen")
+    specimen_by_reference_id = dict(Specimen.objects.values_list("reference_id", "pk"))
+
+    patient_records = []
+    for patient_record in PatientRecord.objects.filter(_specimen_reference_id__isnull=False).iterator():
+        patient_record.specimen_id = specimen_by_reference_id.get(patient_record._specimen_reference_id)
+        patient_records.append(patient_record)
+    PatientRecord.objects.bulk_update(patient_records, ["specimen_id"], batch_size=2000)
+    _flush_deferred_constraints(schema_editor)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patients', '0012_manual_patient_code_backfill_reminder'),
+        ('snpdb', '0201_sample_stash_specimen_reference'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='patientrecord',
+            name='_specimen_reference_id',
+            field=models.TextField(null=True),
+        ),
+        migrations.RunPython(_stash_specimen_reference, migrations.RunPython.noop, elidable=True),
+        migrations.RemoveField(
+            model_name='patientrecord',
+            name='specimen',
+        ),
+
+        # Nothing points at Specimen.reference_id now, so the key can be swapped
+        migrations.AlterField(
+            model_name='specimen',
+            name='reference_id',
+            field=models.TextField(),
+        ),
+        migrations.AddField(
+            model_name='specimen',
+            name='id',
+            field=models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID'),
+            preserve_default=False,
+        ),
+        migrations.AlterUniqueTogether(
+            name='specimen',
+            unique_together={('patient', 'reference_id')},
+        ),
+        migrations.AddField(
+            model_name='specimen',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=timezone.now,
+                                                                    verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='specimen',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, default=timezone.now,
+                                                                        verbose_name='modified'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='specimen',
+            name='external_pk',
+            field=models.OneToOneField(null=True, on_delete=django.db.models.deletion.CASCADE,
+                                       to='patients.externalpk'),
+        ),
+
+        migrations.CreateModel(
+            name='Extraction',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', django_extensions.db.fields.CreationDateTimeField(auto_now_add=True,
+                                                                              verbose_name='created')),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(auto_now=True,
+                                                                                   verbose_name='modified')),
+                ('reference_id', models.TextField(blank=True, null=True)),
+                ('nucleic_acid_source', models.CharField(blank=True,
+                                                         choices=[('D', 'DNA'), ('R', 'RNA')],
+                                                         default='D', max_length=1, null=True)),
+                ('external_pk', models.OneToOneField(null=True, on_delete=django.db.models.deletion.CASCADE,
+                                                     to='patients.externalpk')),
+                ('specimen', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
+                                               to='patients.specimen')),
+            ],
+            options={
+                'unique_together': {('specimen', 'reference_id')},
+            },
+        ),
+        migrations.RunPython(_create_extractions, migrations.RunPython.noop, elidable=True),
+        migrations.RemoveField(
+            model_name='specimen',
+            name='nucleic_acid_source',
+        ),
+
+        migrations.AddField(
+            model_name='patientrecord',
+            name='specimen',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL,
+                                    related_name='related_specimen', to='patients.specimen'),
+        ),
+        migrations.RunPython(_restore_specimen_reference, migrations.RunPython.noop, elidable=True),
+        migrations.RemoveField(
+            model_name='patientrecord',
+            name='_specimen_reference_id',
+        ),
+    ]

--- a/patients/migrations/0013_extraction_specimen_surrogate_pk.py
+++ b/patients/migrations/0013_extraction_specimen_surrogate_pk.py
@@ -115,7 +115,6 @@ class Migration(migrations.Migration):
                                                                               verbose_name='created')),
                 ('modified', django_extensions.db.fields.ModificationDateTimeField(auto_now=True,
                                                                                    verbose_name='modified')),
-                ('reference_id', models.TextField(blank=True, null=True)),
                 ('nucleic_acid_source', models.CharField(blank=True,
                                                          choices=[('D', 'DNA'), ('R', 'RNA')],
                                                          default='D', max_length=1, null=True)),
@@ -124,9 +123,6 @@ class Migration(migrations.Migration):
                 ('specimen', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
                                                to='patients.specimen')),
             ],
-            options={
-                'unique_together': {('specimen', 'reference_id')},
-            },
         ),
         migrations.RunPython(_create_extractions, migrations.RunPython.noop, elidable=True),
         migrations.RemoveField(

--- a/patients/migrations/0014_extraction_date_and_timestamps.py
+++ b/patients/migrations/0014_extraction_date_and_timestamps.py
@@ -1,0 +1,187 @@
+"""
+Extraction.extraction_date - how a lab tells apart two extractions of the same nucleic acid from one
+specimen, which was previously only the surrogate id.
+
+Everything else in patients becomes a TimeStampedModel. Patient, Specimen and Extraction already were
+via ExternallyManagedModel.
+"""
+
+import django.utils.timezone
+import django_extensions.db.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patients', '0013_extraction_specimen_surrogate_pk'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='clinician',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='followleadscientist',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='patientattachment',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='patientcomment',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='patientimport',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='patientmodification',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='patientpopulation',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='patientrecord',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='patientrecords',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AlterModelOptions(
+            name='tissue',
+            options={'get_latest_by': 'modified'},
+        ),
+        migrations.AddField(
+            model_name='clinician',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='clinician',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='externalpk',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='externalpk',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='extraction',
+            name='extraction_date',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='followleadscientist',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='followleadscientist',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='patientattachment',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='patientattachment',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='patientcomment',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='patientcomment',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='patientimport',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='patientimport',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='patientmodification',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='patientmodification',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='patientpopulation',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='patientpopulation',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='patientrecord',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='patientrecord',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='patientrecords',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='patientrecords',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+        migrations.AddField(
+            model_name='tissue',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, default=django.utils.timezone.now, verbose_name='created'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='tissue',
+            name='modified',
+            field=django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified'),
+        ),
+    ]

--- a/patients/migrations/0015_extraction_reference_id.py
+++ b/patients/migrations/0015_extraction_reference_id.py
@@ -1,0 +1,26 @@
+"""
+Extraction gets a local reference beside external_pk, which is nullable because not every deployment
+has an external system managing it - the same reason Patient carries patient_code and Specimen its own
+reference_id.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patients', '0014_extraction_date_and_timestamps'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='extraction',
+            name='reference_id',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='extraction',
+            unique_together={('specimen', 'reference_id')},
+        ),
+    ]

--- a/patients/models.py
+++ b/patients/models.py
@@ -361,14 +361,10 @@ class Extraction(ExternallyManagedModel):
         One extraction can be sequenced more than once (repeats, top-ups) so SequencingSample
         points here rather than the other way around """
     specimen = models.ForeignKey(Specimen, on_delete=CASCADE)
-    reference_id = models.TextField(null=True, blank=True)
     nucleic_acid_source = models.CharField(max_length=1, choices=NucleicAcid.choices, default=NucleicAcid.DNA, null=True, blank=True)
 
-    class Meta:
-        unique_together = ("specimen", "reference_id")
-
     def __str__(self):
-        s = self.reference_id or str(self.specimen)
+        s = str(self.specimen)
         if self.nucleic_acid_source:
             s += f" ({self.get_nucleic_acid_source_display()})"
         return s

--- a/patients/models.py
+++ b/patients/models.py
@@ -62,7 +62,7 @@ class ExternalModelManager(TimeStampedModel):
         return name
 
 
-class ExternalPK(models.Model, PreviewModelMixin):
+class ExternalPK(TimeStampedModel, PreviewModelMixin):
     code = models.TextField()
     external_type = models.TextField()
     external_manager = models.ForeignKey(ExternalModelManager, on_delete=CASCADE)
@@ -215,6 +215,10 @@ class Patient(GuardianPermissionsMixin, HasPhenotypeDescriptionMixin, Externally
         return self.specimen_set.count()
 
     @property
+    def num_extractions(self):
+        return Extraction.objects.filter(specimen__patient=self).count()
+
+    @property
     def age(self):
         """ You may actually want to use Specimen.age_at_collection_date rather than this """
         return calculate_age(self.date_of_birth, self.date_of_death)
@@ -289,14 +293,14 @@ class Patient(GuardianPermissionsMixin, HasPhenotypeDescriptionMixin, Externally
         return reverse('patients')
 
 
-class PatientPopulation(models.Model):
+class PatientPopulation(TimeStampedModel):
     """ Can have many-to-one - e.g. Obama would have an entry for
         both AFRICAN_AFRICAN_AMERICAN and NON_FINNISH_EUROPEAN """
     patient = models.ForeignKey(Patient, on_delete=CASCADE)
     population = models.CharField(max_length=3, choices=PopulationGroup.choices)
 
 
-class Tissue(models.Model):
+class Tissue(TimeStampedModel):
     name = models.TextField()
     description = models.TextField()
 
@@ -362,15 +366,18 @@ class Extraction(ExternallyManagedModel):
         points here rather than the other way around """
     specimen = models.ForeignKey(Specimen, on_delete=CASCADE)
     nucleic_acid_source = models.CharField(max_length=1, choices=NucleicAcid.choices, default=NucleicAcid.DNA, null=True, blank=True)
+    extraction_date = models.DateTimeField(null=True, blank=True)
 
     def __str__(self):
         s = str(self.specimen)
         if self.nucleic_acid_source:
             s += f" ({self.get_nucleic_acid_source_display()})"
+        if self.extraction_date:
+            s += f" {self.extraction_date.strftime(settings.DATE_FORMAT)}"
         return s
 
 
-class PatientAttachment(models.Model):
+class PatientAttachment(TimeStampedModel):
     UPLOAD_PATH = 'patient_attachments'
 
     patient = models.ForeignKey(Patient, on_delete=CASCADE)
@@ -418,13 +425,13 @@ class PatientRecordOriginType:
     )
 
 
-class PatientImport(models.Model):
+class PatientImport(TimeStampedModel):
     """ All the modifications hang off this. We don't want this to get deleted so modifications stay there
         Even after reload patient import """
     name = models.TextField()
 
 
-class PatientModification(models.Model):
+class PatientModification(TimeStampedModel):
     patient = models.ForeignKey(Patient, on_delete=CASCADE)
     user = models.ForeignKey(User, null=True, on_delete=SET_NULL)
     date = models.DateTimeField(auto_now_add=True)
@@ -441,7 +448,7 @@ class PatientModification(models.Model):
                 pass
         return url
 
-class PatientComment(models.Model):
+class PatientComment(TimeStampedModel):
     patient = models.ForeignKey(Patient, on_delete=CASCADE)
     comment = models.TextField()
     patient_modification = models.ForeignKey(PatientModification, on_delete=CASCADE)
@@ -521,7 +528,7 @@ class PatientColumns:
     }
 
 
-class Clinician(models.Model):
+class Clinician(TimeStampedModel):
     email = models.TextField(null=True, blank=True)
     title = models.CharField(max_length=1, choices=Title.CHOICES, null=True, blank=True)
     first_name = models.TextField(null=True, blank=True)
@@ -581,7 +588,7 @@ class Clinician(models.Model):
 # CSV imports
 
 
-class PatientRecords(models.Model):
+class PatientRecords(TimeStampedModel):
     patient_import = models.OneToOneField(PatientImport, on_delete=CASCADE)
 
     def can_view(self, user) -> bool:
@@ -610,7 +617,7 @@ class PatientRecords(models.Model):
         return reverse('view_patient_import', kwargs={"patient_records_id": self.pk})
 
 
-class PatientRecord(models.Model):
+class PatientRecord(TimeStampedModel):
     """ Record created from Uploaded Patient Records
         will be processed into Sample/Patients/Specimens etc. """
     patient_records = models.ForeignKey(PatientRecords, on_delete=CASCADE)
@@ -668,7 +675,7 @@ def patient_attachment_post_save(sender, instance, created, **kwargs):  # pylint
         instance.save()
 
 
-class FollowLeadScientist(models.Model):
+class FollowLeadScientist(TimeStampedModel):
     follow = models.ForeignKey(User, related_name='followed', on_delete=CASCADE)
     user = models.ForeignKey(User, related_name='following', on_delete=CASCADE)
 

--- a/patients/models.py
+++ b/patients/models.py
@@ -304,9 +304,10 @@ class Tissue(models.Model):
         return self.name
 
 
-class Specimen(models.Model):
-    """ Biological material in a test tube that was sequenced """
-    reference_id = models.TextField(primary_key=True)
+class Specimen(ExternallyManagedModel):
+    """ Biological material collected from a patient - one tissue at one timepoint (block, blood draw).
+        The nucleic acid taken off it lives on Extraction below """
+    reference_id = models.TextField()
     description = models.TextField(null=True, blank=True)
     collected_by = models.TextField(null=True, blank=True)
     patient = models.ForeignKey(Patient, on_delete=CASCADE)
@@ -314,9 +315,11 @@ class Specimen(models.Model):
     collection_date = models.DateTimeField(null=True, blank=True)
     received_date = models.DateTimeField(null=True, blank=True)
     mutation_type = models.CharField(max_length=1, choices=Mutation.choices, default=Mutation.GERMLINE, null=True, blank=True)
-    nucleic_acid_source = models.CharField(max_length=1, choices=NucleicAcid.choices, default=NucleicAcid.DNA, null=True, blank=True)
     # See note on patient / sample ages and dates above Patient model
     _age_at_collection_date = models.IntegerField(null=True, blank=True)
+
+    class Meta:
+        unique_together = ("patient", "reference_id")
 
     @property
     def age_at_collection_date(self):
@@ -331,10 +334,43 @@ class Specimen(models.Model):
 
         return age
 
+    def get_or_create_extraction(self, nucleic_acid_source=None) -> 'Extraction':
+        """ The patient CSV describes a single extraction per specimen, so an existing extraction is
+            updated rather than a second one created """
+        extractions = self.extraction_set.order_by("pk")
+        if extraction := extractions.filter(nucleic_acid_source=nucleic_acid_source).first():
+            return extraction
+
+        extraction = extractions.first()
+        if extraction is None:
+            extraction = Extraction.objects.create(specimen=self, nucleic_acid_source=nucleic_acid_source)
+        elif nucleic_acid_source:
+            extraction.nucleic_acid_source = nucleic_acid_source
+            extraction.save()
+        return extraction
+
     def __str__(self):
         s = self.reference_id
         if self.description:
             s += f" ({self.description})"
+        return s
+
+
+class Extraction(ExternallyManagedModel):
+    """ Nucleic acid taken off a Specimen - eg the DNA arm and the RNA arm of one tumour block.
+        One extraction can be sequenced more than once (repeats, top-ups) so SequencingSample
+        points here rather than the other way around """
+    specimen = models.ForeignKey(Specimen, on_delete=CASCADE)
+    reference_id = models.TextField(null=True, blank=True)
+    nucleic_acid_source = models.CharField(max_length=1, choices=NucleicAcid.choices, default=NucleicAcid.DNA, null=True, blank=True)
+
+    class Meta:
+        unique_together = ("specimen", "reference_id")
+
+    def __str__(self):
+        s = self.reference_id or str(self.specimen)
+        if self.nucleic_acid_source:
+            s += f" ({self.get_nucleic_acid_source_display()})"
         return s
 
 
@@ -478,14 +514,14 @@ class PatientColumns:
         PATIENT_PHENOTYPE: "patient__phenotype",
         SAMPLE_ID: "pk",
         SAMPLE_NAME: "name",
-        SPECIMEN_REFERENCE_ID: "specimen__reference_id",
-        SPECIMEN_DESCRIPTION: "specimen__description",
-        SPECIMEN_COLLECTED_BY: "specimen__collected_by",
-        SPECIMEN_COLLECTION_DATE: "specimen__collection_date",
-        SPECIMEN_RECEIVED_DATE: "specimen__received_date",
-        SPECIMEN_MUTATION_TYPE: "specimen__mutation_type",
-        SPECIMEN_NUCLEIC_ACID_SOURCE: "specimen__nucleic_acid_source",
-        SPECIMEN_AGE_AT_COLLECTION_DATE: "specimen___age_at_collection_date",
+        SPECIMEN_REFERENCE_ID: "extraction__specimen__reference_id",
+        SPECIMEN_DESCRIPTION: "extraction__specimen__description",
+        SPECIMEN_COLLECTED_BY: "extraction__specimen__collected_by",
+        SPECIMEN_COLLECTION_DATE: "extraction__specimen__collection_date",
+        SPECIMEN_RECEIVED_DATE: "extraction__specimen__received_date",
+        SPECIMEN_MUTATION_TYPE: "extraction__specimen__mutation_type",
+        SPECIMEN_NUCLEIC_ACID_SOURCE: "extraction__nucleic_acid_source",
+        SPECIMEN_AGE_AT_COLLECTION_DATE: "extraction__specimen___age_at_collection_date",
     }
 
 

--- a/patients/models.py
+++ b/patients/models.py
@@ -365,11 +365,19 @@ class Extraction(ExternallyManagedModel):
         One extraction can be sequenced more than once (repeats, top-ups) so SequencingSample
         points here rather than the other way around """
     specimen = models.ForeignKey(Specimen, on_delete=CASCADE)
+    # Local reference beside external_pk - not every deployment has a system to be managed by,
+    # the same reason Patient carries patient_code and Specimen carries its own reference_id
+    reference_id = models.TextField(null=True, blank=True)
     nucleic_acid_source = models.CharField(max_length=1, choices=NucleicAcid.choices, default=NucleicAcid.DNA, null=True, blank=True)
     extraction_date = models.DateTimeField(null=True, blank=True)
 
+    class Meta:
+        # Unnamed extractions are all distinct under Postgres, which is what the re-extraction
+        # case wants - extraction_date tells those apart
+        unique_together = ("specimen", "reference_id")
+
     def __str__(self):
-        s = str(self.specimen)
+        s = self.reference_id or str(self.specimen)
         if self.nucleic_acid_source:
             s += f" ({self.get_nucleic_acid_source_display()})"
         if self.extraction_date:

--- a/patients/templates/patients/view_patient.html
+++ b/patients/templates/patients/view_patient.html
@@ -95,6 +95,7 @@
         {% end_ui_register_tab_embedded %}
         {% ui_register_tab label="Contact" url="view_patient_contact_tab" param=patient.pk url_check=True tab_set="patients" %}
         {% ui_register_tab label="Specimens" url="view_patient_specimens" param=patient.pk url_check=True tab_set="patients"%}
+        {% ui_register_tab label="Extractions" url="view_patient_extractions" param=patient.pk url_check=True tab_set="patients"%}
         {% ui_register_tab label="Genes" url="view_patient_genes" param=patient.pk url_check=True tab_set="patients" %}
         {% if has_write_permission %}
             {% ui_register_tab_embedded label="Sharing / Permissions" tab_set="patients" %}{% url "group_permissions" 'patients.models.Patient' patient.pk %}{% end_ui_register_tab_embedded %}

--- a/patients/templates/patients/view_patient_extractions.html
+++ b/patients/templates/patients/view_patient_extractions.html
@@ -1,30 +1,30 @@
 {% load crispy_forms_tags %}
 {% load ui_help %}
 {% load ui_utils %}
-<div id="patient-specimens">
-    {% page_help 'patients/view_patient_help2' 'Specimens Help' %}
+<div id="patient-extractions">
+    {% page_help 'patients/view_patient_extractions_help' 'Extractions Help' %}
     <script type="text/javascript">
-        var targetParent = $("#patient-specimens").parent();
-    
+        var targetParent = $("#patient-extractions").parent();
+
         $(document).ready(function() {
             {% update_django_messages %}
             var options = {
                 target: targetParent,
             };
-            $('form#patient-specimens-form').ajaxForm(options); 
+            $('form#patient-extractions-form').ajaxForm(options);
             $(".date-picker").datepicker({changeYear: true, yearRange: "-120:+0"});
-    
-            var title = "Specimens";
-            {% if num_specimens %}
-            title += " ({{ num_specimens }})"
+
+            var title = "Extractions";
+            {% if num_extractions %}
+            title += " ({{ num_extractions }})"
             {% endif %}
-            $("#specimens-tab-link").html(title);
+            $("#extractions-tab-link").html(title);
         });
     </script>
     <div class="container">
-        <form id="patient-specimens-form" method="post" action="{% url 'view_patient_specimens' patient.pk %}">
+        <form id="patient-extractions-form" method="post" action="{% url 'view_patient_extractions' patient.pk %}">
             {% csrf_token %}
-            {% crispy specimen_formset form_helper.horizontal %}
+            {% crispy extraction_formset form_helper.horizontal %}
             <table>
             {% if has_write_permission %}
             <td><button id='save-button' class="btn btn-primary">Save</button></td>

--- a/patients/templates/patients/view_patient_specimens.html
+++ b/patients/templates/patients/view_patient_specimens.html
@@ -25,6 +25,8 @@
         <form id="patient-specimens-form" method="post" action="{% url 'view_patient_specimens' patient.pk %}">
             {% csrf_token %}
             {% crispy specimen_formset form_helper.horizontal %}
+            <h4>Extractions</h4>
+            {% crispy extraction_formset form_helper.horizontal %}
             <table>
             {% if has_write_permission %}
             <td><button id='save-button' class="btn btn-primary">Save</button></td>

--- a/patients/tests/test_specimen_extraction.py
+++ b/patients/tests/test_specimen_extraction.py
@@ -12,6 +12,8 @@ from library.guardian_utils import assign_permission_to_user_and_groups
 from patients.import_records import process_record
 from patients.models import (
     Extraction,
+    ExternalModelManager,
+    ExternalPK,
     Patient,
     PatientColumns,
     PatientImport,
@@ -46,8 +48,10 @@ class TestSpecimenExtraction(TestCase):
         assign_permission_to_user_and_groups(cls.user, cls.patient)
         cls.specimen = Specimen.objects.create(reference_id="2600000001", patient=cls.patient,
                                                mutation_type=Mutation.SOMATIC)
-        cls.dna = Extraction.objects.create(specimen=cls.specimen, nucleic_acid_source=NucleicAcid.DNA)
-        cls.rna = Extraction.objects.create(specimen=cls.specimen, nucleic_acid_source=NucleicAcid.RNA)
+        cls.dna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001C",
+                                            nucleic_acid_source=NucleicAcid.DNA)
+        cls.rna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001B",
+                                            nucleic_acid_source=NucleicAcid.RNA)
 
         genome_build = GenomeBuild.get_name_or_alias("GRCh37")
         vcf = VCF.objects.create(name="extraction_test.vcf", genotype_samples=2, genome_build=genome_build,
@@ -89,6 +93,27 @@ class TestSpecimenExtraction(TestCase):
         self.assertNotEqual(str(redo), str(self.dna))
         dna_qs = self.specimen.extraction_set.filter(nucleic_acid_source=NucleicAcid.DNA)
         self.assertEqual(list(dna_qs.order_by("-extraction_date")), [redo, self.dna])
+
+    def test_local_reference_and_external_pk_coexist(self):
+        """ external_pk is nullable because not every deployment has a system managing it, so each
+            level carries a local reference too """
+        external_manager = ExternalModelManager.objects.create(name="test_lims")
+        external_pk = ExternalPK.objects.create(code="LIMS-EXT-1", external_type="extraction",
+                                                external_manager=external_manager)
+        self.dna.external_pk = external_pk
+        self.dna.save()
+
+        self.dna.refresh_from_db()
+        self.assertEqual(self.dna.reference_id, "2600000001C")
+        self.assertEqual(self.dna.external_pk.code, "LIMS-EXT-1")
+        self.assertIsNone(self.rna.external_pk, "A local reference works without an external one")
+
+    def test_unnamed_extractions_are_distinct(self):
+        """ unique_together is on (specimen, reference_id), and Postgres treats NULLs as distinct,
+            so a specimen can hold several unnamed extractions """
+        Extraction.objects.create(specimen=self.specimen)
+        Extraction.objects.create(specimen=self.specimen)
+        self.assertEqual(self.specimen.extraction_set.filter(reference_id__isnull=True).count(), 2)
 
     def test_timestamps_recorded(self):
         """ Everything in patients is a TimeStampedModel """
@@ -201,10 +226,13 @@ class TestAutocompleteForwarding(TestCase):
         cls.other_patient_specimen = Specimen.objects.create(reference_id="2600000003",
                                                              patient=cls.other_patient)
 
-        cls.dna = Extraction.objects.create(specimen=cls.specimen, nucleic_acid_source=NucleicAcid.DNA)
-        cls.rna = Extraction.objects.create(specimen=cls.specimen, nucleic_acid_source=NucleicAcid.RNA)
-        cls.other_extraction = Extraction.objects.create(specimen=cls.other_specimen)
-        Extraction.objects.create(specimen=cls.other_patient_specimen)
+        cls.dna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001C",
+                                            nucleic_acid_source=NucleicAcid.DNA)
+        cls.rna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001B",
+                                            nucleic_acid_source=NucleicAcid.RNA)
+        cls.other_extraction = Extraction.objects.create(specimen=cls.other_specimen,
+                                                         reference_id="2600000002C")
+        Extraction.objects.create(specimen=cls.other_patient_specimen, reference_id="2600000003C")
 
     def _queryset(self, view_class, **forwarded):
         view = view_class()
@@ -227,6 +255,10 @@ class TestAutocompleteForwarding(TestCase):
     def test_specimen_forwards_patient(self):
         specimens = self._queryset(SpecimenAutocompleteView, patient=self.patient.pk)
         self.assertEqual(set(specimens), {self.specimen, self.other_specimen})
+
+    def test_extraction_searchable_by_its_own_reference(self):
+        """ The TSO 500 container suffix lives on the extraction, not the specimen """
+        self.assertIn('reference_id', ExtractionAutocompleteView.fields)
 
     def test_nothing_forwarded_returns_all_visible(self):
         self.assertEqual(self._queryset(SpecimenAutocompleteView).count(), 3)

--- a/patients/tests/test_specimen_extraction.py
+++ b/patients/tests/test_specimen_extraction.py
@@ -2,6 +2,7 @@
 Specimen -> Extraction -> Sample (#1704)
 """
 import os
+from datetime import datetime
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -77,6 +78,23 @@ class TestSpecimenExtraction(TestCase):
         """ A specimen with both arms must not have one of them repurposed """
         self.assertEqual(self.specimen.get_or_create_extraction(NucleicAcid.RNA), self.rna)
         self.assertEqual(self.specimen.extraction_set.count(), 2)
+
+    def test_extraction_date_distinguishes_a_re_extraction(self):
+        """ Two DNA extractions off one specimen are told apart by when they were taken """
+        redo = Extraction.objects.create(specimen=self.specimen, nucleic_acid_source=NucleicAcid.DNA,
+                                         extraction_date=timezone.make_aware(datetime(2026, 3, 14)))
+        self.dna.extraction_date = timezone.make_aware(datetime(2026, 1, 20))
+        self.dna.save()
+
+        self.assertNotEqual(str(redo), str(self.dna))
+        dna_qs = self.specimen.extraction_set.filter(nucleic_acid_source=NucleicAcid.DNA)
+        self.assertEqual(list(dna_qs.order_by("-extraction_date")), [redo, self.dna])
+
+    def test_timestamps_recorded(self):
+        """ Everything in patients is a TimeStampedModel """
+        for obj in (self.patient, self.specimen, self.dna):
+            self.assertIsNotNone(obj.created, f"{type(obj).__name__} has no created")
+            self.assertIsNotNone(obj.modified, f"{type(obj).__name__} has no modified")
 
 
 class TestPatientCSVExtractionRoundTrip(TestCase):

--- a/patients/tests/test_specimen_extraction.py
+++ b/patients/tests/test_specimen_extraction.py
@@ -45,10 +45,8 @@ class TestSpecimenExtraction(TestCase):
         assign_permission_to_user_and_groups(cls.user, cls.patient)
         cls.specimen = Specimen.objects.create(reference_id="2600000001", patient=cls.patient,
                                                mutation_type=Mutation.SOMATIC)
-        cls.dna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001C",
-                                            nucleic_acid_source=NucleicAcid.DNA)
-        cls.rna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001B",
-                                            nucleic_acid_source=NucleicAcid.RNA)
+        cls.dna = Extraction.objects.create(specimen=cls.specimen, nucleic_acid_source=NucleicAcid.DNA)
+        cls.rna = Extraction.objects.create(specimen=cls.specimen, nucleic_acid_source=NucleicAcid.RNA)
 
         genome_build = GenomeBuild.get_name_or_alias("GRCh37")
         vcf = VCF.objects.create(name="extraction_test.vcf", genotype_samples=2, genome_build=genome_build,
@@ -185,13 +183,10 @@ class TestAutocompleteForwarding(TestCase):
         cls.other_patient_specimen = Specimen.objects.create(reference_id="2600000003",
                                                              patient=cls.other_patient)
 
-        cls.dna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001C",
-                                            nucleic_acid_source=NucleicAcid.DNA)
-        cls.rna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001B",
-                                            nucleic_acid_source=NucleicAcid.RNA)
-        cls.other_extraction = Extraction.objects.create(specimen=cls.other_specimen,
-                                                         reference_id="2600000002C")
-        Extraction.objects.create(specimen=cls.other_patient_specimen, reference_id="2600000003C")
+        cls.dna = Extraction.objects.create(specimen=cls.specimen, nucleic_acid_source=NucleicAcid.DNA)
+        cls.rna = Extraction.objects.create(specimen=cls.specimen, nucleic_acid_source=NucleicAcid.RNA)
+        cls.other_extraction = Extraction.objects.create(specimen=cls.other_specimen)
+        Extraction.objects.create(specimen=cls.other_patient_specimen)
 
     def _queryset(self, view_class, **forwarded):
         view = view_class()
@@ -218,7 +213,3 @@ class TestAutocompleteForwarding(TestCase):
     def test_nothing_forwarded_returns_all_visible(self):
         self.assertEqual(self._queryset(SpecimenAutocompleteView).count(), 3)
         self.assertEqual(self._queryset(ExtractionAutocompleteView).count(), 4)
-
-    def test_extraction_searchable_by_its_own_reference(self):
-        """ The TSO 500 container suffix lives on the extraction, not the specimen """
-        self.assertIn('reference_id', ExtractionAutocompleteView.fields)

--- a/patients/tests/test_specimen_extraction.py
+++ b/patients/tests/test_specimen_extraction.py
@@ -1,0 +1,224 @@
+"""
+Specimen -> Extraction -> Sample (#1704)
+"""
+import os
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from library.guardian_utils import assign_permission_to_user_and_groups
+from patients.import_records import process_record
+from patients.models import (
+    Extraction,
+    Patient,
+    PatientColumns,
+    PatientImport,
+    PatientRecords,
+    Specimen,
+)
+from patients.models_enums import Mutation, NucleicAcid
+from patients.views_autocomplete import ExtractionAutocompleteView, SpecimenAutocompleteView
+from snpdb.models import VCF, GenomeBuild, ImportSource, ImportStatus, Sample
+from upload.models import FileUpload, UploadedFileTypes, UploadedPatientRecords
+
+_FAKE_CSV = os.path.join(os.path.dirname(__file__), "test_data", "fake_patient_records.csv")
+
+
+def _make_row(**overrides):
+    row = dict.fromkeys(PatientColumns.COLUMNS)
+    row[PatientColumns.PATIENT_LAST_NAME] = "EXTRACTLAST"
+    row[PatientColumns.PATIENT_FIRST_NAME] = "EXTRACTFIRST"
+    row.update(overrides)
+    return row
+
+
+class TestSpecimenExtraction(TestCase):
+    """ One specimen, a DNA arm and an RNA arm - the TSO 500 shape that Specimen.nucleic_acid_source
+        used to force into two unrelated specimens """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = User.objects.create_user("extraction_user", password="x")
+        cls.patient = Patient.objects.create(first_name="DNARNA", last_name="PATIENT")
+        assign_permission_to_user_and_groups(cls.user, cls.patient)
+        cls.specimen = Specimen.objects.create(reference_id="2600000001", patient=cls.patient,
+                                               mutation_type=Mutation.SOMATIC)
+        cls.dna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001C",
+                                            nucleic_acid_source=NucleicAcid.DNA)
+        cls.rna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001B",
+                                            nucleic_acid_source=NucleicAcid.RNA)
+
+        genome_build = GenomeBuild.get_name_or_alias("GRCh37")
+        vcf = VCF.objects.create(name="extraction_test.vcf", genotype_samples=2, genome_build=genome_build,
+                                 import_status=ImportStatus.SUCCESS, user=cls.user, date=timezone.now())
+        cls.dna_sample = Sample.objects.create(name="dna_arm", vcf=vcf, patient=cls.patient, extraction=cls.dna)
+        cls.rna_sample = Sample.objects.create(name="rna_arm", vcf=vcf, patient=cls.patient, extraction=cls.rna)
+
+    def test_both_arms_reach_one_specimen(self):
+        self.assertEqual(self.dna_sample.extraction.specimen, self.specimen)
+        self.assertEqual(self.rna_sample.extraction.specimen, self.specimen)
+        self.assertEqual(self.dna_sample.specimen, self.rna_sample.specimen)
+
+    def test_specimen_holds_dna_and_rna(self):
+        sources = set(self.specimen.extraction_set.values_list("nucleic_acid_source", flat=True))
+        self.assertEqual(sources, {NucleicAcid.DNA, NucleicAcid.RNA})
+
+    def test_samples_selectable_by_specimen(self):
+        sample_names = set(Sample.objects.filter(extraction__specimen=self.specimen).values_list("name", flat=True))
+        self.assertEqual(sample_names, {"dna_arm", "rna_arm"})
+
+    def test_reference_id_unique_per_patient_not_globally(self):
+        """ R4 - the surrogate PK is what lets 2 patients use the same reference """
+        other_patient = Patient.objects.create(first_name="OTHER", last_name="PATIENT")
+        other_specimen = Specimen.objects.create(reference_id="2600000001", patient=other_patient)
+        self.assertNotEqual(other_specimen.pk, self.specimen.pk)
+
+    def test_get_or_create_extraction_matches_nucleic_acid_source(self):
+        """ A specimen with both arms must not have one of them repurposed """
+        self.assertEqual(self.specimen.get_or_create_extraction(NucleicAcid.RNA), self.rna)
+        self.assertEqual(self.specimen.extraction_set.count(), 2)
+
+
+class TestPatientCSVExtractionRoundTrip(TestCase):
+    """ R6 - the existing SPECIMEN_NUCLEIC_ACID_SOURCE column implies a single extraction """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = User.objects.create_user("csv_extraction_user", password="x")
+        cls.patient = Patient.objects.create(first_name="EXTRACTFIRST", last_name="EXTRACTLAST")
+        assign_permission_to_user_and_groups(cls.user, cls.patient)
+
+        genome_build = GenomeBuild.get_name_or_alias("GRCh37")
+        vcf = VCF.objects.create(name="csv_extraction_test.vcf", genotype_samples=1, genome_build=genome_build,
+                                 import_status=ImportStatus.SUCCESS, user=cls.user, date=timezone.now())
+        cls.sample = Sample.objects.create(name="csv_sample", vcf=vcf, import_status=ImportStatus.SUCCESS)
+        assign_permission_to_user_and_groups(cls.user, cls.sample)
+
+    def setUp(self):
+        patient_import = PatientImport.objects.create(name="extraction_import")
+        self.patient_records = PatientRecords.objects.create(patient_import=patient_import)
+        file_upload = FileUpload.objects.create(user=self.user, name="extraction_import_file", path=_FAKE_CSV,
+                                                file_type=UploadedFileTypes.PATIENT_RECORDS,
+                                                import_source=ImportSource.COMMAND_LINE)
+        UploadedPatientRecords.objects.create(file_upload=file_upload, patient_records=self.patient_records)
+
+    def _import_row(self, **overrides):
+        row = _make_row(**{
+            PatientColumns.SAMPLE_NAME: "csv_sample",
+            PatientColumns.SPECIMEN_REFERENCE_ID: "CSVSPEC001",
+            PatientColumns.SPECIMEN_DESCRIPTION: "left femur",
+            PatientColumns.SPECIMEN_NUCLEIC_ACID_SOURCE: "DNA",
+            **overrides,
+        })
+        process_record(self.patient_records, record_id=1, row=row)
+
+    def test_import_creates_extraction_under_specimen(self):
+        self._import_row()
+
+        specimen = Specimen.objects.get(reference_id="CSVSPEC001")
+        self.assertEqual(specimen.patient, self.patient)
+        self.assertEqual(specimen.description, "left femur")
+
+        extraction = Extraction.objects.get(specimen=specimen)
+        self.assertEqual(extraction.nucleic_acid_source, NucleicAcid.DNA)
+
+    def test_sample_reaches_specimen_via_extraction(self):
+        self._import_row()
+
+        self.sample.refresh_from_db()
+        self.assertEqual(self.sample.extraction.specimen.reference_id, "CSVSPEC001")
+        self.assertEqual(self.sample.specimen.reference_id, "CSVSPEC001")
+
+    def test_reimport_reuses_the_same_extraction(self):
+        self._import_row()
+        extraction_pk = Extraction.objects.get(specimen__reference_id="CSVSPEC001").pk
+
+        self._import_row()
+        self.assertEqual(Extraction.objects.filter(specimen__reference_id="CSVSPEC001").count(), 1)
+        self.assertEqual(Extraction.objects.get(specimen__reference_id="CSVSPEC001").pk, extraction_pk)
+
+    def test_reimport_updates_nucleic_acid_source_in_place(self):
+        self._import_row()
+        self._import_row(**{PatientColumns.SPECIMEN_NUCLEIC_ACID_SOURCE: "RNA"})
+
+        extractions = Extraction.objects.filter(specimen__reference_id="CSVSPEC001")
+        self.assertEqual(extractions.count(), 1)
+        self.assertEqual(extractions.get().nucleic_acid_source, NucleicAcid.RNA)
+
+    def test_blank_nucleic_acid_source_still_links_sample(self):
+        self._import_row(**{PatientColumns.SPECIMEN_NUCLEIC_ACID_SOURCE: None})
+
+        self.sample.refresh_from_db()
+        self.assertEqual(self.sample.extraction.specimen.reference_id, "CSVSPEC001")
+        self.assertIsNone(self.sample.extraction.nucleic_acid_source)
+
+    def test_export_columns_round_trip(self):
+        """ The CSV written back out reads the same values through the new relations """
+        self._import_row()
+
+        values = Sample.objects.filter(pk=self.sample.pk).values(*PatientColumns.SAMPLE_QUERYSET_PATH.values()).get()
+        self.assertEqual(values[PatientColumns.SAMPLE_QUERYSET_PATH[PatientColumns.SPECIMEN_REFERENCE_ID]],
+                         "CSVSPEC001")
+        self.assertEqual(values[PatientColumns.SAMPLE_QUERYSET_PATH[PatientColumns.SPECIMEN_DESCRIPTION]],
+                         "left femur")
+        self.assertEqual(values[PatientColumns.SAMPLE_QUERYSET_PATH[PatientColumns.SPECIMEN_NUCLEIC_ACID_SOURCE]],
+                         NucleicAcid.DNA)
+
+
+class TestAutocompleteForwarding(TestCase):
+    """ Picking one level of Patient -> Specimen -> Extraction narrows the others """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = User.objects.create_user("autocomplete_user", password="x")
+        cls.patient = Patient.objects.create(first_name="FORWARD", last_name="PATIENT")
+        cls.other_patient = Patient.objects.create(first_name="OTHER", last_name="PATIENT")
+        for patient in (cls.patient, cls.other_patient):
+            assign_permission_to_user_and_groups(cls.user, patient)
+
+        cls.specimen = Specimen.objects.create(reference_id="2600000001", patient=cls.patient)
+        cls.other_specimen = Specimen.objects.create(reference_id="2600000002", patient=cls.patient)
+        cls.other_patient_specimen = Specimen.objects.create(reference_id="2600000003",
+                                                             patient=cls.other_patient)
+
+        cls.dna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001C",
+                                            nucleic_acid_source=NucleicAcid.DNA)
+        cls.rna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001B",
+                                            nucleic_acid_source=NucleicAcid.RNA)
+        cls.other_extraction = Extraction.objects.create(specimen=cls.other_specimen,
+                                                         reference_id="2600000002C")
+        Extraction.objects.create(specimen=cls.other_patient_specimen, reference_id="2600000003C")
+
+    def _queryset(self, view_class, **forwarded):
+        view = view_class()
+        view.forwarded = forwarded
+        return view.get_user_queryset(self.user)
+
+    def test_extraction_forwards_patient(self):
+        extractions = self._queryset(ExtractionAutocompleteView, patient=self.patient.pk)
+        self.assertEqual(set(extractions), {self.dna, self.rna, self.other_extraction})
+
+    def test_extraction_forwards_specimen(self):
+        """ Both arms of the forwarded specimen, and nothing from its sibling """
+        extractions = self._queryset(ExtractionAutocompleteView, specimen=self.specimen.pk)
+        self.assertEqual(set(extractions), {self.dna, self.rna})
+
+    def test_specimen_forwards_extraction(self):
+        specimens = self._queryset(SpecimenAutocompleteView, extraction=self.rna.pk)
+        self.assertEqual(set(specimens), {self.specimen})
+
+    def test_specimen_forwards_patient(self):
+        specimens = self._queryset(SpecimenAutocompleteView, patient=self.patient.pk)
+        self.assertEqual(set(specimens), {self.specimen, self.other_specimen})
+
+    def test_nothing_forwarded_returns_all_visible(self):
+        self.assertEqual(self._queryset(SpecimenAutocompleteView).count(), 3)
+        self.assertEqual(self._queryset(ExtractionAutocompleteView).count(), 4)
+
+    def test_extraction_searchable_by_its_own_reference(self):
+        """ The TSO 500 container suffix lives on the extraction, not the specimen """
+        self.assertIn('reference_id', ExtractionAutocompleteView.fields)

--- a/patients/tests/test_urls.py
+++ b/patients/tests/test_urls.py
@@ -36,7 +36,7 @@ class Test(URLTestCase):
         assign_permission_to_user_and_groups(cls.user_owner, cls.patient)
 
         cls.specimen = Specimen.objects.create(reference_id="funny bone biopsy", patient=cls.patient)
-        cls.extraction = Extraction.objects.create(specimen=cls.specimen)
+        cls.extraction = Extraction.objects.create(specimen=cls.specimen, reference_id="funny bone DNA")
 
         cls.clinician = Clinician.objects.get_or_create(title=Title.DR, first_name='Nick', last_name='Riviera')[0]
         emm = ExternalModelManager.objects.get_or_create(name="fake_model_manager", details="blah")[0]
@@ -67,7 +67,7 @@ class Test(URLTestCase):
         cls.PRIVATE_AUTOCOMPLETE_URLS = [
             ('patient_autocomplete', cls.patient, {"q": cls.patient.last_name}),
             ('specimen_autocomplete', cls.specimen, {"q": cls.specimen.reference_id}),
-            ('extraction_autocomplete', cls.extraction, {"q": cls.specimen.reference_id}),
+            ('extraction_autocomplete', cls.extraction, {"q": cls.extraction.reference_id}),
         ]
 
         # (url_name, url_kwargs, object to check appears in grid pk column or (grid column, object)

--- a/patients/tests/test_urls.py
+++ b/patients/tests/test_urls.py
@@ -9,6 +9,7 @@ from library.enums.titles import Title
 from library.guardian_utils import assign_permission_to_user_and_groups
 from patients.models import (
     Clinician,
+    Extraction,
     ExternalModelManager,
     ExternalPK,
     Patient,
@@ -35,6 +36,7 @@ class Test(URLTestCase):
         assign_permission_to_user_and_groups(cls.user_owner, cls.patient)
 
         cls.specimen = Specimen.objects.create(reference_id="funny bone biopsy", patient=cls.patient)
+        cls.extraction = Extraction.objects.create(specimen=cls.specimen, reference_id="funny bone DNA")
 
         cls.clinician = Clinician.objects.get_or_create(title=Title.DR, first_name='Nick', last_name='Riviera')[0]
         emm = ExternalModelManager.objects.get_or_create(name="fake_model_manager", details="blah")[0]
@@ -64,6 +66,7 @@ class Test(URLTestCase):
         cls.PRIVATE_AUTOCOMPLETE_URLS = [
             ('patient_autocomplete', cls.patient, {"q": cls.patient.last_name}),
             ('specimen_autocomplete', cls.specimen, {"q": cls.specimen.reference_id}),
+            ('extraction_autocomplete', cls.extraction, {"q": cls.extraction.reference_id}),
         ]
 
         # (url_name, url_kwargs, object to check appears in grid pk column or (grid column, object)

--- a/patients/tests/test_urls.py
+++ b/patients/tests/test_urls.py
@@ -58,6 +58,7 @@ class Test(URLTestCase):
             ('view_patient', patient_kwargs, 200),
             # ('view_patient_contact_tab', patient_kwargs, 200),
             ('view_patient_specimens', patient_kwargs, 200),
+            ('view_patient_extractions', patient_kwargs, 200),
             ('view_patient_genes', patient_kwargs, 200),
             ('view_patient_modifications', patient_kwargs, 200),
             ('view_patient_import', {"patient_records_id": patient_records.pk}, 200),

--- a/patients/tests/test_urls.py
+++ b/patients/tests/test_urls.py
@@ -36,7 +36,7 @@ class Test(URLTestCase):
         assign_permission_to_user_and_groups(cls.user_owner, cls.patient)
 
         cls.specimen = Specimen.objects.create(reference_id="funny bone biopsy", patient=cls.patient)
-        cls.extraction = Extraction.objects.create(specimen=cls.specimen, reference_id="funny bone DNA")
+        cls.extraction = Extraction.objects.create(specimen=cls.specimen)
 
         cls.clinician = Clinician.objects.get_or_create(title=Title.DR, first_name='Nick', last_name='Riviera')[0]
         emm = ExternalModelManager.objects.get_or_create(name="fake_model_manager", details="blah")[0]
@@ -66,7 +66,7 @@ class Test(URLTestCase):
         cls.PRIVATE_AUTOCOMPLETE_URLS = [
             ('patient_autocomplete', cls.patient, {"q": cls.patient.last_name}),
             ('specimen_autocomplete', cls.specimen, {"q": cls.specimen.reference_id}),
-            ('extraction_autocomplete', cls.extraction, {"q": cls.extraction.reference_id}),
+            ('extraction_autocomplete', cls.extraction, {"q": cls.specimen.reference_id}),
         ]
 
         # (url_name, url_kwargs, object to check appears in grid pk column or (grid column, object)

--- a/patients/urls.py
+++ b/patients/urls.py
@@ -52,6 +52,7 @@ urlpatterns = [
     # Autocomplete
     path('autocomplete/Patient/', views_autocomplete.PatientAutocompleteView.as_view(), name='patient_autocomplete'),
     path('autocomplete/Specimen/', views_autocomplete.SpecimenAutocompleteView.as_view(), name='specimen_autocomplete'),
+    path('autocomplete/Extraction/', views_autocomplete.ExtractionAutocompleteView.as_view(), name='extraction_autocomplete'),
     path('autocomplete/Clinician/', views_autocomplete.ClinicianAutocompleteView.as_view(), name='clinician_autocomplete'),
     path('autocomplete/ExternalPKAutocompleteView', views_autocomplete.ExternalPKAutocompleteView.as_view(), name='external_pk_autocomplete'),
 ]

--- a/patients/urls.py
+++ b/patients/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('view_patient/<int:patient_id>', views.view_patient, name='view_patient'),
     path('view_patient/contact/<int:patient_id>', views.view_patient_contact_tab, name='view_patient_contact_tab'),
     path('view_patient/patient_specimens/<int:patient_id>', views.view_patient_specimens, name='view_patient_specimens'),
+    path('view_patient/patient_extractions/<int:patient_id>', views.view_patient_extractions, name='view_patient_extractions'),
     path('view_patient/genes/<int:patient_id>', views.view_patient_genes, name='view_patient_genes'),
     path('view_patient/modifications/<int:patient_id>', views.view_patient_modifications, name='view_patient_modifications'),
 

--- a/patients/views.py
+++ b/patients/views.py
@@ -17,6 +17,7 @@ from ontology.forms import HGNCForm, HPOForm, MONDOForm, OMIMForm
 from patients import forms
 from patients.forms import PatientContactForm, PatientSearchForm
 from patients.models import (
+    Extraction,
     Patient,
     PatientAttachment,
     PatientColumns,
@@ -77,6 +78,15 @@ def view_patient_contact_tab(request, patient_id):
     return render(request, 'patients/view_patient_contact_tab.html', context)
 
 
+def _patient_extraction_formset(patient, data=None):
+    """ Restricted to the patient's own specimens - Extraction has no direct FK to Patient """
+    specimen_qs = patient.specimen_set.all()
+    formset = forms.PatientExtractionFormSet(data, queryset=Extraction.objects.filter(specimen__in=specimen_qs))
+    for form in formset.forms:
+        form.fields["specimen"].queryset = specimen_qs
+    return formset
+
+
 def view_patient_specimens(request, patient_id):
     patient = Patient.get_for_user(request.user, patient_id)
     if request.method == "POST":
@@ -84,12 +94,19 @@ def view_patient_specimens(request, patient_id):
         valid = specimen_formset.is_valid()
         if valid:
             specimen_formset.save()
+
+        extraction_formset = _patient_extraction_formset(patient, data=request.POST)
+        extraction_valid = extraction_formset.is_valid()
+        if extraction_valid:
+            extraction_formset.save()
+        valid &= extraction_valid
         add_save_message(request, valid, "Patient Specimen")
 
     specimen_formset = forms.PatientSpecimenFormSet(instance=patient)
     context = {"patient": patient,
                "num_specimens": patient.num_specimens,
                "specimen_formset": specimen_formset,
+               "extraction_formset": _patient_extraction_formset(patient),
                "has_write_permission": patient.can_write(request.user)}
     return render(request, 'patients/view_patient_specimens.html', context)
 

--- a/patients/views.py
+++ b/patients/views.py
@@ -78,15 +78,6 @@ def view_patient_contact_tab(request, patient_id):
     return render(request, 'patients/view_patient_contact_tab.html', context)
 
 
-def _patient_extraction_formset(patient, data=None):
-    """ Restricted to the patient's own specimens - Extraction has no direct FK to Patient """
-    specimen_qs = patient.specimen_set.all()
-    formset = forms.PatientExtractionFormSet(data, queryset=Extraction.objects.filter(specimen__in=specimen_qs))
-    for form in formset.forms:
-        form.fields["specimen"].queryset = specimen_qs
-    return formset
-
-
 def view_patient_specimens(request, patient_id):
     patient = Patient.get_for_user(request.user, patient_id)
     if request.method == "POST":
@@ -94,21 +85,40 @@ def view_patient_specimens(request, patient_id):
         valid = specimen_formset.is_valid()
         if valid:
             specimen_formset.save()
-
-        extraction_formset = _patient_extraction_formset(patient, data=request.POST)
-        extraction_valid = extraction_formset.is_valid()
-        if extraction_valid:
-            extraction_formset.save()
-        valid &= extraction_valid
         add_save_message(request, valid, "Patient Specimen")
 
     specimen_formset = forms.PatientSpecimenFormSet(instance=patient)
     context = {"patient": patient,
                "num_specimens": patient.num_specimens,
                "specimen_formset": specimen_formset,
-               "extraction_formset": _patient_extraction_formset(patient),
                "has_write_permission": patient.can_write(request.user)}
     return render(request, 'patients/view_patient_specimens.html', context)
+
+
+def _patient_extraction_formset(patient, data=None):
+    """ Restricted to the patient's own specimens - Extraction has no direct FK to Patient """
+    specimen_qs = patient.specimen_set.all()
+    formset_class = forms.patient_extraction_formset_factory(patient)
+    formset = formset_class(data, queryset=Extraction.objects.filter(specimen__in=specimen_qs))
+    for form in formset.forms:
+        form.fields["specimen"].queryset = specimen_qs
+    return formset
+
+
+def view_patient_extractions(request, patient_id):
+    patient = Patient.get_for_user(request.user, patient_id)
+    if request.method == "POST":
+        extraction_formset = _patient_extraction_formset(patient, data=request.POST)
+        valid = extraction_formset.is_valid()
+        if valid:
+            extraction_formset.save()
+        add_save_message(request, valid, "Patient Extraction")
+
+    context = {"patient": patient,
+               "num_extractions": patient.num_extractions,
+               "extraction_formset": _patient_extraction_formset(patient),
+               "has_write_permission": patient.can_write(request.user)}
+    return render(request, 'patients/view_patient_extractions.html', context)
 
 
 def view_patient_genes(request, patient_id):

--- a/patients/views_autocomplete.py
+++ b/patients/views_autocomplete.py
@@ -11,7 +11,7 @@ from django.views.decorators.vary import vary_on_cookie
 
 from library.constants import MINUTE_SECS
 from library.django_utils.autocomplete_utils import AutocompleteView
-from patients.models import Clinician, ExternalPK, Patient, Specimen
+from patients.models import Clinician, Extraction, ExternalPK, Patient, Specimen
 
 
 @method_decorator([cache_page(MINUTE_SECS), vary_on_cookie], name='dispatch')
@@ -24,16 +24,31 @@ class PatientAutocompleteView(AutocompleteView):
 
 @method_decorator([cache_page(MINUTE_SECS), vary_on_cookie], name='dispatch')
 class SpecimenAutocompleteView(AutocompleteView):
+    """ Narrows on whichever of Patient -> Specimen -> Extraction a form has already set """
     fields = ['reference_id']
 
     def get_user_queryset(self, user):
-        patients_qs = Patient.filter_for_user(user)
-        patient = self.forwarded.get('patient', None)
-        if patient:
-            # print(f"Filtering for forwarded patient: {patient})")
-            patients_qs = patients_qs.filter(pk=patient)
+        qs = Specimen.objects.filter(patient__in=Patient.filter_for_user(user))
+        if patient := self.forwarded.get('patient'):
+            qs = qs.filter(patient=patient)
+        if extraction := self.forwarded.get('extraction'):
+            qs = qs.filter(extraction=extraction)
+        return qs
 
-        return Specimen.objects.filter(patient__in=patients_qs)
+
+@method_decorator([cache_page(MINUTE_SECS), vary_on_cookie], name='dispatch')
+class ExtractionAutocompleteView(AutocompleteView):
+    """ Narrows on whichever of Patient -> Specimen a form has already set """
+    # An extraction may be referred to by its own reference (eg a container suffix) or its specimen's
+    fields = ['reference_id', 'specimen__reference_id']
+
+    def get_user_queryset(self, user):
+        qs = Extraction.objects.filter(specimen__patient__in=Patient.filter_for_user(user))
+        if patient := self.forwarded.get('patient'):
+            qs = qs.filter(specimen__patient=patient)
+        if specimen := self.forwarded.get('specimen'):
+            qs = qs.filter(specimen=specimen)
+        return qs
 
 
 @method_decorator(cache_page(MINUTE_SECS), name='dispatch')

--- a/patients/views_autocomplete.py
+++ b/patients/views_autocomplete.py
@@ -39,8 +39,7 @@ class SpecimenAutocompleteView(AutocompleteView):
 @method_decorator([cache_page(MINUTE_SECS), vary_on_cookie], name='dispatch')
 class ExtractionAutocompleteView(AutocompleteView):
     """ Narrows on whichever of Patient -> Specimen a form has already set """
-    # An extraction may be referred to by its own reference (eg a container suffix) or its specimen's
-    fields = ['reference_id', 'specimen__reference_id']
+    fields = ['specimen__reference_id']
 
     def get_user_queryset(self, user):
         qs = Extraction.objects.filter(specimen__patient__in=Patient.filter_for_user(user))

--- a/patients/views_autocomplete.py
+++ b/patients/views_autocomplete.py
@@ -39,7 +39,8 @@ class SpecimenAutocompleteView(AutocompleteView):
 @method_decorator([cache_page(MINUTE_SECS), vary_on_cookie], name='dispatch')
 class ExtractionAutocompleteView(AutocompleteView):
     """ Narrows on whichever of Patient -> Specimen a form has already set """
-    fields = ['specimen__reference_id']
+    # An extraction may be referred to by its own reference (eg a container suffix) or its specimen's
+    fields = ['reference_id', 'specimen__reference_id']
 
     def get_user_queryset(self, user):
         qs = Extraction.objects.filter(specimen__patient__in=Patient.filter_for_user(user))

--- a/seqauto/migrations/0046_sequencingsample_extraction.py
+++ b/seqauto/migrations/0046_sequencingsample_extraction.py
@@ -1,0 +1,19 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patients', '0013_extraction_specimen_surrogate_pk'),
+        ('seqauto', '0045_jointcalledvcf_sequencing_samples'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sequencingsample',
+            name='extraction',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL,
+                                    to='patients.extraction'),
+        ),
+    ]

--- a/seqauto/models/models_seqauto.py
+++ b/seqauto/models/models_seqauto.py
@@ -36,7 +36,7 @@ from library.genomics.vcf_utils import get_variant_caller_and_version_from_vcf
 from library.preview_request import PreviewModelMixin
 from library.utils import sorted_nicely
 from library.utils.file_utils import name_from_filename
-from patients.models import FakeData, Patient
+from patients.models import Extraction, FakeData, Patient
 from seqauto.illumina.illumina_sequencers import SEQUENCING_RUN_REGEX
 from seqauto.models.models_enums import DataGeneration, PairedEnd, SequencerRead
 from seqauto.models.models_sequencing import EnrichmentKit, Experiment, Sequencer
@@ -282,6 +282,8 @@ class SequencingSample(models.Model):
         As it's not a file, not a SeqAutoRecord
      """
     sample_sheet = models.ForeignKey(SampleSheet, on_delete=CASCADE)
+    # Optional enrichment - seqauto isn't run everywhere, so Sample.extraction is the join key
+    extraction = models.ForeignKey(Extraction, null=True, blank=True, on_delete=SET_NULL)
     sample_id = models.TextField()
     # sample_name is used to name files. In MiSeq/NextSeq samplesheet you can add names.
     # For Hiseq and if left empty on MiSeq this will be sample_id

--- a/snpdb/forms.py
+++ b/snpdb/forms.py
@@ -20,7 +20,7 @@ from library.cache import timed_cache
 from library.django_utils.autocomplete_utils import ModelSelect2, ModelSelect2Multiple
 from library.forms import ROFormMixin
 from library.guardian_utils import DjangoPermission
-from patients.models import Patient, Specimen
+from patients.models import Extraction, Patient, Specimen
 from snpdb import models
 from snpdb.models import (
     DEFAULT_GRID_LOADING_ANIMATIONS,
@@ -363,9 +363,9 @@ class SampleForm(forms.ModelForm, ROFormMixin):
                    'name': TextInput(),
                    'patient': ModelSelect2(url='patient_autocomplete',
                                            attrs={'data-placeholder': 'Patient...'}),
-                   'specimen': ModelSelect2(url='specimen_autocomplete',
-                                            forward=['patient'],
-                                            attrs={'data-placeholder': 'Specimen...'})}
+                   'extraction': ModelSelect2(url='extraction_autocomplete',
+                                              forward=['patient'],
+                                              attrs={'data-placeholder': 'Extraction...'})}
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user")
@@ -384,14 +384,14 @@ class SampleForm(forms.ModelForm, ROFormMixin):
 
     def clean(self):
         cleaned_data = super().clean()
-        specimen = cleaned_data.get('specimen')
-        if specimen:
+        extraction = cleaned_data.get('extraction')
+        if extraction:
             patient = cleaned_data.get('patient')
             if patient is None:
-                self.add_error('patient', "Patient must be supplied if specimen supplied")
-            elif specimen.patient != patient:
-                msg = "Specimen must be from supplied patient"
-                self.add_error('specimen', msg)
+                self.add_error('patient', "Patient must be supplied if extraction supplied")
+            elif extraction.specimen.patient != patient:
+                msg = "Extraction must be from supplied patient"
+                self.add_error('extraction', msg)
                 self.add_error('patient', msg)
         return cleaned_data
 
@@ -560,10 +560,11 @@ class SettingsOverrideForm(BaseModelForm):
     @staticmethod
     def _validate_sample_formatter_func(sample_label_template):
         """ Throws error if invalid """
-        specimen = Specimen(reference_id='refId', description='description')
+        specimen = Specimen(pk=3, reference_id='refId', description='description')
+        extraction = Extraction(pk=4, specimen=specimen)
         patient = Patient(pk=2, first_name='first_name', last_name='last_name',
                           patient_code='patient_code')
-        sample = Sample(pk=1, name="sample", patient=patient, specimen=specimen)
+        sample = Sample(pk=1, name="sample", patient=patient, extraction=extraction)
         params = sample._get_sample_formatter_params()
         errors = []
         for i, t in enumerate(sample_label_template.split("||")):

--- a/snpdb/grids.py
+++ b/snpdb/grids.py
@@ -124,7 +124,8 @@ class SamplesListGrid(JqGridUserRowConfig):
               "somaliersampleextract__somalierancestry__predicted_ancestry",
               "patient__patient_code", "patient__first_name", "patient__last_name", "patient__sex",
               "patient__date_of_birth", "patient__date_of_death",
-              "specimen__reference_id", "specimen__tissue__name", "specimen__collection_date", "vcf__id"]
+              "extraction__specimen__reference_id", "extraction__specimen__tissue__name",
+              "extraction__specimen__collection_date", "vcf__id"]
     colmodel_overrides = {
         'id': {"hidden": True},
         "name": {"width": 400,
@@ -158,7 +159,7 @@ class SamplesListGrid(JqGridUserRowConfig):
         'patient__date_of_death': {'hidden': True},
         'het_hom_count': {'name': 'het_hom_count', "model_field": False, 'sorttype': 'int',
                           'label': 'Het/Hom Count'},
-        "specimen__reference_id": {'label': 'Specimen'},
+        "extraction__specimen__reference_id": {'label': 'Specimen'},
         # These urls are only there for CSV export
         "sample_url": {'name': 'sample_url', 'label': 'Sample URL', "model_field": False, 'hidden': True},
         "vcf_url": {'name': 'vcf_url', 'label': 'VCF URL', "model_field": False, 'hidden': True},

--- a/snpdb/migrations/0201_sample_stash_specimen_reference.py
+++ b/snpdb/migrations/0201_sample_stash_specimen_reference.py
@@ -1,0 +1,40 @@
+"""
+Specimen's TextField primary key is about to be replaced with a surrogate key (#1704), so drop the
+FK pointing at it, keeping the reference_id text in a temporary column. 0202 uses that to re-attach
+each sample to the Extraction created under its old specimen.
+"""
+from django.db import migrations, models
+from django.db.models import F
+
+
+def _flush_deferred_constraints(schema_editor):
+    """ Postgres refuses ALTER TABLE while deferred FK trigger events from a data change are pending """
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
+def _stash_specimen_reference(apps, schema_editor):
+    Sample = apps.get_model("snpdb", "Sample")
+    Sample.objects.filter(specimen__isnull=False).update(_specimen_reference_id=F("specimen_id"))
+    _flush_deferred_constraints(schema_editor)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patients', '0012_manual_patient_code_backfill_reminder'),
+        ('snpdb', '0200_ptc_columns'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sample',
+            name='_specimen_reference_id',
+            field=models.TextField(null=True),
+        ),
+        migrations.RunPython(_stash_specimen_reference, migrations.RunPython.noop, elidable=True),
+        migrations.RemoveField(
+            model_name='sample',
+            name='specimen',
+        ),
+    ]

--- a/snpdb/migrations/0202_sample_extraction.py
+++ b/snpdb/migrations/0202_sample_extraction.py
@@ -1,0 +1,49 @@
+"""
+#1704 - Sample.extraction replaces Sample.specimen, specimen now being reached via
+sample.extraction.specimen. patients.0013 made one Extraction per existing Specimen, so each sample
+re-attaches to the extraction under the specimen it was pointing at.
+"""
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def _flush_deferred_constraints(schema_editor):
+    """ Postgres refuses ALTER TABLE while deferred FK trigger events from a data change are pending """
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
+def _restore_sample_extraction(apps, schema_editor):
+    """ reference_id was globally unique while it was Specimen's primary key, so it identifies the row """
+    Sample = apps.get_model("snpdb", "Sample")
+    Extraction = apps.get_model("patients", "Extraction")
+    extraction_by_reference_id = dict(Extraction.objects.values_list("specimen__reference_id", "pk"))
+
+    samples = []
+    for sample in Sample.objects.filter(_specimen_reference_id__isnull=False).iterator():
+        sample.extraction_id = extraction_by_reference_id.get(sample._specimen_reference_id)
+        samples.append(sample)
+    Sample.objects.bulk_update(samples, ["extraction_id"], batch_size=2000)
+    _flush_deferred_constraints(schema_editor)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patients', '0013_extraction_specimen_surrogate_pk'),
+        ('snpdb', '0201_sample_stash_specimen_reference'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sample',
+            name='extraction',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL,
+                                    to='patients.extraction'),
+        ),
+        migrations.RunPython(_restore_sample_extraction, migrations.RunPython.noop, elidable=True),
+        migrations.RemoveField(
+            model_name='sample',
+            name='_specimen_reference_id',
+        ),
+    ]

--- a/snpdb/models/models_vcf.py
+++ b/snpdb/models/models_vcf.py
@@ -27,7 +27,7 @@ from library.genomics.vcf_enums import VariantClass
 from library.guardian_utils import DjangoPermission
 from library.log_utils import log_traceback
 from library.preview_request import PreviewKeyValue, PreviewModelMixin
-from patients.models import FakeData, Patient, Specimen
+from patients.models import Extraction, FakeData, Patient, Specimen
 from snpdb.models.models import LabProject, Tag
 from snpdb.models.models_enums import (
     ImportStatus,
@@ -337,8 +337,8 @@ class Sample(GuardianPermissionsMixin, SortByPKMixin, PreviewModelMixin, models.
     no_dna_control = models.BooleanField(default=False)
     research_consent = models.BooleanField(null=True, blank=True)
     patient = models.ForeignKey(Patient, null=True, blank=True, on_delete=SET_NULL)
-    # TODO: A sample may have >1 specimens (eg tumor/normal subtraction)
-    specimen = models.ForeignKey(Specimen, null=True, blank=True, on_delete=SET_NULL)
+    # TODO: A sample may have >1 extractions (eg tumor/normal subtraction)
+    extraction = models.ForeignKey(Extraction, null=True, blank=True, on_delete=SET_NULL)
     import_status = models.CharField(max_length=1, choices=ImportStatus.choices, default=ImportStatus.CREATED)
     variants_type = models.CharField(max_length=1, choices=VariantsType.choices, default=VariantsType.UNKNOWN)
 
@@ -357,6 +357,12 @@ class Sample(GuardianPermissionsMixin, SortByPKMixin, PreviewModelMixin, models.
             genome_builds={self.vcf.genome_build},
             summary_extra=[PreviewKeyValue("VCF", str(self.vcf))]
         )
+
+    @property
+    def specimen(self) -> Optional[Specimen]:
+        if self.extraction:
+            return self.extraction.specimen
+        return None
 
     @property
     def genome_build(self):

--- a/snpdb/templates/snpdb/data/view_sample.html
+++ b/snpdb/templates/snpdb/data/view_sample.html
@@ -70,8 +70,8 @@ $(document).ready(function() {
     const sampleForm = $("#sample-form");
     const patientSelect = $("#id_patient", sampleForm);
     patientSelect.change(function() {
-        let specimenSelect = $("#id_specimen", sampleForm);
-        clearAutocompleteChoice(specimenSelect);
+        let extractionSelect = $("#id_extraction", sampleForm);
+        clearAutocompleteChoice(extractionSelect);
     });
     const dialog = setupCreatePatientDialog();
     const sampleName = $("#id_name").val();

--- a/snpdb/templates/snpdb/data/view_vcf.html
+++ b/snpdb/templates/snpdb/data/view_vcf.html
@@ -416,7 +416,7 @@ $(document).ready(function() {
                     <th>VCF Sample Name
                     <th>Name
                     <th>Patient
-                    <th>Specimen
+                    <th>Extraction
                 </tr>
             </thead>
             {% for form in samples_form %}
@@ -455,7 +455,7 @@ $(document).ready(function() {
                             </div>
                         </div>
                     </td>
-                    <td>{{ form.specimen }}{{ form.specimen.errors }}</td>
+                    <td>{{ form.extraction }}{{ form.extraction.errors }}</td>
                 </tr>
                 
             {% endfor %}

--- a/snpdb/views/views.py
+++ b/snpdb/views/views.py
@@ -399,7 +399,7 @@ def view_vcf(request, vcf_id):
     sample_stats_pass_het_hom_count, _, sample_zygosities_pass = _get_vcf_sample_stats(vcf, passing_filter=True)
 
     VCFSampleFormSet = inlineformset_factory(VCF, Sample, extra=0, can_delete=False,
-                                             fields=["vcf_sample_name", "name", "patient", "specimen"],
+                                             fields=["vcf_sample_name", "name", "patient", "extraction"],
                                              widgets=SampleForm.Meta.widgets)
 
     post = request.POST or None

--- a/variantgrid/static_files/default_static/page_help/patients/view_patient_extractions_help.html
+++ b/variantgrid/static_files/default_static/page_help/patients/view_patient_extractions_help.html
@@ -1,0 +1,12 @@
+An extraction is the nucleic acid taken off a specimen. One tumour block gives both a DNA and an RNA
+extraction, and both belong to the same specimen.
+
+<p>
+Add the specimen on the Specimens tab first, then pick it here.
+
+<p>
+The extraction date is what tells apart two extractions of the same nucleic acid from one specimen,
+eg where the first did not yield enough material.
+
+<p>
+One extraction may be sequenced more than once (repeats, top-ups), so it can have several samples.

--- a/variantgrid/static_files/default_static/page_help/patients/view_patient_help2.html
+++ b/variantgrid/static_files/default_static/page_help/patients/view_patient_help2.html
@@ -1,4 +1,9 @@
-Specimens are something DNA is extracted from, eg blood in a test tube.
+Specimens are the material collected from a patient, eg blood in a test tube or a tumour block.
 
 <p>
-A patient may have multiple specimens, which may have multiple sample (eg if the same blood sample was sequenced twice)  
+An extraction is the nucleic acid taken off a specimen - one tumour block can give both a DNA and an
+RNA extraction, and both belong to the same specimen.
+
+<p>
+A patient may have multiple specimens, and an extraction may have multiple samples (eg if the same
+blood sample was sequenced twice)


### PR DESCRIPTION
🤖 Written by Claude.

Phase 1 of the TSO 500 plan — the `Specimen → Extraction → Sample` hierarchy from #1704.

## Why

`Specimen` carried `nucleic_acid_source`, so the DNA and RNA arms of one tumour block had to become two unrelated `Specimen` rows with nothing tying them back together. `Extraction` goes between `Specimen` and `Sample` and takes the field, so both arms hang off one specimen.

```
Patient └── Specimen └── Extraction └── [SequencingSample] └── Sample
```

## Models

**Added `patients.Extraction`** — `specimen` FK, `reference_id`, `nucleic_acid_source` and `extraction_date`, plus `external_pk`/`created`/`modified` from `ExternallyManagedModel` (R5). No QC fields: `external_pk` keeps yield/concentration/260-280 reconcilable in the tracking system, and VG never generates those numbers, so a second copy would only drift.

`reference_id` sits beside `external_pk` rather than instead of it, matching the levels above — `Patient` carries `patient_code`, `Specimen` its own `reference_id`. `external_pk` is nullable because not every deployment has a system managing its records, so each level needs a local identifier too. `extraction_date` is how a lab tells apart two extractions of the same nucleic acid from one specimen.

**`Specimen`** — extends `ExternallyManagedModel`; `reference_id` demoted from `TextField` PK to a plain field with a surrogate PK and `unique_together (patient, reference_id)` (R4); `nucleic_acid_source` removed (R3); `mutation_type` stays, since it describes the material.

**`snpdb.Sample`** — `specimen` FK → `extraction` FK (R2), plus a read-only `specimen` property returning `self.extraction.specimen`. That property is what keeps the consumer diff small — anything wanting only the specimen still reads one attribute.

**`seqauto.SequencingSample`** — optional `extraction` FK (R1/R8). Enrichment, not the join key; `Sample.extraction` is settable without seqauto, since VCFs arrive by hand and some deployments never run it.

## Migrations

Four, ordered so nothing points at `Specimen.reference_id` while its key is swapped:

1. `snpdb/0201` — stash `sample.specimen_id` (the reference text) in a temp column, drop the FK.
2. `patients/0013` — same for `PatientRecord.specimen`; swap the key; add the `ExternallyManagedModel` columns; create `Extraction`; **one `Extraction` per existing `Specimen` carrying its `nucleic_acid_source`**; drop `Specimen.nucleic_acid_source`; re-point `PatientRecord`.
3. `seqauto/0046` — `SequencingSample.extraction`.
4. `snpdb/0202` — add `Sample.extraction`, re-point via the stashed reference, drop the temp column.

Then `patients/0014` (extraction date, and `TimeStampedModel` across the rest of the app) and `patients/0015` (extraction reference).

The remap keys on `reference_id`, which was globally unique while it was the PK, so it identifies the row exactly.

**Worth knowing for review:** I ran this against a seeded clone of the test DB rather than an empty schema — reversed to `patients/0012` + `snpdb/0200`, seeded specimens with DNA/RNA/null sources plus samples and a `PatientRecord`, migrated forward. That caught two failures an empty-table run hides:

- Passing `default=None` for the `TimeStampedModel` columns inserts NULL. Django's schema editor supplies `timezone.now()` for `auto_now`/`auto_now_add` itself (`base/schema.py:486`), but only when the field has no default at all — an explicit `None` satisfies `has_default()` and short-circuits it.
- Postgres refuses `ALTER TABLE` while deferred FK trigger events from a preceding `RunPython` are pending. Each data step now ends with a `SET CONSTRAINTS ALL IMMEDIATE` flush.

## Consumers (R7)

All five, plus what fell out:

| File | Change |
|---|---|
| `patients/import_records.py` | `assign_specimen_to_sample` → `assign_extraction_to_sample`; specimen lookup is per-patient, still raising when a reference belongs to someone else |
| `snpdb/forms.py` | widget `specimen` → `extraction`; `clean()` validates `extraction.specimen.patient` |
| `snpdb/grids.py` | `specimen__…` → `extraction__specimen__…`, label unchanged |
| `patients/views_autocomplete.py` | added `ExtractionAutocompleteView` + URL |
| `classification/…/evidence_from_sample_and_patient.py` | `get_evidence_fields_for_specimen()` → `…_for_extraction()`, `NUCLEIC_ACID_SOURCE` read off the extraction |

Beyond R7: `PatientColumns.SAMPLE_QUERYSET_PATH` (CSV export paths), the VCF sample formset, `view_vcf.html`/`view_sample.html`, `patients/admin.py`, and the specimens page help.

Extractions get their own patient tab alongside Specimens. Its specimen picker is `specimen_autocomplete`, which had been left without a caller when the sample form moved to extractions — `Extraction` has no FK to `Patient`, so the patient is forwarded as a constant the way `external_pk_autocomplete_form_factory` already does, with the view setting the formset queryset as the real constraint.

Everything else in `patients` becomes a `TimeStampedModel` — `Tissue`, `PatientPopulation`, `PatientAttachment`, `PatientImport`, `PatientModification`, `PatientComment`, `PatientRecords`, `PatientRecord`, `Clinician`, `ExternalPK`, `FollowLeadScientist`. Backfill checked against seeded rows in all eleven tables.

Two further additions that weren't in R7 but avoid regressions:

- `PatientSpecimenFormSet` used `ALL_FIELDS`, which post-`ExternallyManagedModel` would render an `external_pk` select of every `ExternalPK`. Now `exclude=['external_pk']`.
- `nucleic_acid_source` leaving the specimen form left no way to set DNA/RNA in the UI, so the patient specimens tab grows an `Extraction` formset.

Autocomplete forwarding chains through the new level: extraction narrows on a forwarded `patient` or `specimen`, specimen narrows on a forwarded `patient` or `extraction`. Extractions are searchable by their specimen's `reference_id`.

## Patient CSV (R6)

The existing single `SPECIMEN_NUCLEIC_ACID_SOURCE` column implies one extraction, so existing files import untouched — `Specimen.get_or_create_extraction()` creates or updates one `Extraction` under the specimen rather than making a second. Those files describe one extraction per specimen anyway.

## Tests

`patients/tests/test_specimen_extraction.py` — one specimen holding a DNA and an RNA extraction, CSV round-trip (creation, traversal, re-import reuse, in-place source update, blank source, export paths), and autocomplete forwarding in both directions. Plus an `extraction_autocomplete` case in `test_urls.py`.

```
python3 manage.py test --keepdb patients snpdb
Ran 217 tests — OK
```

`classification seqauto upload analysis` also pass (497 tests, OK, 5 skipped). Pylint on the changed files reports only pre-existing warnings.

## Known gaps, deliberately left

- The patient CSV columns are all `SPECIMEN_*`, so a CSV can name one extraction per specimen but not the DNA and RNA arms of one block.
- `specimen_autocomplete` no longer has a caller in this repo, the sample form having moved to `extraction_autocomplete`. Kept, since the sapath and private repos may use it.
- Carrying specimen/extraction through the seqauto API is Phase 2. The second commit settles the shape: plain text beside the model FKs, the API always accepting what it was sent, linking what exists and deferring the rest to a later matching pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ePLzeerJq3erQKsYN8E5E


