### PR TITLE
snpdb/annotation: fix N+1 queries on the variant details page #1730

### DIFF
--- a/annotation/transcripts_annotation_selections.py
+++ b/annotation/transcripts_annotation_selections.py
@@ -275,7 +275,8 @@ class VariantTranscriptSelections:
         # Convert once to explicit, then pass this around
         variant_coordinate = variant.coordinate.as_external_explicit(self.genome_build)
         has_other_annotation_consortium_transcripts = False
-        for transcript_version in TranscriptVersion.objects.filter(**kwargs).order_by("-version"):
+        transcript_version_qs = TranscriptVersion.objects.filter(**kwargs).select_related("gene_version")
+        for transcript_version in transcript_version_qs.order_by("-version"):
             # Don't duplicate ones already available via RefSeq/Ensembl equivalence
             # and only take the highest version we have
             if transcript_version.transcript_id not in existing_other_transcripts:

--- a/snpdb/variant_sample_information.py
+++ b/snpdb/variant_sample_information.py
@@ -391,7 +391,7 @@ class VariantSampleGenotypes(VariantZygosityCounts):
         classifications_by_sample_id = defaultdict(list)
         qs = ClassificationModification.latest_for_user(self.user, allele=allele, published=True,
                                                         classification__sample__in=sample_ids)
-        for cm in qs:
+        for cm in qs.select_related("classification__lab"):
             classification = cm.classification
             pills = clinical_significance_pills(classification.summary_typed, classification.allele_origin_bucket)
             classification_json = {
@@ -441,7 +441,10 @@ class VariantSampleGenotypes(VariantZygosityCounts):
     def _get_locus_counts(self) -> list[dict]:
         """ Zygosity counts for every variant at this locus, this variant first """
         counts_by_variant_id = self._get_locus_zygosity_counts()
-        variant_by_id = {v.pk: v for v in Variant.objects.filter(pk__in=counts_by_variant_id)}
+        # str(v) and v.alt.seq below reach through to the locus/sequence rows
+        variant_qs = Variant.objects.filter(pk__in=counts_by_variant_id) \
+            .select_related("locus__contig", "locus__ref", "alt")
+        variant_by_id = {v.pk: v for v in variant_qs}
 
         sorted_rows = []
         for variant_id, zygosity_counts in counts_by_variant_id.items():


### PR DESCRIPTION
🤖 Written by Claude.

Addresses part of #1730 — the snpdb/annotation fixes that are just `select_related`. Split out of #1727; the classification half is in a separate PR.

### Variant details page

- The sample classifications table used `latest_for_user`, which applies no `select_related`, so each row refetched `Classification` — including the wide `evidence` JSONB — plus `lab`.
- The locus counts table fetched `Variant` rows without their locus/sequence rows, and `str(v)` then costs three queries each via `locus.contig.name`, `locus.ref.seq` and `alt.seq`.

### Transcript table

`gene_version` loaded lazily over a loop that pulls every transcript version for the variant's gene symbols — often 50-300 rows. Used by the variant page, classification autopopulate and the classification detail view.

### Not included

The grid items in the issue (the AlleleLiftover grids, the variant tag `can_write`) need the `pre_render(qs)` hook to bulk-load a page's objects into a dict. That is a consistent little pattern rather than a one-line change, so it is better as its own PR than bolted onto this one.

### Testing

`python3 manage.py test --keepdb snpdb.tests annotation.tests` — 551 tests pass.
