### PR TITLE
Annotation: build contigs as an IN list rather than a GenomeBuildContig join #1720

### DIFF
--- a/annotation/tasks/annotate_variants.py
+++ b/annotation/tasks/annotate_variants.py
@@ -658,6 +658,9 @@ def _unannotated_variants_to_vcf(genome_build: GenomeBuild, vcf_filename,
 def write_qs_to_vcf(vcf_filename, genome_build, qs, info_dict=VARIANT_GRID_INFO_DICT, use_accession=False) -> int:
     # We had an issue with writing accessions in VEP, so use chrom names and the default VEP fasta instead
     # @see https://github.com/Ensembl/ensembl-vep/issues/1635
+    # Contigs are shared between builds (eg GRCh37/hg19) so the ordering join needs restricting to this
+    # build, otherwise a variant is written once per build its contig belongs to
+    qs = qs.filter(locus__contig__genomebuildcontig__genome_build=genome_build)
     qs = qs.order_by("locus__contig__genomebuildcontig__order", "locus__position")
     if use_accession:
         chrom_key = "locus__contig__refseq_accession"

--- a/snpdb/models/models_genome.py
+++ b/snpdb/models/models_genome.py
@@ -145,6 +145,10 @@ class GenomeBuild(models.Model, SortMetaOrderingMixin, PreviewModelMixin):
         return qs.order_by("genomebuildcontig__order")
 
     @cached_property
+    def contig_ids(self) -> list[int]:
+        return list(self.contigs.values_list("pk", flat=True))
+
+    @cached_property
     def standard_contigs(self):
         return self.contigs.filter(role=SequenceRole.ASSEMBLED_MOLECULE)
 

--- a/snpdb/models/models_variant.py
+++ b/snpdb/models/models_variant.py
@@ -636,8 +636,12 @@ class Variant(PreviewModelMixin, models.Model):
 
     @staticmethod
     def get_contigs_q(genome_build: GenomeBuild) -> Q:
-        """ Restrict to contigs in a genome build """
-        return Q(locus__contig__genomebuildcontig__genome_build=genome_build)
+        """ Restrict to contigs in a genome build.
+
+            A build's contigs are a small fixed set, so this is an IN list rather than a join through
+            GenomeBuildContig - the join collapses the planner's row estimate to 1 and it can end up
+            re-scanning the whole variant side once per contig (#1720) """
+        return Q(locus__contig_id__in=genome_build.contig_ids)
 
     @staticmethod
     def get_reference_q() -> Q:


### PR DESCRIPTION
Addresses #1720 — `get_variants_qs_for_annotation()` taking ~83s per range lock.

## The slow query

The `genomebuildcontig` join in `Variant.get_contigs_q()`, combined with the `variantannotation__isnull=True` anti-join, collapsed the planner's row estimate to 1. On that estimate it picked a nested loop over the 640 `GenomeBuildContig` rows and materialised the 2.5M-row variant side, rescanning it once per contig — 1.6 billion join-filter comparisons and ~5.9M temp blocks spilled.

A build's contigs are a small fixed set, so filter on them directly via a new `GenomeBuild.contig_ids`. Measured on a 17M variant dev DB, largest GRCh38 range lock (2.55M ids), `pipeline_type=STANDARD`:

| | exec time |
|---|---|
| `genomebuildcontig` join | 82.4 s |
| `locus__contig_id__in=[...]` | 5.9 s |

A materialised id list was chosen over passing the queryset — the lazy `values_list` compiles to a per-row correlated semi-join (6.2 s vs 8.0 s).

There are 424 range locks on that DB and the query runs at least twice per annotation run (`count_annotation_run` plus the VCF dump).

## Why `write_qs_to_vcf` changed too

It orders by `locus__contig__genomebuildcontig__order` with no build restriction of its own, and was relying on the caller's `get_contigs_q()` join to constrain that ordering join. Contigs are shared between builds (GRCh37/hg19), so without it each variant is written to the dumped VCF once per build its contig belongs to — `annotation.tests.test_external_annotation` caught this, dumping 8 records for 4 variants. `snpdb/variants_to_vcf.py` already carries a comment about the same hazard. The dump path plans fine with the restriction back in place (2.7 s on the full range lock).

## Checks

All 15 `get_contigs_q()` call sites filter Variant querysets, none negate it, and `GenomeBuildContig` is unique per (build, contig) — the row set is unchanged, with no `distinct()` implications. Counts match on real data (8,235,868 variants for GRCh38 both ways).

Tests: snpdb + annotation + analysis + variantopedia + upload + classification, 1153 tests, OK.

Measurements of the remaining 6 s, and why the follow-up suggestion in the issue description needs correcting, are in [this comment](https://github.com/SACGF/variantgrid/issues/1720#issuecomment-5277458582).

🤖 Generated with [Claude Code](https://claude.com/claude-code)