### PR TITLE
TSO 500 pipeline fixes: VCF header FILTER IDs, CSV file-type detection #1506

### DIFF
--- a/library/genomics/vcf_utils.py
+++ b/library/genomics/vcf_utils.py
@@ -21,6 +21,21 @@ from library.utils import open_file_or_filename, open_handle_gzip
 from snpdb.models import GenomeFasta, Sequence, SequenceRole, Variant, VariantCoordinate
 
 
+VCF_HEADER_FILTER_ID_PATTERN = re.compile(r'^##FILTER=<ID=([^,>]+)')
+
+
+def vcf_header_filter_ids(vcf_header_lines: Iterable[str]) -> set[str]:
+    """ Declared FILTER IDs, read straight out of the raw header lines.
+
+        Callers write keys beyond ID/Description here (eg Illumina's LrCalculator adds Number/Type) which
+        strict parsers reject outright, so we only pull out the ID rather than parsing the whole line """
+    filter_ids = set()
+    for line in vcf_header_lines:
+        if m := VCF_HEADER_FILTER_ID_PATTERN.match(line):
+            filter_ids.add(m.group(1))
+    return filter_ids
+
+
 def cyvcf2_header_types(cyvcf2_reader) -> defaultdict:
     header_types = defaultdict(dict)
     for h in cyvcf2_reader.header_iter():

--- a/library/tests/test_vcf_header_filter_ids.py
+++ b/library/tests/test_vcf_header_filter_ids.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+
+from library.genomics.vcf_utils import vcf_header_filter_ids
+
+
+class TestVCFHeaderFilterIds(TestCase):
+    def test_reads_ids(self):
+        header = [
+            '##fileformat=VCFv4.2\n',
+            '##FILTER=<ID=LowQ,Description="Low quality">\n',
+            '##FILTER=<ID=base_quality,Description="Site filtered because median base quality is low">\n',
+            '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n',
+        ]
+        self.assertEqual({"LowQ", "base_quality"}, vcf_header_filter_ids(header))
+
+    def test_extra_keys(self):
+        """ Illumina's LrCalculator writes Number/Type on FILTER lines - strict parsers reject the whole header """
+        header = ['##FILTER=<ID=Undetermined,Number=1,Type=String,Description="CNV type may be undetermined. ">\n']
+        self.assertEqual({"Undetermined"}, vcf_header_filter_ids(header))
+
+    def test_id_only(self):
+        self.assertEqual({"PASS"}, vcf_header_filter_ids(['##FILTER=<ID=PASS>\n']))
+
+    def test_ignores_other_header_types(self):
+        header = [
+            '##INFO=<ID=END,Number=1,Type=Integer,Description="End position">\n',
+            '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
+            '##ALT=<ID=DEL,Description="Deletion relative to the reference.">\n',
+        ]
+        self.assertEqual(set(), vcf_header_filter_ids(header))
+
+    def test_no_filters(self):
+        self.assertEqual(set(), vcf_header_filter_ids([]))

--- a/upload/import_task_factories/import_task_factories.py
+++ b/upload/import_task_factories/import_task_factories.py
@@ -125,7 +125,10 @@ class PatientRecordsImportTaskFactory(ImportTaskFactory):
         return [UploadedPatientRecords]
 
     def get_processing_ability(self, user, filename, file_extension):
-        df = pd.read_csv(filename, encoding='unicode_escape')
+        try:
+            df = pd.read_csv(filename, encoding='unicode_escape')
+        except Exception:  # Every CSV factory is asked, so a shape we can't read is someone else's file
+            return 0
         if PatientColumns.PATIENT_LAST_NAME in df.columns:
             return 1000
         return 0

--- a/upload/management/commands/vcf_clean_and_filter.py
+++ b/upload/management/commands/vcf_clean_and_filter.py
@@ -15,14 +15,12 @@ Which we unfortunately see sometimes.
 import re
 import sys
 from collections import Counter
-from io import StringIO
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from vcf import Reader
 
 from library.genomics.vcf_enums import VCFColumns
-from library.genomics.vcf_utils import UnsortedVCFError, VCFSortChecker
+from library.genomics.vcf_utils import UnsortedVCFError, VCFSortChecker, vcf_header_filter_ids
 from snpdb.models import GenomeBuild, GenomeFasta
 
 
@@ -169,11 +167,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def _get_defined_vcf_filters(vcf_header_lines) -> set:
-        defined_filters = {"PASS"}
-        stream = StringIO("".join(vcf_header_lines))
-        reader = Reader(stream)
-        defined_filters.update(reader.filters.keys())
-        return defined_filters
+        return {"PASS"} | vcf_header_filter_ids(vcf_header_lines)
 
     @staticmethod
     def _write_unsorted_marker(filename, reason: str):


### PR DESCRIPTION
Two pipeline fixes found by running the TSO 500 test data (`upload/test_data/tso500/`) through the
real pipe stages. Both are self-contained and worth having regardless of the TSO 500 work — this is
Phase 0 of `claude/plans/tso500_overall_plan.md`.

### `vcf_clean_and_filter` — read declared FILTER IDs without PyVCF

`_get_defined_vcf_filters` built the set of header-declared FILTER IDs with PyVCF's `Reader`, whose
FILTER regex accepts `ID` and `Description` only. Illumina's LrCalculator writes `Number` and `Type`
on its FILTER lines:

```
##FILTER=<ID=Undetermined,Number=1,Type=String,Description="Both segments for this gene ...">
```

which raises `SyntaxError: One of the FILTER lines is malformed` and kills the import at the very
first pipe stage. bcftools and cyvcf2 both read the line without complaint.

The command only needs the IDs, so `vcf_header_filter_ids()` in `library/genomics/vcf_utils.py` reads
them straight off the raw header lines — the same hand-rolled approach the rest of the command already
takes, and it can't be tripped by whatever else a caller decides to write there. A regex rather than
cyvcf2 because cyvcf2 needs a real file descriptor, which doesn't suit a command filtering stdin.

This was the last PyVCF use in the pipe, so `from vcf import Reader` goes with it.

### File-type detection — one unreadable CSV no longer breaks every other CSV type

`get_import_task_factory_from_extension` asks all five `csv` factories for their processing ability,
and `PatientRecordsImportTaskFactory.get_processing_ability` called `pd.read_csv` bare. Any CSV shape
pandas can't read raised out of detection for *all* of them, not just its own. TSO 500's
`AllFusions.csv` hits this via its 31-line `#`-prefixed comment preamble
(`pandas.errors.ParserError: Expected 1 fields in line 28, saw 2`). It now returns 0 — someone else's
file.

### Testing

`library/tests/test_vcf_header_filter_ids.py` covers the ID-only, extra-keys, other-header-types and
empty cases. `python3 manage.py test --keepdb upload library.tests.test_vcf_header_filter_ids` passes
(82 + 5).

### Follow-on

With this in, `_DragenExonCNV.vcf` reaches the importer and `AllFusions.csv` can be uploaded at all.
Neither loads *correctly* yet — that is Phase 2, planned in `claude/plans/tso500_phase2_plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ePLzeerJq3erQKsYN8E5E
