### PR TITLE
Classification: fix N+1 queries in the allele groupings grid and tasks #1729

### DIFF
--- a/classification/models/classification_grouping.py
+++ b/classification/models/classification_grouping.py
@@ -93,7 +93,8 @@ class AlleleGrouping(TimeStampedModel):
     @cached_property
     def allele_origin_dict(self) -> dict[AlleleOriginBucket, 'AlleleOriginGrouping']:
         by_bucket = {}
-        for ao in AlleleOriginGrouping.objects.filter(allele_grouping=self).prefetch_related("classificationgrouping_set"):
+        for ao in AlleleOriginGrouping.objects.filter(allele_grouping=self) \
+                .prefetch_related("classificationgrouping_set__lab__organization"):
             by_bucket[ao.allele_origin_bucket] = ao
         return by_bucket
 
@@ -477,7 +478,8 @@ class ClassificationGrouping(TimeStampedModel):
     @staticmethod
     def update_all_dirty():
         # maybe move this out since it does AlleleOriginGroupings too
-        for dirty in ClassificationGrouping.objects.filter(dirty=True).iterator():
+        # update() dirties the allele_origin_grouping straight away, so bring it along
+        for dirty in ClassificationGrouping.objects.filter(dirty=True).select_related("allele_origin_grouping").iterator():
             dirty.update()
         for dirty in AlleleOriginGrouping.objects.filter(dirty=True).iterator():
             dirty.update()

--- a/classification/models/clinvar_export_prepare.py
+++ b/classification/models/clinvar_export_prepare.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from typing import Optional
 
+from django.db.models import Count, Q
 from django.utils import timezone
 from django.utils.timezone import now
 
@@ -176,9 +177,11 @@ class ClinvarExportPrepare:
                 no_condition_count += 1
         clinvar_merger.consolidate()
 
-        total = clinvar_allele.clinvarexport_set.count()
-        in_error = clinvar_allele.clinvarexport_set.filter(status=ClinVarExportStatus.IN_ERROR).count()
-        valid = total - in_error
+        export_counts = clinvar_allele.clinvarexport_set.aggregate(
+            total=Count("pk"),
+            in_error=Count("pk", filter=Q(status=ClinVarExportStatus.IN_ERROR)))
+        in_error = export_counts["in_error"]
+        valid = export_counts["total"] - in_error
 
         clinvar_allele.classifications_missing_condition = no_condition_count
         clinvar_allele.submissions_valid = valid

--- a/classification/models/discordance_models.py
+++ b/classification/models/discordance_models.py
@@ -177,23 +177,31 @@ class DiscordanceReport(TimeStampedModel, ReviewableModelMixin, PreviewModelMixi
 
         existing_vms = set()
         existing_labs = set()
-        for drc in DiscordanceReportClassification.objects.filter(report=self):
+        drc_qs = DiscordanceReportClassification.objects.filter(report=self) \
+            .select_related("classification_original__classification__lab")
+        for drc in drc_qs:
             existing_vms.add(drc.classification_original.classification_id)
             existing_labs.add(drc.classification_original.classification.lab)
 
         newly_added_labs: set[Lab] = set()
+        added_classification_ids = []
         for vcm_id in self.clinical_context.classifications_qs.values_list('id', flat=True):
             if vcm_id in existing_vms:
                 existing_vms.remove(vcm_id)
             else:
-                vcm = ClassificationModification.objects.get(is_last_published=True, classification=vcm_id)
-                if vcm.classification.lab not in existing_labs:
-                    newly_added_labs.add(vcm.classification.lab)
+                added_classification_ids.append(vcm_id)
 
-                DiscordanceReportClassification(
-                    report=self,
-                    classification_original=vcm
-                ).save()
+        added_qs = ClassificationModification.objects.filter(is_last_published=True,
+                                                             classification__in=added_classification_ids) \
+            .select_related("classification__lab")
+        for vcm in added_qs:
+            if vcm.classification.lab not in existing_labs:
+                newly_added_labs.add(vcm.classification.lab)
+
+            DiscordanceReportClassification(
+                report=self,
+                classification_original=vcm
+            ).save()
 
         invalidate_cached_property(self, 'discordance_report_classifications')
         invalidate_cached_property(self, 'involved_labs')

--- a/classification/views/allele_grouping_datatables.py
+++ b/classification/views/allele_grouping_datatables.py
@@ -71,7 +71,9 @@ class AlleleGroupingColumns(DatatableConfig[AlleleGrouping]):
 
     def c_hgvs_for(self, cg: ClassificationGrouping) -> HGVSDisplay:
         is_preferred_genome_build = True
-        allele_info = cg.latest_classification_modification.classification.allele_info
+        # update() keeps this in step with latest_classification_modification.classification.allele_info,
+        # and reading it here avoids walking that chain as three lazy FK loads per row
+        allele_info = cg.latest_allele_info
         for gb in self.genome_build_prefs:
             if ri := allele_info[gb]:
                 if c_hgvs := ri.c_hgvs_obj:
@@ -84,7 +86,9 @@ class AlleleGroupingColumns(DatatableConfig[AlleleGrouping]):
     def render_allele(self, row: CellData) -> JsonDataType:
         allele_group = _allele_group(row.get("allele"))
         # FIXME cache this
-        cgs = ClassificationGrouping.objects.filter(allele_origin_grouping__allele_grouping=allele_group.pk, dirty=False)
+        cgs = ClassificationGrouping.objects.filter(allele_origin_grouping__allele_grouping=allele_group.pk,
+                                                    dirty=False) \
+            .select_related("latest_allele_info__grch37__genome_build", "latest_allele_info__grch38__genome_build")
         all_chgvs = sorted({self.c_hgvs_for(cg) for cg in cgs})
         c_hgvs_json: JsonDataType
         if all_chgvs:


### PR DESCRIPTION
🤖 Written by Claude.

Addresses part of #1729 — the classification fixes that are just `select_related`/`prefetch_related` or hoisting a query out of a loop. Split out of #1727; the snpdb/annotation half is in a separate PR.

### Allele Groupings grid

The worst of them. `render_allele` runs a `ClassificationGrouping` query per row, then `c_hgvs_for` walked `latest_classification_modification -> classification -> allele_info -> allele_info[gb] -> ri.genome_build` as lazy FK loads for every grouping of every row.

`ClassificationGrouping.update()` sets `latest_allele_info` from `best_classification.classification.allele_info` in the same breath as `latest_classification_modification`, so the stored field is exactly what that chain resolves to — read it directly and `select_related` the resolved variant info for both builds.

The Labs column had the same problem from the other end: `allele_origin_dict` prefetched `classificationgrouping_set` but not `lab`, and `sorted(labs)` calls `Lab.__lt__`, which reaches for `organization`. Both now come through the prefetch.

### `DiscordanceReport.update()`

Runs on every classification publish/withdraw touching a discordant clinical context. Two problems: `classification_original.classification` was dereferenced per row (two queries each, one of them the wide `ClassificationModification`), and each newly added classification was fetched with its own `.get()`. Now one `select_related` queryset for the existing rows and one bulk query for the added ones.

**Behaviour note for review:** the old `.get(is_last_published=True, classification=vcm_id)` raised `DoesNotExist` if a classification had no published modification, failing the whole update. The bulk query skips it instead. I think skipping is the better behaviour, but it is a change, so flagging it.

### Others

- `update_all_dirty` — `update()` dirties `allele_origin_grouping` immediately, so it is worth bringing along; this runs over tens of thousands of groupings after a bulk import.
- The nightly ClinVar prepare ran two `COUNT` queries per allele; collapsed into one `aggregate` with a filtered `Count`.

### Not included

The remaining classification grid items in the issue (`imported_allele_info_view`, `clinvar_export_view`) need the `pre_render(qs)` hook to bulk-load a page's objects into a dict. That is a consistent little pattern rather than a one-line change, so it is better as its own PR than bolted onto this one.

### Testing

`python3 manage.py test --keepdb classification.tests` — 98 tests pass.
