### PR TITLE
Drop queries whose results are discarded #1724

### DIFF
--- a/classification/models/classification_groups.py
+++ b/classification/models/classification_groups.py
@@ -139,7 +139,7 @@ class ClassificationGroupUtils:
 
         if self._modifications:
             flag_collections_ids = {mod.classification.flag_collection_id for mod in self._modifications}
-            flags_qs.filter(collection_id__in=flag_collections_ids)
+            flags_qs = flags_qs.filter(collection_id__in=flag_collections_ids)
 
         for flag in flags_qs:
             mod_id_to_clin_sig[flag.collection_id] = flag.data.get(ClassificationFlagTypes.CLASSIFICATION_PENDING_CHANGES_CLIN_SIG_KEY) if flag.data else 'Unknown'

--- a/flags/views/views.py
+++ b/flags/views/views.py
@@ -251,6 +251,18 @@ class FlagHelper:
         json_data['collections'] = flag_collections_json
 
         for flag in self.flags.values():
+
+            created = flag.created
+            flag_type = self.flag_types[flag.flag_type_id]
+            if flag_type.only_one:
+                # find when flag was last opened
+                try:
+                    created = FlagComment.objects.filter(flag=flag, resolution__status=FlagStatus.OPEN).order_by(
+                        '-created'). \
+                        values_list('created', flat=True).first()
+                except Exception:
+                    pass
+
             resolution = self.flag_resolutions[flag.resolution_id]
             json_entry = {
                 'id': flag.pk,
@@ -259,7 +271,7 @@ class FlagHelper:
                 'status': resolution.status,
                 'resolution': resolution.id,
                 'user': flag.user_id,
-                'created': flag.created.timestamp()
+                'created': created.timestamp()
             }
             if flag.data:
                 json_entry['data'] = flag.data

--- a/flags/views/views.py
+++ b/flags/views/views.py
@@ -251,15 +251,6 @@ class FlagHelper:
         json_data['collections'] = flag_collections_json
 
         for flag in self.flags.values():
-            flag_type = self.flag_types[flag.flag_type_id]
-            if flag_type.only_one:
-                # find when flag was last opened
-                try:
-                    created = FlagComment.objects.filter(flag=flag, resolution__status=FlagStatus.OPEN).order_by('-created').\
-                        values_list('created', flat=True).first()
-                except Exception:
-                    pass
-
             resolution = self.flag_resolutions[flag.resolution_id]
             json_entry = {
                 'id': flag.pk,

--- a/uicore/templatetags/english_tags.py
+++ b/uicore/templatetags/english_tags.py
@@ -10,10 +10,11 @@ register = template.Library()
 
 def count_items(items: Union[list, QuerySet, int]) -> int:
     item_count: int
-    if hasattr(items, '__len__'):
-        item_count = len(items)
-    elif isinstance(items, QuerySet):
+    if isinstance(items, QuerySet):
+        # QuerySet defines __len__, so this needs to come first to avoid evaluating the whole thing
         item_count = items.count()
+    elif hasattr(items, '__len__'):
+        item_count = len(items)
     else:
         item_count = items
 


### PR DESCRIPTION
🤖 Written by Claude.

Addresses #1724. Three places where a query ran but its result was thrown away. No output changes in any of them — this is removing wasted work.

### `ClassificationGroupUtils._pending_changes_flag_map`

```python
flags_qs.filter(collection_id__in=flag_collections_ids)   # result discarded
```

Querysets are immutable, so the narrowing filter was a no-op and the loop below iterated every open pending-changes flag in the database. The resulting map is keyed by `collection_id` and only read for the modifications in hand, so the output was already correct — but the scan grew with total database size. Reached via the `{% classification_groups %}` tag, so it ran on allele, gene symbol, variant details and discordance report pages.

### Flags JSON payload

The `only_one` branch ran a `FlagComment` query per flag to find when it was last opened and never read the result — the entry built directly below uses `flag.created`. Removed the block; `flag_type` was only bound for that branch so it goes too. `FlagComment` and `FlagStatus` are still imported for other uses in the module.

This endpoint fires on every classification, allele, variant and discordance page.

### `count_items`

`QuerySet` defines `__len__`, so testing `hasattr(items, '__len__')` first made the `isinstance(items, QuerySet)` branch unreachable and `{% count qs ... %}` evaluated the entire queryset to produce a number. Reordered so querysets use `.count()`. Current callers pass small collections so there is no measurable win today — it stops the next caller falling in.

### Testing

`python3 manage.py test --keepdb classification.tests` — 98 tests pass. `flags` and `uicore` have no test modules.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LC9Z2HMXw1FFbmvSLjcJXz
