### PR TITLE
Specimen tissue status, and pages for Specimen / Extraction #1706

### DIFF
--- a/classification/autopopulate_evidence_keys/evidence_from_sample_and_patient.py
+++ b/classification/autopopulate_evidence_keys/evidence_from_sample_and_patient.py
@@ -3,9 +3,10 @@ from typing import Optional
 
 from classification.autopopulate_evidence_keys.evidence_from_variant import AutopopulateData
 from classification.enums import SpecialEKeys
-from patients.models_enums import Sex, Zygosity
+from patients.models_enums import Sex, TissueStatus, Zygosity
 from patients.models import Extraction
 from snpdb.models import Sample, SampleGenotype
+from snpdb.models.models_enums import VariantsType
 from snpdb.models.models_variant import Variant
 
 
@@ -31,9 +32,22 @@ def negative_as_none(value):
     return value
 
 
+def get_allele_origin(sample: Sample) -> Optional[str]:
+    """ The specimen says what the material is and the sample says what's in the call set, so an origin
+        is only asserted where both agree - a mixed tumour sample's origin is genuinely per-variant and
+        is left for the curator. Returns an allele_origin evidence key option, not a display label """
+    if sample.variants_type == VariantsType.SOMATIC_ONLY:
+        return "somatic"
+    if sample.variants_type == VariantsType.GERMLINE and sample.extraction:
+        if sample.extraction.specimen.tissue_status == TissueStatus.REFERENCE:
+            return "germline"
+    return None
+
+
 def get_evidence_fields_for_sample_and_patient(variant: Variant, sample: Sample) -> AutopopulateData:
     data = AutopopulateData("sample")
     data[SpecialEKeys.SAMPLE_ID] = sample.name
+    data[SpecialEKeys.ALLELE_ORIGIN] = get_allele_origin(sample)
 
     patient = sample.patient
     if patient:
@@ -88,7 +102,6 @@ def get_evidence_fields_for_extraction(extraction: Extraction) -> AutopopulateDa
     data = AutopopulateData("specimen")
     specimen = extraction.specimen
     data[SpecialEKeys.SPECIMEN_ID] = specimen.reference_id
-    data[SpecialEKeys.ALLELE_ORIGIN] = specimen.get_mutation_type_display()
     data[SpecialEKeys.SAMPLE_TYPE] = str(specimen.tissue)
     data[SpecialEKeys.AGE] = specimen.age_at_collection_date
     data[SpecialEKeys.NUCLEIC_ACID_SOURCE] = extraction.get_nucleic_acid_source_display()

--- a/claude/plans/tso500_overall_plan.md
+++ b/claude/plans/tso500_overall_plan.md
@@ -6,8 +6,9 @@ each issue carries its own design.
 
 The file-level ingestion analysis is in [`tso500_ingestion_plan.md`](tso500_ingestion_plan.md); the
 test data and its gotchas are in [`upload/test_data/tso500/README.md`](../../upload/test_data/tso500/README.md).
-Four phases have their own design docs: [`tso500_phase2_plan.md`](tso500_phase2_plan.md) for the loader
-refinements, [`fusion_variants_issue_1506_plan.md`](fusion_variants_issue_1506_plan.md) for gene
+Five phases have their own design docs: [`tso500_phase2_plan.md`](tso500_phase2_plan.md) for the loader
+refinements, [`tso500_phase_3_plan.md`](tso500_phase_3_plan.md) for tissue status and the specimen
+pages, [`fusion_variants_issue_1506_plan.md`](fusion_variants_issue_1506_plan.md) for gene
 fusions, [`tso500_phase_7_plan.md`](tso500_phase_7_plan.md) for the grouping node, and
 [`somatic_curation_reuse_issue_1419_plan.md`](somatic_curation_reuse_issue_1419_plan.md) for Phase 8's
 reporting.
@@ -135,6 +136,8 @@ one, so they want to stay stable from the first client.
 
 ## Phase 3 — finish the specimen model, and give it somewhere to show (private#2447, #1706)
 
+Designed in [`tso500_phase_3_plan.md`](tso500_phase_3_plan.md), which is the spec.
+
 Both are Phase 1 leftovers rather than new work, and both are markedly cheaper before Phase 4 puts
 `Specimen` behind a public API than after.
 
@@ -160,10 +163,11 @@ The design is settled on the issue: a per-specimen `tissue_status` (Reference (u
 (lesional) / Unknown, defaulting to Unknown), leaving the call-set question to the existing
 `VCF.variants_type` and the per-variant question to the existing `allele_origin`, and having autopopulate
 assert an origin only where both levels agree. Matched normal stays derivable — "reference specimen, same
-patient" — rather than becoming an FK. The migration maps `S` → affected; `G` is ambiguous because it was
-the default, so check the deployment's distinct `PatientRecord.specimen_mutation_type` values
-(`patients/models.py:662`) before deciding it means anything. The patient CSV's `SPECIMEN_MUTATION_TYPE`
-column follows.
+patient" — rather than becoming an FK. The migration maps `S` → affected and `G` → unknown, `G` being
+ambiguous because it was the default, and registers a `ManualOperation` only on deployments whose
+`PatientRecord.specimen_mutation_type` (`patients/models.py:662`) actually carries a `G` — evidence the
+CSV column was populated rather than defaulted. The patient CSV's `SPECIMEN_MUTATION_TYPE` column
+follows, as a hard rename rather than an alias.
 
 ### #1706 — specimen and extraction pages, search, preview
 
@@ -486,7 +490,6 @@ With one person, the order above is the order.
 
 | Decision | Phase | Why it is cheaper now |
 |---|---|---|
-| Does `G` in `PatientRecord.specimen_mutation_type` mean anything on each deployment? | 3 | Decides whether the migration can map `G` → Unknown and lose nothing |
 | Multi-gene partner with one HGNC and one clone identifier — park the row or resolve to the HGNC member? | 5 | Determines whether `GeneFusion` identity can be non-null on both sides |
 | Single grid or multiple grids for non-variants? | 6 | Best answered against real fusion rows, so genuinely wait for Phase 5 |
 

--- a/claude/plans/tso500_phase_3_plan.md
+++ b/claude/plans/tso500_phase_3_plan.md
@@ -1,0 +1,325 @@
+# TSO 500 Phase 3 — tissue status, and pages for Specimen / Extraction
+
+Design for the Phase 3 row of [`tso500_overall_plan.md`](tso500_overall_plan.md): two Phase 1 leftovers,
+[SACGF/variantgrid_private#2447](https://github.com/SACGF/variantgrid_private/issues/2447) (replace
+`Specimen.mutation_type` with a tissue status) and [#1706](https://github.com/SACGF/variantgrid/issues/1706)
+(specimen and extraction pages, search, preview).
+
+Both are markedly cheaper before Phase 4 puts `Specimen` behind a public API, and both are the last
+model-shaped work in `patients` before #1707 serializes it.
+
+---
+
+## Scope
+
+In:
+
+- `Specimen.mutation_type` → `Specimen.tissue_status`, everywhere it reaches: autopopulate, the patient
+  CSV, `PatientRecord`, admin, forms.
+- Detail pages for `Specimen` and `Extraction`, with permissions, `PreviewModelMixin`, a search handler,
+  and links each way along `Patient → Specimen → Extraction → Sample`.
+
+Out, riding with Phase 6 where the grid column pass already is:
+
+- Top-level specimen / extraction grids under the patients menu.
+- An extraction link on the sample grid.
+- private#2837's specimen/patient IDs in the variant page's sample table.
+
+The split is on "does Phase 4 need it": Phase 4's done-when is *the measures show on the specimen page*,
+so the page is a prerequisite; the grids are not.
+
+---
+
+## Part A — `Specimen.tissue_status` (private#2447)
+
+### What is there now
+
+`Specimen.mutation_type` (`patients/models.py:321`) is a two-value Germline/Somatic `CharField` with
+`default=Mutation.GERMLINE`. Its one substantive consumer is classification autopopulate
+(`classification/autopopulate_evidence_keys/evidence_from_sample_and_patient.py:91`):
+
+```python
+data[SpecialEKeys.ALLELE_ORIGIN] = specimen.get_mutation_type_display()
+```
+
+`allele_origin` feeds `AlleleOriginBucket.bucket_for_allele_origin`
+(`classification/enums/classification_enums.py:24`), which partitions `AlleleOriginGrouping` and the
+cross-lab overlaps. So every TSO 500 tumour block, having never had the field set, stamps its
+classifications "Germline" and files them alongside other labs' real germline records — corrupting
+exactly the somatic classifications Phase 8 exists to produce.
+
+The rest of the reach is mechanical: `patients/admin.py:20`, the specimen formset
+(`patients/forms.py:121`, which excludes only `external_pk` so it picks the field up automatically),
+`PatientColumns.SPECIMEN_MUTATION_TYPE` and its queryset path (`patients/models.py:533`),
+`PatientRecord.specimen_mutation_type` (`patients/models.py:662`), `patients/import_records.py:241,
+363, 373, 419`, and `patients/templates/patients/view_patient_record.html:53`.
+
+### The field
+
+In `patients/models_enums.py`, replacing `Mutation` (which has no other consumer):
+
+```python
+class TissueStatus(models.TextChoices):
+    REFERENCE = 'R', 'Reference (unaffected)'   # hair, buccal, blood in a solid-tumour workup
+    AFFECTED = 'A', 'Affected / lesional'       # tumour block, affected skin in mosaic disease
+    UNKNOWN = 'U', 'Unknown'
+```
+
+On `Specimen`, `default=TissueStatus.UNKNOWN`, not null. The current `null=True, blank=True` plus a
+Germline default is where the silent damage comes from: an unset field is indistinguishable from a
+deliberate one. `UNKNOWN` is an explicit value that says so.
+
+This lives on `Specimen` rather than on the `Tissue` lookup (`patients/models.py:303`) because the same
+tissue plays different roles — blood is the reference in a solid-tumour workup and *is* the tumour in
+leukaemia; skin is reference normally and is the affected tissue in Proteus. That is the mosaic case the
+issue was opened about, and it is why a per-specimen field earns its keep instead of tagging tissue types.
+
+### Three levels, and one correction to the issue
+
+| Level | Question | Where | Values |
+|---|---|---|---|
+| Specimen | What is this material, and what role does it play in the test? | `Specimen.tissue_status` (new) | Reference / Affected / Unknown |
+| Call set | What's in this VCF? | `Sample.variants_type` (exists) | Unknown / Germline / Mixed / Somatic only |
+| Variant | What is *this* variant's origin? | `allele_origin` → `AlleleOriginBucket` (exists) | germline / somatic / other |
+
+The issue says `VCF.variants_type`. It is actually on **`Sample`** (`snpdb/models/models_vcf.py:343`),
+alongside `Sample.extraction` and `Sample.is_somatic`. That matters for where the derivation goes.
+
+### Autopopulate becomes a derivation
+
+`get_evidence_fields_for_extraction` (`:87`) takes only an `Extraction`, so it cannot see
+`variants_type`. Move the origin decision up into `get_evidence_fields_for_sample_and_patient` (`:34`),
+which already holds both the sample and `sample.extraction` (`:45`), and leave the extraction helper
+doing the things that are genuinely per-extraction (specimen ID, sample type, age, nucleic acid source).
+
+The rule — assert an origin only where both levels agree:
+
+| `tissue_status` | `variants_type` | `allele_origin` |
+|---|---|---|
+| Reference | Germline | `germline` |
+| any | Somatic only (tumour minus normal) | `somatic` |
+| anything else | anything else | unset |
+
+Unset falls back to `settings.ALLELE_ORIGIN_NOT_PROVIDED_BUCKET` so the curator sets it per variant.
+That last row is the heart of the issue: for a mixed tumour sample the origin is genuinely per-variant
+and cannot be known at accession.
+
+Emit the lowercase option strings (`"germline"`, `"somatic"`) rather than a `get_..._display()` label —
+`bucket_for_allele_origin` looks the value up through `EvidenceKeyMap.cached_key(...).matched_options()`,
+and the evidence key's own option keys are what that matches.
+
+### Migration
+
+Three migrations' worth of work, in one file per Django convention (next is `patients/0016_`):
+
+1. Add `tissue_status` with `default=TissueStatus.UNKNOWN`.
+2. `RunPython` mapping `mutation_type` `S` → `AFFECTED`, `G` and null → `UNKNOWN`.
+3. Remove `mutation_type`.
+
+`S` → `AFFECTED` is clean. `G` is ambiguous because it was the default — it may mean "a curator said
+germline" or "nobody touched it", and there is no way to tell the two apart from the column alone. On
+this dev box every `PatientRecord.specimen_mutation_type` is null, but that says nothing about SA
+Pathology or variantgrid.com.
+
+So rather than guess, map `G` → `UNKNOWN` and register a `ManualOperation` whose `test=` callable only
+fires on deployments that actually have evidence of a deliberate germline declaration — a
+`PatientRecord` row with `specimen_mutation_type='G'`, meaning the CSV column was populated rather than
+defaulted. Following `snpdb/migrations/0188_one_off_migrate_common_filter_gnomad_versions.py`. On a
+deployment that never populated the column the task is never registered and nothing is lost; on one that
+did, a human reviews those specimens.
+
+`PatientRecord.specimen_mutation_type` → `specimen_tissue_status` with the same value mapping, in the
+same migration. `PatientRecord` is an audit of what an uploaded CSV row said, so it follows the
+vocabulary the CSV now speaks.
+
+### The patient CSV
+
+`PatientColumns.SPECIMEN_MUTATION_TYPE = 'Specimen Mutation type (Germline/Somatic)'` carries its
+vocabulary in the header text, so it becomes:
+
+```python
+SPECIMEN_TISSUE_STATUS = 'Specimen Tissue status (Reference/Affected/Unknown)'
+```
+
+`parse_choice` (`patients/import_records.py:119`) already accepts either the key or the display value in
+any case, so `R`, `Reference (unaffected)`, `AFFECTED` all parse without further work.
+
+Import validates that *every* column in `PatientColumns.COLUMNS` is present
+(`patients/import_records.py:455`) and raises otherwise, so a saved spreadsheet with the old header
+fails the import naming the column it is missing. That is the intended behaviour — Germline → Unknown
+is a loss of meaning rather than a translation, so silently reinterpreting an old column would be
+worse than making people re-download the template from `example_upload_csv_empty`
+(`patients/views.py:221`). The existing error message already names the missing column, so the failure
+says what to do.
+
+### Everything else in Part A
+
+- `patients/admin.py:20` — `mutation_type` → `tissue_status` in `list_display`.
+- `patients/forms.py:121` — nothing, the formset excludes only `external_pk`.
+- `patients/templates/patients/view_patient_record.html:53` — label and accessor.
+- `patients/models.py:533` — `SAMPLE_QUERYSET_PATH` entry, which drives the "download all samples as CSV"
+  round trip (`patients/views.py:230`).
+- `patients/tests/test_specimen_extraction.py:50` — uses `mutation_type=Mutation.SOMATIC`.
+
+---
+
+## Part B — pages, search, preview (#1706)
+
+### Permissions first
+
+`Specimen` and `Extraction` are plain `ExternallyManagedModel` (`patients/models.py:311`, `:363`): no
+guardian permissions of their own, which is right — a specimen's confidentiality is its patient's. The
+codebase already has the pattern for delegating, in `Trio` (`snpdb/models/models_cohort.py:780`, `:795`,
+`:800`):
+
+```python
+class Specimen(GuardianPermissionsMixin, ExternallyManagedModel, PreviewModelMixin):
+    @classmethod
+    def get_permission_class(cls):
+        return Patient
+
+    def get_permission_object(self):
+        return self.patient
+
+    @classmethod
+    def _filter_from_permission_object_qs(cls, queryset):
+        return cls.objects.filter(patient__in=queryset)
+```
+
+and `Extraction` the same through `specimen__patient__in`. That buys `can_view`, `can_write`,
+`check_can_view`, `filter_for_user` and `get_for_user` for free, and `get_for_user` loads the full
+instance where permissions delegate (`library/django_utils/guardian_permissions_mixin.py:99`), so the
+delegation resolves correctly.
+
+One wrinkle: `ExternallyManagedModel.can_write` already exists on both models and returns whether the
+external manager permits modification. `Patient` resolves the clash by ANDing the two
+(`patients/models.py:180`); do the same on both.
+
+This also lets `patients/views_autocomplete.py:26,40` drop their hand-rolled
+`filter(patient__in=Patient.filter_for_user(user))` for `Specimen.filter_for_user(user)`.
+
+### Pages
+
+Two views and two templates, plus URLs:
+
+```python
+path('view_specimen/<int:specimen_id>', views.view_specimen, name='view_specimen'),
+path('view_extraction/<int:extraction_id>', views.view_extraction, name='view_extraction'),
+```
+
+Each view is `Specimen.get_for_user(request.user, pk)`, a `ModelForm` with `set_form_read_only` where
+`can_write` is false, saved on POST — mirroring `view_patient` (`patients/views.py:33`). The fields are
+the same ones the patient tabs' formsets already edit, so the forms are a `modelform_factory` over the
+same field lists; the tabs stay as the bulk editor and the page is where one specimen lives.
+
+`external_pk` is excluded from both forms and shown read-only beside the editable fields, the way the
+specimen formset already excludes it (`patients/forms.py:121`). It is the tracking system's identity for
+the record and Phase 4's resolver keys on it, so it is displayed rather than typed — and
+`ExternallyManagedModel.can_write` separately locks the whole form where the external manager forbids
+modification, which `ExternalModelManager.explaination` (`patients/models.py:48`) already has text for.
+
+The specimen page shows: patient (linked), tissue, collection/received dates, age at collection,
+`tissue_status`, external PK where set, then a table of its extractions (linked) with their samples
+(linked). The extraction page shows: specimen (linked), patient (linked), reference, nucleic acid source,
+extraction date, and its samples — plus its `SequencingSample` rows, which Phase 1 already pointed here
+and Phase 4 will start populating.
+
+`get_absolute_url` on both, which is what `PreviewData.for_object` and every future link need.
+
+Add both URL names to the `patients` app's block in the settings URL register, so the shariant
+deployment that turns `patients` off (`variantgrid/settings/env/shariantcommon.py:193`) turns these off
+with it.
+
+### Preview
+
+`PreviewModelMixin` on both, following `Patient` (`patients/models.py:157`):
+
+- `preview_if_url_visible()` → `'patients'`, matching `Patient`, `Sample` and `ExternalPK`, so the
+  hover-cards vanish wherever the patients app is off.
+- `preview_icon()` — a vial for `Specimen`, a flask/droplet for `Extraction`. Distinct from `Patient`'s
+  `fa-solid fa-user-injured` and `Sample`'s `fa-solid fa-microscope`.
+- `preview` — identifier is `reference_id or external_pk or f"({pk})"`, title is the patient, and
+  `summary_extra` carries tissue status and collection date for a specimen, nucleic acid source and
+  extraction date for an extraction.
+
+### Search
+
+A new `patients/signals/specimen_search.py`, registered the way `patient_search.py` is. `HAS_3_ANY`
+rather than `HAS_3_ALPHA_MIN`, because a TSO 500 reference like `2600000001` is all digits.
+
+```python
+@search_receiver(search_type=Specimen, pattern=HAS_3_ANY,
+                 example=SearchExample(note="Specimen reference", examples=["2600000001"]))
+def specimen_search(search_input: SearchInputInstance):
+    yield Specimen.filter_for_user(search_input.user).filter(search_input.q_words('reference_id'))
+```
+
+and an extraction receiver over `reference_id` — matching what `ExtractionAutocompleteView` already
+searches (`patients/views_autocomplete.py:43`), which also searches `specimen__reference_id` so a
+container suffix and its parent both find it.
+
+Both go through `filter_for_user`, which Part B's first section just gave them. `ExternalPK` search
+(`patients/signals/external_pk_search.py`) walks a hardcoded `RELATED_OBJECT_FIELDS` list of
+`["case", "pathologytestorder", "patient"]` — add `specimen` and `extraction` so an external identifier
+finds them too.
+
+### Links each way
+
+- Patient page: the specimens and extractions tabs are formsets, so add a link out of each row to its
+  own page. (`patients/templates/patients/view_patient_specimens.html`,
+  `view_patient_extractions.html`.)
+- Specimen page → patient, extractions, samples. Extraction page → specimen, patient, samples.
+- Sample page (`snpdb/templates/snpdb/data/view_sample.html:73`) already has an extraction autocomplete;
+  give it a "View Extraction" cross-link beside the existing "View Patient" one (`:49`), the same
+  `setCrossLink` pattern.
+
+---
+
+## Order of work
+
+1. Part A's model change, migration and `ManualOperation` — it is the one ordering constraint in the
+   phase, since #1707 must serialize the field it is keeping.
+2. Part A's consumers: autopopulate, CSV, `PatientRecord`, admin, template.
+3. Part B's permission delegation.
+4. Part B's URLs, views, templates.
+5. Part B's preview and search.
+
+3–5 are views and templates on top of a settled model, so they parallelise with anything.
+
+## Tests
+
+- Extend `patients/tests/test_specimen_extraction.py`: the autopopulate truth table — reference+germline
+  → `germline`, anything+somatic-only → `somatic`, affected+mixed → unset — asserted against
+  `get_evidence_fields_for_sample_and_patient` rather than the helper, since that is where the
+  derivation now lives.
+- A migration test is not worth it, but a unit test that a `Specimen` created with no arguments comes
+  out `UNKNOWN` is, because that default is the whole point of the issue.
+- CSV round trip: the existing `process_record` tests in `test_specimen_extraction.py` cover the new
+  column, and `_make_row` builds from `PatientColumns.COLUMNS` so it follows the rename automatically.
+- `patients/tests/test_urls.py` already builds a specimen and an extraction in `setUpTestData`, so
+  `view_specimen` and `view_extraction` go straight into `PRIVATE_OBJECT_URL_NAMES_AND_KWARGS`, which
+  gives the 200-for-owner and 403-for-non-owner pair for free — and that 403 is the real test of the
+  permission delegation.
+
+## Done when
+
+A specimen has its own page, reachable from search and from the patient, and `tissue_status` has
+replaced `mutation_type` everywhere including the CSV — with a tumour block's classifications no longer
+stamped "Germline" by default.
+
+---
+
+## Settled
+
+- **The old CSV header is a hard break.** No alias — a spreadsheet carrying
+  `'Specimen Mutation type (Germline/Somatic)'` fails the import naming the missing column, and people
+  re-download the template. Germline → Unknown is a loss of meaning, so importing it silently would be
+  worse than failing.
+- **Whether `G` means anything is unknown**, so the migration keeps the `ManualOperation`. It is
+  registered only where a `PatientRecord` actually carries `G` — evidence the CSV column was populated
+  rather than defaulted — so on a deployment that never used it, no task appears and nothing is asked of
+  anyone.
+- **The pages are editable**, except `external_pk`, which is displayed read-only.
+- **`tissue_status` is per-specimen only.** Both arms of one block share the material, so it does not go
+  on `Extraction` the way `nucleic_acid_source` did.
+- **`Tissue` gets no page.** It is a lookup table; admin covers it.

--- a/patients/admin.py
+++ b/patients/admin.py
@@ -17,7 +17,7 @@ class TissueAdmin(ModelAdminBasics):
 
 @admin.register(models.Specimen)
 class SpecimenAdmin(ModelAdminBasics):
-    list_display = ("id", "reference_id", "patient", "tissue", "mutation_type", "collection_date")
+    list_display = ("id", "reference_id", "patient", "tissue", "tissue_status", "collection_date")
     search_fields = ("reference_id",)
 
 

--- a/patients/apps.py
+++ b/patients/apps.py
@@ -9,5 +9,5 @@ class PatientsConfig(AppConfig):
         # pylint: disable=import-outside-toplevel,unused-import
         # Registers receivers on import - noqa: F401 keeps the unused-import autofix from
         # silently unregistering them
-        from patients.signals import external_pk_search, patient_search  # noqa: F401
+        from patients.signals import external_pk_search, patient_search, specimen_search  # noqa: F401
         # pylint: enable=import-outside-toplevel,unused-import

--- a/patients/forms.py
+++ b/patients/forms.py
@@ -1,6 +1,6 @@
 from dal import forward
 from django import forms
-from django.forms.models import inlineformset_factory, modelformset_factory
+from django.forms.models import inlineformset_factory, modelform_factory, modelformset_factory
 from django.forms.widgets import TextInput
 
 from library.django_utils.autocomplete_utils import ModelSelect2
@@ -129,6 +129,22 @@ PatientSpecimenFormSet = inlineformset_factory(Patient,
                                                         'collection_date': TextInput(attrs={'class': 'date-picker'}),
                                                         'received_date': TextInput(attrs={'class': 'date-picker'})},
                                                extra=1)
+
+
+# The specimen/extraction pages edit the same fields as the patient tabs' formsets - the tabs stay the
+# bulk editor, external_pk is the tracking system's identity so both show it read only beside the form
+SpecimenForm = modelform_factory(Specimen,
+                                 exclude=['external_pk', 'patient'],
+                                 widgets={'description': TextInput(),
+                                          'reference_id': TextInput(),
+                                          'collected_by': TextInput(),
+                                          'collection_date': TextInput(attrs={'class': 'date-picker'}),
+                                          'received_date': TextInput(attrs={'class': 'date-picker'})})
+
+ExtractionForm = modelform_factory(Extraction,
+                                   fields=['reference_id', 'nucleic_acid_source', 'extraction_date'],
+                                   widgets={'reference_id': TextInput(),
+                                            'extraction_date': TextInput(attrs={'class': 'date-picker'})})
 
 
 def patient_extraction_formset_factory(patient):

--- a/patients/import_records.py
+++ b/patients/import_records.py
@@ -29,7 +29,7 @@ from patients.models import (
     PatientRecordOriginType,
     Specimen,
 )
-from patients.models_enums import Mutation, NucleicAcid, PatientRecordMatchType, Sex
+from patients.models_enums import NucleicAcid, PatientRecordMatchType, Sex, TissueStatus
 from snpdb.models import Sample
 
 UNKNOWN_STRING = 'UNKNOWN'  # Upper
@@ -238,7 +238,7 @@ def process_record(patient_records, record_id, row):
     specimen_collected_by = row[PatientColumns.SPECIMEN_COLLECTED_BY]
     specimen_collection_date = parse_date(row, PatientColumns.SPECIMEN_COLLECTION_DATE, validation_messages)
     specimen_received_date = parse_date(row, PatientColumns.SPECIMEN_RECEIVED_DATE, validation_messages)
-    specimen_mutation_type = parse_choice(Mutation.choices, row, PatientColumns.SPECIMEN_MUTATION_TYPE, validation_messages)
+    specimen_tissue_status = parse_choice(TissueStatus.choices, row, PatientColumns.SPECIMEN_TISSUE_STATUS, validation_messages)
     specimen_nucleic_acid_source = parse_choice(NucleicAcid.choices, row, PatientColumns.SPECIMEN_NUCLEIC_ACID_SOURCE, validation_messages)
     specimen_age_at_collection = row[PatientColumns.SPECIMEN_AGE_AT_COLLECTION_DATE]
 
@@ -360,7 +360,8 @@ def process_record(patient_records, record_id, row):
             #tissue=tissue,
             "collection_date": specimen_collection_date,
             "received_date": specimen_received_date,
-            "mutation_type": specimen_mutation_type,
+            # tissue_status is never null - a blank column means Unknown rather than "no answer"
+            "tissue_status": specimen_tissue_status or TissueStatus.UNKNOWN,
             "_age_at_collection_date": specimen_age_at_collection
         }
         changed = set_fields_if_blank(specimen, field_values)
@@ -370,7 +371,7 @@ def process_record(patient_records, record_id, row):
             specimen.patient = patient
             specimen.collection_date = specimen_collection_date
             specimen.received_date = specimen_received_date
-            specimen.mutation_type = specimen_mutation_type
+            specimen.tissue_status = specimen_tissue_status or TissueStatus.UNKNOWN
             specimen._age_at_collection_date = specimen_age_at_collection
 
             specimen.save()
@@ -416,7 +417,7 @@ def process_record(patient_records, record_id, row):
                                  specimen_collected_by=specimen_collected_by,
                                  specimen_collection_date=specimen_collection_date,
                                  specimen_received_date=specimen_received_date,
-                                 specimen_mutation_type=specimen_mutation_type,
+                                 specimen_tissue_status=specimen_tissue_status,
                                  specimen_nucleic_acid_source=specimen_nucleic_acid_source,
                                  specimen_age_at_collection_date=specimen_age_at_collection)
 

--- a/patients/migrations/0016_specimen_tissue_status.py
+++ b/patients/migrations/0016_specimen_tissue_status.py
@@ -1,0 +1,70 @@
+# Specimen.mutation_type -> Specimen.tissue_status - @see variantgrid_private#2447
+
+from django.db import migrations, models
+
+from manual.operations.manual_operations import ManualOperation
+
+_MUTATION_SOMATIC = 'S'
+_MUTATION_GERMLINE = 'G'
+_TISSUE_STATUS_AFFECTED = 'A'
+_TISSUE_STATUS_UNKNOWN = 'U'
+
+
+def _mutation_type_to_tissue_status(apps, _schema_editor):
+    """ Somatic means a tumour block was declared. Germline was the field default, so a 'G' can't be
+        told apart from nobody touching it - it becomes Unknown and the ManualOperation below asks a
+        human to look at deployments that actually populated the column """
+    Specimen = apps.get_model("patients", "Specimen")
+    # Everything else is already Unknown from the field default the AddField above applied
+    Specimen.objects.filter(mutation_type=_MUTATION_SOMATIC).update(tissue_status=_TISSUE_STATUS_AFFECTED)
+
+    PatientRecord = apps.get_model("patients", "PatientRecord")
+    PatientRecord.objects.filter(specimen_mutation_type=_MUTATION_SOMATIC).update(
+        specimen_tissue_status=_TISSUE_STATUS_AFFECTED)
+    PatientRecord.objects.filter(specimen_mutation_type=_MUTATION_GERMLINE).update(
+        specimen_tissue_status=_TISSUE_STATUS_UNKNOWN)
+
+
+def _has_declared_germline_specimens(apps):
+    """ A PatientRecord carrying 'G' is evidence the CSV column was populated rather than defaulted,
+        so those specimens are worth a human deciding whether they meant Reference """
+    PatientRecord = apps.get_model("patients", "PatientRecord")
+    return PatientRecord.objects.filter(specimen_mutation_type=_MUTATION_GERMLINE).exists()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("patients", "0015_extraction_reference_id"),
+        ("manual", "0002_deployment"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="specimen",
+            name="tissue_status",
+            field=models.CharField(choices=[('R', 'Reference (unaffected)'), ('A', 'Affected / lesional'),
+                                            ('U', 'Unknown')], default='U', max_length=1),
+        ),
+        migrations.AddField(
+            model_name="patientrecord",
+            name="specimen_tissue_status",
+            field=models.CharField(choices=[('R', 'Reference (unaffected)'), ('A', 'Affected / lesional'),
+                                            ('U', 'Unknown')], max_length=1, null=True),
+        ),
+        migrations.RunPython(_mutation_type_to_tissue_status, migrations.RunPython.noop),
+        ManualOperation.operation_other(
+            args=["Review specimens whose patient CSV declared 'Germline' - they became tissue status "
+                  "Unknown, and want setting to Reference where the material really was unaffected"],
+            note="Only registered where a PatientRecord carries 'G', ie the column was populated rather "
+                 "than left at the old field default (variantgrid_private#2447)",
+            test=_has_declared_germline_specimens),
+        migrations.RemoveField(
+            model_name="specimen",
+            name="mutation_type",
+        ),
+        migrations.RemoveField(
+            model_name="patientrecord",
+            name="specimen_mutation_type",
+        ),
+    ]

--- a/patients/models.py
+++ b/patients/models.py
@@ -24,11 +24,11 @@ from library.enums.titles import Title
 from library.preview_request import PreviewData, PreviewKeyValue, PreviewModelMixin
 from library.utils import calculate_age
 from patients.models_enums import (
-    Mutation,
     NucleicAcid,
     PatientRecordMatchType,
     PopulationGroup,
     Sex,
+    TissueStatus,
 )
 
 TEST_PATIENT_KWARGS = {"first_name": "PATIENT", "last_name": "TESTPATIENT"}
@@ -308,7 +308,7 @@ class Tissue(TimeStampedModel):
         return self.name
 
 
-class Specimen(ExternallyManagedModel):
+class Specimen(GuardianPermissionsMixin, ExternallyManagedModel, PreviewModelMixin):
     """ Biological material collected from a patient - one tissue at one timepoint (block, blood draw).
         The nucleic acid taken off it lives on Extraction below """
     reference_id = models.TextField()
@@ -318,12 +318,51 @@ class Specimen(ExternallyManagedModel):
     tissue = models.ForeignKey(Tissue, null=True, blank=True, on_delete=SET_NULL)
     collection_date = models.DateTimeField(null=True, blank=True)
     received_date = models.DateTimeField(null=True, blank=True)
-    mutation_type = models.CharField(max_length=1, choices=Mutation.choices, default=Mutation.GERMLINE, null=True, blank=True)
+    # Per-specimen rather than per-tissue - the same tissue plays different roles in different tests
+    tissue_status = models.CharField(max_length=1, choices=TissueStatus.choices, default=TissueStatus.UNKNOWN)
     # See note on patient / sample ages and dates above Patient model
     _age_at_collection_date = models.IntegerField(null=True, blank=True)
 
     class Meta:
         unique_together = ("patient", "reference_id")
+
+    @classmethod
+    def get_permission_class(cls):
+        return Patient
+
+    def get_permission_object(self):
+        # A specimen's confidentiality is its patient's
+        return self.patient
+
+    @classmethod
+    def _filter_from_permission_object_qs(cls, queryset):
+        return cls.objects.filter(patient__in=queryset)
+
+    def can_write(self, user) -> bool:
+        return ExternallyManagedModel.can_write(self, user) and GuardianPermissionsMixin.can_write(self, user)
+
+    @classmethod
+    def preview_icon(cls) -> str:
+        return "fa-solid fa-vial"
+
+    @classmethod
+    def preview_if_url_visible(cls) -> Optional[str]:
+        return 'patients'
+
+    @property
+    def preview(self) -> PreviewData:
+        parts = [PreviewKeyValue(key="Tissue status", value=self.get_tissue_status_display())]
+        if self.collection_date:
+            parts.append(PreviewKeyValue(key="Collected", value=self.collection_date))
+
+        return self.preview_with(
+            identifier=self.reference_id or self.external_pk or f"({self.pk})",
+            title=str(self.patient),
+            summary_extra=parts
+        )
+
+    def get_absolute_url(self):
+        return reverse('view_specimen', kwargs={"specimen_id": self.pk})
 
     @property
     def age_at_collection_date(self):
@@ -360,7 +399,7 @@ class Specimen(ExternallyManagedModel):
         return s
 
 
-class Extraction(ExternallyManagedModel):
+class Extraction(GuardianPermissionsMixin, ExternallyManagedModel, PreviewModelMixin):
     """ Nucleic acid taken off a Specimen - eg the DNA arm and the RNA arm of one tumour block.
         One extraction can be sequenced more than once (repeats, top-ups) so SequencingSample
         points here rather than the other way around """
@@ -375,6 +414,45 @@ class Extraction(ExternallyManagedModel):
         # Unnamed extractions are all distinct under Postgres, which is what the re-extraction
         # case wants - extraction_date tells those apart
         unique_together = ("specimen", "reference_id")
+
+    @classmethod
+    def get_permission_class(cls):
+        return Patient
+
+    def get_permission_object(self):
+        return self.specimen.patient
+
+    @classmethod
+    def _filter_from_permission_object_qs(cls, queryset):
+        return cls.objects.filter(specimen__patient__in=queryset)
+
+    def can_write(self, user) -> bool:
+        return ExternallyManagedModel.can_write(self, user) and GuardianPermissionsMixin.can_write(self, user)
+
+    @classmethod
+    def preview_icon(cls) -> str:
+        return "fa-solid fa-flask"
+
+    @classmethod
+    def preview_if_url_visible(cls) -> Optional[str]:
+        return 'patients'
+
+    @property
+    def preview(self) -> PreviewData:
+        parts = []
+        if self.nucleic_acid_source:
+            parts.append(PreviewKeyValue(key="Nucleic acid", value=self.get_nucleic_acid_source_display()))
+        if self.extraction_date:
+            parts.append(PreviewKeyValue(key="Extracted", value=self.extraction_date))
+
+        return self.preview_with(
+            identifier=self.reference_id or self.external_pk or f"({self.pk})",
+            title=str(self.specimen.patient),
+            summary_extra=parts
+        )
+
+    def get_absolute_url(self):
+        return reverse('view_extraction', kwargs={"extraction_id": self.pk})
 
     def __str__(self):
         s = self.reference_id or str(self.specimen)
@@ -481,7 +559,7 @@ class PatientColumns:
     SPECIMEN_COLLECTED_BY = 'Specimen Collected by'
     SPECIMEN_COLLECTION_DATE = 'Specimen Collection date'
     SPECIMEN_RECEIVED_DATE = 'Specimen Received date'
-    SPECIMEN_MUTATION_TYPE = 'Specimen Mutation type (Germline/Somatic)'
+    SPECIMEN_TISSUE_STATUS = 'Specimen Tissue status (Reference/Affected/Unknown)'
     SPECIMEN_NUCLEIC_ACID_SOURCE = 'Specimen Nucleic acid source (DNA/RNA)'
     SPECIMEN_AGE_AT_COLLECTION_DATE = 'Age at collection date (mutually exclusive to date of birth)'
 
@@ -504,7 +582,7 @@ class PatientColumns:
         (SPECIMEN_COLLECTED_BY, "String", ""),
         (SPECIMEN_COLLECTION_DATE, "Date", ""),
         (SPECIMEN_RECEIVED_DATE, "Date", ""),
-        (SPECIMEN_MUTATION_TYPE, "Mutation Type", ""),
+        (SPECIMEN_TISSUE_STATUS, "Tissue Status", "Role the material plays in the test"),
         (SPECIMEN_NUCLEIC_ACID_SOURCE, "Nucleic Acid Source", ""),
         (SPECIMEN_AGE_AT_COLLECTION_DATE, "Int", "Only use this column if date of birth is unavailable"),
     ]
@@ -530,7 +608,7 @@ class PatientColumns:
         SPECIMEN_COLLECTED_BY: "extraction__specimen__collected_by",
         SPECIMEN_COLLECTION_DATE: "extraction__specimen__collection_date",
         SPECIMEN_RECEIVED_DATE: "extraction__specimen__received_date",
-        SPECIMEN_MUTATION_TYPE: "extraction__specimen__mutation_type",
+        SPECIMEN_TISSUE_STATUS: "extraction__specimen__tissue_status",
         SPECIMEN_NUCLEIC_ACID_SOURCE: "extraction__nucleic_acid_source",
         SPECIMEN_AGE_AT_COLLECTION_DATE: "extraction__specimen___age_at_collection_date",
     }
@@ -659,7 +737,7 @@ class PatientRecord(TimeStampedModel):
     specimen_collected_by = models.TextField(null=True)
     specimen_collection_date = models.TextField(null=True)
     specimen_received_date = models.TextField(null=True)
-    specimen_mutation_type = models.CharField(max_length=1, choices=Mutation.choices, null=True)
+    specimen_tissue_status = models.CharField(max_length=1, choices=TissueStatus.choices, null=True)
     specimen_nucleic_acid_source = models.CharField(max_length=1, choices=NucleicAcid.choices, null=True)
     specimen_age_at_collection_date = models.IntegerField(null=True, blank=True)
 

--- a/patients/models_enums.py
+++ b/patients/models_enums.py
@@ -9,9 +9,12 @@ class NucleicAcid(models.TextChoices):
     RNA = 'R', 'RNA'
 
 
-class Mutation(models.TextChoices):
-    GERMLINE = 'G', 'Germline'
-    SOMATIC = 'S', 'Somatic'
+class TissueStatus(models.TextChoices):
+    """ What role the material plays in the test - the same tissue can be either, eg blood is the
+        reference in a solid tumour workup and is the tumour in leukaemia """
+    REFERENCE = 'R', 'Reference (unaffected)'
+    AFFECTED = 'A', 'Affected / lesional'
+    UNKNOWN = 'U', 'Unknown'
 
 
 class SimpleZygosity(models.TextChoices):

--- a/patients/signals/external_pk_search.py
+++ b/patients/signals/external_pk_search.py
@@ -15,7 +15,7 @@ from snpdb.search import HAS_ALPHA_PATTERN, SearchExample, SearchInputInstance, 
 def search_external_pk(search_input: SearchInputInstance):
     # TODO test me
     # Returns related objects
-    RELATED_OBJECT_FIELDS = ["case", "pathologytestorder", "patient"]
+    RELATED_OBJECT_FIELDS = ["case", "pathologytestorder", "patient", "specimen", "extraction"]
     for external_pk in ExternalPK.objects.filter(code__iexact=search_input.search_string):
         for f in RELATED_OBJECT_FIELDS:
             try:

--- a/patients/signals/specimen_search.py
+++ b/patients/signals/specimen_search.py
@@ -1,0 +1,29 @@
+from patients.models import Extraction, Specimen
+from snpdb.search import HAS_3_ANY, SearchExample, SearchInputInstance, search_receiver
+
+
+@search_receiver(
+    search_type=Specimen,
+    # HAS_3_ANY rather than alpha - a TSO 500 specimen reference is all digits
+    pattern=HAS_3_ANY,
+    example=SearchExample(
+        note="Specimen reference",
+        examples=["2600000001"]
+    )
+)
+def specimen_search(search_input: SearchInputInstance):
+    yield Specimen.filter_for_user(search_input.user).filter(search_input.q_words('reference_id'))
+
+
+@search_receiver(
+    search_type=Extraction,
+    pattern=HAS_3_ANY,
+    example=SearchExample(
+        note="Extraction reference, or the reference of its specimen",
+        examples=["2600000001C"]
+    )
+)
+def extraction_search(search_input: SearchInputInstance):
+    """ An extraction may be referred to by its own reference (eg a container suffix), or its specimen's """
+    q_reference = search_input.q_words('reference_id') | search_input.q_words('specimen__reference_id')
+    yield Extraction.filter_for_user(search_input.user).filter(q_reference)

--- a/patients/templates/patients/view_extraction.html
+++ b/patients/templates/patients/view_extraction.html
@@ -1,0 +1,78 @@
+{% extends menu_patients_base %}
+{% load ui_utils %}
+{% load crispy_forms_tags %}
+{% block title %}Extraction {{ extraction }}{% endblock title %}
+{% block head %}
+<script>
+    $(document).ready(() => {
+        $(".date-picker").datepicker({changeYear: true, yearRange: "-120:+0"});
+    });
+</script>
+{% endblock head %}
+
+{% block submenu_page_content %}
+    <div class="container">
+        <h3>Extraction: {{ extraction }} {% admin_link extraction %}</h3>
+
+        {% labelled label="Specimen" %}
+            <a href="{% url 'view_specimen' extraction.specimen_id %}">{{ extraction.specimen }}</a>
+        {% endlabelled %}
+        {% labelled label="Patient" %}
+            <a href="{% url 'view_patient' extraction.specimen.patient_id %}">{{ extraction.specimen.patient }}</a>
+        {% endlabelled %}
+        {% labelled label="External ID" %}{{ extraction.external_pk|default:"-" }}{% endlabelled %}
+        {% if extraction.external_manager %}
+            {% labelled label="Externally managed" %}{{ extraction.external_manager.explaination }}{% endlabelled %}
+        {% endif %}
+
+        <form method="post" id="extraction-form">
+            {% csrf_token %}
+            {% crispy form form_helper.horizontal %}
+            {% if has_write_permission %}
+                <button id="save-extraction" class="btn btn-primary">Save</button>
+                <button type="reset" class="btn btn-secondary">Reset</button>
+            {% else %}
+                You can view but not modify this extraction.
+            {% endif %}
+        </form>
+
+        <hr/>
+        <h4>Samples</h4>
+        {% if samples %}
+            <table class="table">
+                <thead>
+                    <tr><th>Sample<th>VCF<th>Variants type</tr>
+                </thead>
+                <tbody>
+                {% for sample in samples %}
+                    <tr>
+                        <td><a href="{% url 'view_sample' sample.pk %}">{{ sample.name }}</a>
+                        <td>{{ sample.vcf }}
+                        <td>{{ sample.get_variants_type_display }}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p>This extraction has no samples.</p>
+        {% endif %}
+
+        {% if sequencing_samples %}
+            <h4>Sequencing Samples</h4>
+            <table class="table">
+                <thead>
+                    <tr><th>Sequencing sample<th>Sample sheet<th>Enrichment kit</tr>
+                </thead>
+                <tbody>
+                {% for sequencing_sample in sequencing_samples %}
+                    <tr>
+                        <td>{{ sequencing_sample.sample_name }}
+                        <td>{{ sequencing_sample.sample_sheet }}
+                        <td>{{ sequencing_sample.enrichment_kit|default:"-" }}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
+{% endblock submenu_page_content %}

--- a/patients/templates/patients/view_patient_extractions.html
+++ b/patients/templates/patients/view_patient_extractions.html
@@ -22,6 +22,14 @@
         });
     </script>
     <div class="container">
+        {% if extraction_formset.queryset %}
+            <div class="mb-2">
+                Extraction pages:
+                {% for extraction in extraction_formset.queryset %}
+                    <a href="{% url 'view_extraction' extraction.pk %}">{{ extraction }}</a>{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
         <form id="patient-extractions-form" method="post" action="{% url 'view_patient_extractions' patient.pk %}">
             {% csrf_token %}
             {% crispy extraction_formset form_helper.horizontal %}

--- a/patients/templates/patients/view_patient_record.html
+++ b/patients/templates/patients/view_patient_record.html
@@ -50,7 +50,7 @@
                 {% labelled label="Specimen Collected By" %}{{ patient_record.specimen_collected_by }}{% endlabelled %}
                 {% labelled label="Specimen Collected Date" %}{{ patient_record.specimen_collection_date }}{% endlabelled %}
                 {% labelled label="Specimen Received Date" %}{{ patient_record.specimen_received_date }}{% endlabelled %}
-                {% labelled label="Specimen Mutation Type" %}{{ patient_record.get_specimen_mutation_type_display }}{% endlabelled %}
+                {% labelled label="Specimen Tissue Status" %}{{ patient_record.get_specimen_tissue_status_display }}{% endlabelled %}
                 {% labelled label="Specimen Nucleic Acid Source" %}{{ patient_record.get_specimen_nucleic_acid_source_display }}{% endlabelled %}
                 {% labelled label="Specimen Age at collection" %}{{ patient_record.specimen_age_at_collection_date }}{% endlabelled %}
             </div>

--- a/patients/templates/patients/view_patient_specimens.html
+++ b/patients/templates/patients/view_patient_specimens.html
@@ -22,6 +22,14 @@
         });
     </script>
     <div class="container">
+        {% if specimen_formset.queryset %}
+            <div class="mb-2">
+                Specimen pages:
+                {% for specimen in specimen_formset.queryset %}
+                    <a href="{% url 'view_specimen' specimen.pk %}">{{ specimen.reference_id }}</a>{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
         <form id="patient-specimens-form" method="post" action="{% url 'view_patient_specimens' patient.pk %}">
             {% csrf_token %}
             {% crispy specimen_formset form_helper.horizontal %}

--- a/patients/templates/patients/view_specimen.html
+++ b/patients/templates/patients/view_specimen.html
@@ -1,0 +1,64 @@
+{% extends menu_patients_base %}
+{% load ui_utils %}
+{% load crispy_forms_tags %}
+{% block title %}Specimen {{ specimen.reference_id }}{% endblock title %}
+{% block head %}
+<script>
+    $(document).ready(() => {
+        $(".date-picker").datepicker({changeYear: true, yearRange: "-120:+0"});
+    });
+</script>
+{% endblock head %}
+
+{% block submenu_page_content %}
+    <div class="container">
+        <h3>Specimen: {{ specimen.reference_id }} {% admin_link specimen %}</h3>
+
+        {% labelled label="Patient" %}
+            <a href="{% url 'view_patient' specimen.patient_id %}">{{ specimen.patient }}</a>
+        {% endlabelled %}
+        {% labelled label="External ID" %}{{ specimen.external_pk|default:"-" }}{% endlabelled %}
+        {% if specimen.external_manager %}
+            {% labelled label="Externally managed" %}{{ specimen.external_manager.explaination }}{% endlabelled %}
+        {% endif %}
+        {% labelled label="Age at collection" %}{{ specimen.age_at_collection_date|default_if_none:"-" }}{% endlabelled %}
+
+        <form method="post" id="specimen-form">
+            {% csrf_token %}
+            {% crispy form form_helper.horizontal %}
+            {% if has_write_permission %}
+                <button id="save-specimen" class="btn btn-primary">Save</button>
+                <button type="reset" class="btn btn-secondary">Reset</button>
+            {% else %}
+                You can view but not modify this specimen.
+            {% endif %}
+        </form>
+
+        <hr/>
+        <h4>Extractions</h4>
+        {% if extractions %}
+            <table class="table">
+                <thead>
+                    <tr><th>Extraction<th>Nucleic acid source<th>Extraction date<th>Samples</tr>
+                </thead>
+                <tbody>
+                {% for extraction in extractions %}
+                    <tr>
+                        <td><a href="{% url 'view_extraction' extraction.pk %}">{{ extraction.reference_id|default:extraction.pk }}</a>
+                        <td>{{ extraction.get_nucleic_acid_source_display|default:"-" }}
+                        <td>{{ extraction.extraction_date|default_if_none:"-" }}
+                        <td>
+                            {% for sample in extraction.sample_set.all %}
+                                <a href="{% url 'view_sample' sample.pk %}">{{ sample.name }}</a>{% if not forloop.last %}, {% endif %}
+                            {% empty %}
+                                -
+                            {% endfor %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p>This specimen has no extractions.</p>
+        {% endif %}
+    </div>
+{% endblock submenu_page_content %}

--- a/patients/tests/test_specimen_extraction.py
+++ b/patients/tests/test_specimen_extraction.py
@@ -1,5 +1,5 @@
 """
-Specimen -> Extraction -> Sample (#1704)
+Specimen -> Extraction -> Sample (#1704), and Specimen.tissue_status (variantgrid_private#2447)
 """
 import os
 from datetime import datetime
@@ -8,6 +8,10 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.utils import timezone
 
+from classification.autopopulate_evidence_keys.evidence_from_sample_and_patient import (
+    get_evidence_fields_for_sample_and_patient,
+)
+from classification.enums import SpecialEKeys
 from library.guardian_utils import assign_permission_to_user_and_groups
 from patients.import_records import process_record
 from patients.models import (
@@ -17,12 +21,14 @@ from patients.models import (
     Patient,
     PatientColumns,
     PatientImport,
+    PatientRecord,
     PatientRecords,
     Specimen,
 )
-from patients.models_enums import Mutation, NucleicAcid
+from patients.models_enums import NucleicAcid, TissueStatus
 from patients.views_autocomplete import ExtractionAutocompleteView, SpecimenAutocompleteView
 from snpdb.models import VCF, GenomeBuild, ImportSource, ImportStatus, Sample
+from snpdb.models.models_enums import VariantsType
 from upload.models import FileUpload, UploadedFileTypes, UploadedPatientRecords
 
 _FAKE_CSV = os.path.join(os.path.dirname(__file__), "test_data", "fake_patient_records.csv")
@@ -47,7 +53,7 @@ class TestSpecimenExtraction(TestCase):
         cls.patient = Patient.objects.create(first_name="DNARNA", last_name="PATIENT")
         assign_permission_to_user_and_groups(cls.user, cls.patient)
         cls.specimen = Specimen.objects.create(reference_id="2600000001", patient=cls.patient,
-                                               mutation_type=Mutation.SOMATIC)
+                                               tissue_status=TissueStatus.AFFECTED)
         cls.dna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001C",
                                             nucleic_acid_source=NucleicAcid.DNA)
         cls.rna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000001B",
@@ -120,6 +126,97 @@ class TestSpecimenExtraction(TestCase):
         for obj in (self.patient, self.specimen, self.dna):
             self.assertIsNotNone(obj.created, f"{type(obj).__name__} has no created")
             self.assertIsNotNone(obj.modified, f"{type(obj).__name__} has no modified")
+
+
+class TestSpecimenTissueStatus(TestCase):
+    """ variantgrid_private#2447 - a specimen nobody has described says so, rather than defaulting to
+        a Germline claim that autopopulate then stamps on every classification """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = User.objects.create_user("tissue_status_user", password="x")
+        cls.patient = Patient.objects.create(first_name="TISSUE", last_name="PATIENT")
+        assign_permission_to_user_and_groups(cls.user, cls.patient)
+
+        genome_build = GenomeBuild.get_name_or_alias("GRCh37")
+        cls.vcf = VCF.objects.create(name="tissue_status.vcf", genotype_samples=1, genome_build=genome_build,
+                                     import_status=ImportStatus.SUCCESS, user=cls.user, date=timezone.now())
+
+    def test_unset_tissue_status_is_unknown(self):
+        specimen = Specimen.objects.create(reference_id="UNDESCRIBED", patient=self.patient)
+        self.assertEqual(specimen.tissue_status, TissueStatus.UNKNOWN)
+
+    def _allele_origin(self, tissue_status, variants_type):
+        specimen = Specimen.objects.create(reference_id=f"{tissue_status}{variants_type}",
+                                           patient=self.patient, tissue_status=tissue_status)
+        extraction = Extraction.objects.create(specimen=specimen, nucleic_acid_source=NucleicAcid.DNA)
+        sample = Sample.objects.create(name=f"sample_{tissue_status}{variants_type}", vcf=self.vcf,
+                                       patient=self.patient, extraction=extraction,
+                                       variants_type=variants_type)
+        data = get_evidence_fields_for_sample_and_patient(None, sample)
+        return data[SpecialEKeys.ALLELE_ORIGIN]
+
+    def test_reference_specimen_germline_call_set_is_germline(self):
+        self.assertEqual(self._allele_origin(TissueStatus.REFERENCE, VariantsType.GERMLINE), "germline")
+
+    def test_somatic_only_call_set_is_somatic_whatever_the_tissue(self):
+        for tissue_status in TissueStatus:
+            self.assertEqual(self._allele_origin(tissue_status, VariantsType.SOMATIC_ONLY), "somatic",
+                             f"{tissue_status} + somatic only")
+
+    def test_affected_specimen_mixed_call_set_is_unset(self):
+        """ A tumour sample carrying both origins is per-variant, so the curator decides """
+        self.assertIsNone(self._allele_origin(TissueStatus.AFFECTED, VariantsType.MIXED))
+
+    def test_unknown_tissue_germline_call_set_is_unset(self):
+        self.assertIsNone(self._allele_origin(TissueStatus.UNKNOWN, VariantsType.GERMLINE))
+
+    def test_affected_specimen_germline_call_set_is_unset(self):
+        self.assertIsNone(self._allele_origin(TissueStatus.AFFECTED, VariantsType.GERMLINE))
+
+    def test_sample_without_extraction_is_unset(self):
+        sample = Sample.objects.create(name="no_extraction", vcf=self.vcf, patient=self.patient,
+                                       variants_type=VariantsType.GERMLINE)
+        data = get_evidence_fields_for_sample_and_patient(None, sample)
+        self.assertIsNone(data[SpecialEKeys.ALLELE_ORIGIN])
+
+
+class TestSpecimenExtractionPermissions(TestCase):
+    """ #1706 - both delegate to their patient, which is where a specimen's confidentiality lives """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.owner = User.objects.create_user("specimen_owner", password="x")
+        cls.other_user = User.objects.create_user("specimen_other", password="x")
+        cls.patient = Patient.objects.create(first_name="PERM", last_name="PATIENT")
+        assign_permission_to_user_and_groups(cls.owner, cls.patient)
+
+        cls.specimen = Specimen.objects.create(reference_id="PERMSPEC", patient=cls.patient)
+        cls.extraction = Extraction.objects.create(specimen=cls.specimen, reference_id="PERMSPECC")
+
+    def test_owner_sees_them(self):
+        self.assertEqual(list(Specimen.filter_for_user(self.owner)), [self.specimen])
+        self.assertEqual(list(Extraction.filter_for_user(self.owner)), [self.extraction])
+        self.assertTrue(self.specimen.can_view(self.owner))
+        self.assertTrue(self.extraction.can_view(self.owner))
+
+    def test_other_user_sees_nothing(self):
+        self.assertEqual(list(Specimen.filter_for_user(self.other_user)), [])
+        self.assertEqual(list(Extraction.filter_for_user(self.other_user)), [])
+        self.assertFalse(self.specimen.can_view(self.other_user))
+        self.assertFalse(self.extraction.can_view(self.other_user))
+
+    def test_external_manager_blocks_writes(self):
+        """ ExternallyManagedModel.can_write is ANDed with the patient's guardian permission """
+        self.assertTrue(self.specimen.can_write(self.owner))
+
+        external_manager = ExternalModelManager.objects.create(name="read_only_lims", can_modify=False)
+        self.specimen.external_pk = ExternalPK.objects.create(code="LIMS-SPEC-1", external_type="specimen",
+                                                              external_manager=external_manager)
+        self.specimen.save()
+        self.assertFalse(self.specimen.can_write(self.owner))
 
 
 class TestPatientCSVExtractionRoundTrip(TestCase):
@@ -196,6 +293,21 @@ class TestPatientCSVExtractionRoundTrip(TestCase):
         self.assertEqual(self.sample.extraction.specimen.reference_id, "CSVSPEC001")
         self.assertIsNone(self.sample.extraction.nucleic_acid_source)
 
+    def test_tissue_status_column_parses_display_value(self):
+        """ parse_choice takes the key or the display value in any case """
+        self._import_row(**{PatientColumns.SPECIMEN_TISSUE_STATUS: "affected / lesional"})
+
+        specimen = Specimen.objects.get(reference_id="CSVSPEC001")
+        self.assertEqual(specimen.tissue_status, TissueStatus.AFFECTED)
+        record = PatientRecord.objects.get(specimen=specimen)
+        self.assertEqual(record.specimen_tissue_status, TissueStatus.AFFECTED)
+
+    def test_blank_tissue_status_column_is_unknown(self):
+        self._import_row()
+
+        specimen = Specimen.objects.get(reference_id="CSVSPEC001")
+        self.assertEqual(specimen.tissue_status, TissueStatus.UNKNOWN)
+
     def test_export_columns_round_trip(self):
         """ The CSV written back out reads the same values through the new relations """
         self._import_row()
@@ -207,6 +319,8 @@ class TestPatientCSVExtractionRoundTrip(TestCase):
                          "left femur")
         self.assertEqual(values[PatientColumns.SAMPLE_QUERYSET_PATH[PatientColumns.SPECIMEN_NUCLEIC_ACID_SOURCE]],
                          NucleicAcid.DNA)
+        self.assertEqual(values[PatientColumns.SAMPLE_QUERYSET_PATH[PatientColumns.SPECIMEN_TISSUE_STATUS]],
+                         TissueStatus.UNKNOWN)
 
 
 class TestAutocompleteForwarding(TestCase):

--- a/patients/tests/test_urls.py
+++ b/patients/tests/test_urls.py
@@ -59,6 +59,8 @@ class Test(URLTestCase):
             # ('view_patient_contact_tab', patient_kwargs, 200),
             ('view_patient_specimens', patient_kwargs, 200),
             ('view_patient_extractions', patient_kwargs, 200),
+            ('view_specimen', {"specimen_id": cls.specimen.pk}, 200),
+            ('view_extraction', {"extraction_id": cls.extraction.pk}, 200),
             ('view_patient_genes', patient_kwargs, 200),
             ('view_patient_modifications', patient_kwargs, 200),
             ('view_patient_import', {"patient_records_id": patient_records.pk}, 200),

--- a/patients/urls.py
+++ b/patients/urls.py
@@ -24,6 +24,8 @@ urlpatterns = [
     path('view_patient/contact/<int:patient_id>', views.view_patient_contact_tab, name='view_patient_contact_tab'),
     path('view_patient/patient_specimens/<int:patient_id>', views.view_patient_specimens, name='view_patient_specimens'),
     path('view_patient/patient_extractions/<int:patient_id>', views.view_patient_extractions, name='view_patient_extractions'),
+    path('view_specimen/<int:specimen_id>', views.view_specimen, name='view_specimen'),
+    path('view_extraction/<int:extraction_id>', views.view_extraction, name='view_extraction'),
     path('view_patient/genes/<int:patient_id>', views.view_patient_genes, name='view_patient_genes'),
     path('view_patient/modifications/<int:patient_id>', views.view_patient_modifications, name='view_patient_modifications'),
 

--- a/patients/views.py
+++ b/patients/views.py
@@ -2,6 +2,7 @@ import mimetypes
 
 import pandas as pd
 from django.conf import settings
+from django.db.models import Prefetch
 from django.http.response import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_http_methods, require_POST
@@ -25,6 +26,7 @@ from patients.models import (
     PatientRecord,
     PatientRecordOriginType,
     PatientRecords,
+    Specimen,
 )
 from snpdb.models import Sample
 from uicore.utils.form_helpers import form_helper_horizontal
@@ -119,6 +121,53 @@ def view_patient_extractions(request, patient_id):
                "extraction_formset": _patient_extraction_formset(patient),
                "has_write_permission": patient.can_write(request.user)}
     return render(request, 'patients/view_patient_extractions.html', context)
+
+
+def view_specimen(request, specimen_id):
+    specimen = Specimen.get_for_user(request.user, specimen_id)
+    form = forms.SpecimenForm(request.POST or None, instance=specimen)
+    form.helper = form_helper_horizontal()
+
+    has_write_permission = specimen.can_write(request.user)
+    if not has_write_permission:
+        set_form_read_only(form)
+
+    if request.method == "POST":
+        valid = form.is_valid()
+        if valid:
+            specimen = form.save()
+        add_save_message(request, valid, "Specimen")
+
+    # Samples carry their VCF's permissions, so they're filtered separately to the specimen's own
+    visible_samples = Prefetch("sample_set", queryset=Sample.filter_for_user(request.user).order_by("pk"))
+    context = {"specimen": specimen,
+               "form": form,
+               "extractions": specimen.extraction_set.order_by("pk").prefetch_related(visible_samples),
+               "has_write_permission": has_write_permission}
+    return render(request, 'patients/view_specimen.html', context)
+
+
+def view_extraction(request, extraction_id):
+    extraction = Extraction.get_for_user(request.user, extraction_id)
+    form = forms.ExtractionForm(request.POST or None, instance=extraction)
+    form.helper = form_helper_horizontal()
+
+    has_write_permission = extraction.can_write(request.user)
+    if not has_write_permission:
+        set_form_read_only(form)
+
+    if request.method == "POST":
+        valid = form.is_valid()
+        if valid:
+            extraction = form.save()
+        add_save_message(request, valid, "Extraction")
+
+    context = {"extraction": extraction,
+               "form": form,
+               "samples": Sample.filter_for_user(request.user).filter(extraction=extraction).order_by("pk"),
+               "sequencing_samples": extraction.sequencingsample_set.order_by("pk"),
+               "has_write_permission": has_write_permission}
+    return render(request, 'patients/view_extraction.html', context)
 
 
 def view_patient_genes(request, patient_id):

--- a/patients/views_autocomplete.py
+++ b/patients/views_autocomplete.py
@@ -28,7 +28,7 @@ class SpecimenAutocompleteView(AutocompleteView):
     fields = ['reference_id']
 
     def get_user_queryset(self, user):
-        qs = Specimen.objects.filter(patient__in=Patient.filter_for_user(user))
+        qs = Specimen.filter_for_user(user)
         if patient := self.forwarded.get('patient'):
             qs = qs.filter(patient=patient)
         if extraction := self.forwarded.get('extraction'):
@@ -43,7 +43,7 @@ class ExtractionAutocompleteView(AutocompleteView):
     fields = ['reference_id', 'specimen__reference_id']
 
     def get_user_queryset(self, user):
-        qs = Extraction.objects.filter(specimen__patient__in=Patient.filter_for_user(user))
+        qs = Extraction.filter_for_user(user)
         if patient := self.forwarded.get('patient'):
             qs = qs.filter(specimen__patient=patient)
         if specimen := self.forwarded.get('specimen'):

--- a/snpdb/templates/snpdb/data/view_sample.html
+++ b/snpdb/templates/snpdb/data/view_sample.html
@@ -55,9 +55,21 @@ function setPatientLink() {
     patientSelector.change(mySetPatientLink);
 }
 
+function setExtractionLink() {
+    const extractionSelector = $("#id_extraction");
+    extractionSelector.parent().append("<a class='cross-link' id='extraction-link'>View Extraction</a>");
+    function mySetExtractionLink() {
+        const pk = extractionSelector.find(":selected").val();
+        setCrossLink($("#extraction-link"), Urls.view_extraction, pk);
+    }
+    mySetExtractionLink();
+    extractionSelector.change(mySetExtractionLink);
+}
+
 
 $(document).ready(function() {
     setPatientLink();
+    setExtractionLink();
 
     $("#sample-tabs").tabs();
 

--- a/variantgrid/settings/env/shariantcommon.py
+++ b/variantgrid/settings/env/shariantcommon.py
@@ -191,6 +191,8 @@ URLS_NAME_REGISTER.update({  # Disable selected snpdb urls
     "patient_imports": False,
     "patient_term_approvals": False,
     "patients": False,
+    "view_specimen": False,
+    "view_extraction": False,
 
     "gene_lists": False,
     "genes": False,


### PR DESCRIPTION
TSO 500 phase 3. Both halves designed in [`claude/plans/tso500_phase_3_plan.md`](claude/plans/tso500_phase_3_plan.md), added in the first commit.

Issues: #1706, SACGF/variantgrid_private#2447

## Part A — `Specimen.mutation_type` becomes `Specimen.tissue_status`

The old field was a two-value Germline/Somatic `CharField` with `default=Mutation.GERMLINE`, and its one substantive consumer is classification autopopulate, which sets `SpecialEKeys.ALLELE_ORIGIN` and so feeds `AlleleOriginBucket` and the cross-lab overlaps. Every TSO 500 tumour block, having never had the field set, was stamping its classifications "Germline" and filing them alongside other labs' real germline records.

`tissue_status` is Reference (unaffected) / Affected (lesional) / Unknown, not null, defaulting to Unknown — an unset field now says so rather than being indistinguishable from a deliberate answer. It sits on `Specimen` rather than on the `Tissue` lookup because the same tissue plays different roles: blood is the reference in a solid-tumour workup and *is* the tumour in leukaemia.

**Autopopulate becomes a derivation.** The specimen says what the material is; `Sample.variants_type` says what's in the call set. An origin is asserted only where both agree:

| `tissue_status` | `variants_type` | `allele_origin` |
|---|---|---|
| Reference | Germline | `germline` |
| any | Somatic only | `somatic` |
| anything else | anything else | unset |

Unset falls back to `settings.ALLELE_ORIGIN_NOT_PROVIDED_BUCKET` so the curator decides per variant — which is the honest answer for a mixed tumour sample. The emitted value is the `allele_origin` evidence key's own option string, since that is what `bucket_for_allele_origin` matches on.

**Migration** (`patients/0016`), in order:

1. `AddField` `Specimen.tissue_status` (`default='U'`)
2. `AddField` `PatientRecord.specimen_tissue_status`
3. `RunPython` — `S` → Affected; `G` → Unknown
4. `ManualOperation` — registered only where a `PatientRecord` carries `G`
5. `RemoveField` `Specimen.mutation_type`
6. `RemoveField` `PatientRecord.specimen_mutation_type`

`G` was the field default, so it cannot be told apart from nobody touching the record. Rather than guess, it maps to Unknown and the `ManualOperation`'s `test=` only fires where a `PatientRecord` actually carries a `G` — evidence the CSV column was populated rather than defaulted. On a deployment that never used the column, no task appears and nothing is asked of anyone.

**The patient CSV column is a hard rename** to `'Specimen Tissue status (Reference/Affected/Unknown)'`. Import already validates that every column is present, so a saved spreadsheet with the old header fails naming what's missing. Germline → Unknown is a loss of meaning, so silently reinterpreting the old column would be worse than making people re-download the template.

## Part B — pages, preview and search (#1706)

- **Permissions delegate to the patient**, the way `Trio` delegates to its cohort — a specimen's confidentiality is its patient's. That buys `can_view` / `can_write` / `filter_for_user` / `get_for_user`, and lets `patients/views_autocomplete.py` drop its hand-rolled `filter(patient__in=Patient.filter_for_user(user))`. `ExternallyManagedModel.can_write` is ANDed in, as `Patient` already does.
- **Detail pages** at `view_specimen` / `view_extraction`, editable except `external_pk` — that is the tracking system's identity and phase 4's resolver keys on it, so it is displayed rather than typed. Both URL names are turned off with the rest of the patients block on shariant.
- **Samples on both pages go through `Sample.filter_for_user`** separately from the specimen's own permission, since a sample carries its VCF's permissions rather than its patient's.
- **`PreviewModelMixin`** on both, so they hover-card the way `Patient` does.
- **Search** uses `HAS_3_ANY` rather than the alpha pattern, because a TSO 500 reference like `2600000001` is all digits. `ExternalPK` search learns to walk to both models.
- **Links each way** along Patient → Specimen → Extraction → Sample, including a "View Extraction" cross-link on the sample page beside the existing "View Patient" one.

The grid half of #1706 — top-level specimen/extraction grids, the sample grid link, and private#2837's IDs on the variant page — rides with phase 6 where the column pass already is.

## Testing

```
$ python3 manage.py test --keepdb patients classification.tests
Ran 161 tests in 10.941s
OK (skipped=4)
```

New coverage: the autopopulate truth table asserted against `get_evidence_fields_for_sample_and_patient`, a `Specimen` created with no arguments coming out `UNKNOWN`, the CSV column parsing both key and display value, and `view_specimen`/`view_extraction` in `PRIVATE_OBJECT_URL_NAMES_AND_KWARGS` for the 200-for-owner / 403-for-non-owner pair. `TestSpecimenExtractionPermissions` covers the queryset path (`filter_for_user`) that search and the autocompletes use.

The test database was also rebuilt from zero once to confirm `0016` applies cleanly in a full migration chain, not just incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ePLzeerJq3erQKsYN8E5E