### PR TITLE
OMIM built-in filter: resolve genes via GeneAnnotation subquery #1733

### DIFF
--- a/analysis/grids.py
+++ b/analysis/grids.py
@@ -160,7 +160,7 @@ class VariantGrid(AbstractVariantGrid):
         q = None
         if self.node_count:
             analysis = self.node.analysis
-            q = get_extra_filters_q(analysis.user, analysis.genome_build, self.node_count.label)
+            q = get_extra_filters_q(analysis.user, analysis.annotation_version, self.node_count.label)
         return q
 
     def _get_grid_only_annotation_kwargs(self):

--- a/analysis/models/nodes/analysis_node.py
+++ b/analysis/models/nodes/analysis_node.py
@@ -1338,7 +1338,7 @@ class NodeColumnSummaryCacheCollection(models.Model):
                                                                                 variant_column=variant_column,
                                                                                 extra_filters=extra_filters)
         if created:
-            extra_filters_q = get_extra_filters_q(node.analysis.user, node.analysis.genome_build, extra_filters)
+            extra_filters_q = get_extra_filters_q(node.analysis.user, node.analysis.annotation_version, extra_filters)
             queryset = node.get_queryset(extra_filters_q)
             count_qs = queryset.values_list(variant_column).distinct().annotate(Count('id'))
             data_list = []

--- a/analysis/models/nodes/filters/built_in_filter_node.py
+++ b/analysis/models/nodes/filters/built_in_filter_node.py
@@ -26,7 +26,7 @@ class BuiltInFilterNode(AnalysisNode):
         return Q(clinvar__review_status__in=review_statuses)
 
     def _get_node_q(self) -> Optional[Q]:
-        q = get_extra_filters_q(self.analysis.user, self.analysis.genome_build, self.built_in_filter)
+        q = get_extra_filters_q(self.analysis.user, self.analysis.annotation_version, self.built_in_filter)
         if self.built_in_filter == BuiltInFilters.CLINVAR and self.clinvar_stars_min:
             q &= self.get_clinvar_stars_q()
         elif self.built_in_filter == BuiltInFilters.COSMIC and self.cosmic_count_min:

--- a/analysis/models/nodes/node_counts.py
+++ b/analysis/models/nodes/node_counts.py
@@ -4,22 +4,32 @@ from django.contrib.auth.models import User
 from django.db.models import Count
 from django.db.models.query_utils import Q
 
+from annotation.models import AnnotationVersion, GeneAnnotation
 from annotation.models.damage_enums import PathogenicityImpact
 from classification.enums import ClinicalSignificance
-from classification.models import Classification, GenomeBuild
+from classification.models import Classification
 from snpdb.models.models_enums import BuiltInFilters
 
 
-def get_extra_filters_q(user: User, genome_build: GenomeBuild, extra_filters):
+def get_omim_q(annotation_version: AnnotationVersion) -> Q:
+    """ Genes with OMIM terms, as a subquery against the small GeneAnnotation table - going through
+        'variantannotation__gene__geneannotation' joins the huge VariantAnnotation table through Gene """
+    gene_annotation_qs = GeneAnnotation.objects.filter(omim_terms__isnull=False)
+    if gene_annotation_version_id := annotation_version.gene_annotation_version_id:
+        gene_annotation_qs = gene_annotation_qs.filter(version_id=gene_annotation_version_id)
+    return Q(variantannotation__gene__in=gene_annotation_qs.values_list("gene_id", flat=True))
+
+
+def get_extra_filters_q(user: User, annotation_version: AnnotationVersion, extra_filters):
     if extra_filters == BuiltInFilters.CLINVAR:
         q = Q(clinvar__highest_pathogenicity__gte=4)
     elif extra_filters == BuiltInFilters.OMIM:
-        q = Q(variantannotation__gene__geneannotation__omim_terms__isnull=False)
+        q = get_omim_q(annotation_version)
     elif extra_filters in [BuiltInFilters.CLASSIFIED, BuiltInFilters.CLASSIFIED_PATHOGENIC]:
         clinical_significance_list = None
         if extra_filters == BuiltInFilters.CLASSIFIED_PATHOGENIC:
             clinical_significance_list = [ClinicalSignificance.LIKELY_PATHOGENIC, ClinicalSignificance.PATHOGENIC]
-        q = Classification.get_variant_q(user, genome_build, clinical_significance_list)
+        q = Classification.get_variant_q(user, annotation_version.genome_build, clinical_significance_list)
     elif extra_filters == BuiltInFilters.IMPACT_HIGH_OR_MODERATE:
         q = Q(variantannotation__impact__in=(PathogenicityImpact.HIGH, PathogenicityImpact.MODERATE))
     elif extra_filters == BuiltInFilters.COSMIC:
@@ -77,7 +87,7 @@ def get_node_counts_and_labels_dict(node, counts_to_get):
         if count_type == BuiltInFilters.TOTAL:
             q = None
         else:
-            q = get_extra_filters_q(node.analysis.user, node.analysis.genome_build, count_type)
+            q = get_extra_filters_q(node.analysis.user, node.analysis.annotation_version, count_type)
         # empty_result_set_value=0 only works for Django >= 4, so we handle manually below
         aggregate_kwargs[count_type] = Count("pk", filter=q, empty_result_set_value=0)
     node_counts = qs.aggregate(**aggregate_kwargs)

--- a/analysis/tests/test_built_in_filter_omim.py
+++ b/analysis/tests/test_built_in_filter_omim.py
@@ -1,0 +1,67 @@
+from django.test import TestCase
+
+from analysis.models.nodes.node_counts import get_omim_q
+from annotation.annotation_version_querysets import get_variant_queryset_for_annotation_version
+from annotation.fake_annotation import get_fake_annotation_version
+from annotation.models import AnnotationRun, GeneAnnotation, GeneAnnotationVersion
+from annotation.models.models import VariantAnnotation, VariantAnnotationVersion
+from genes.models import Gene
+from genes.models_enums import AnnotationConsortium
+from library.django_utils.django_partition import temporary_db_table
+from snpdb.models import GenomeBuild
+from snpdb.tests.utils.vcf_testing_utils import slowly_create_test_variant
+
+
+class TestBuiltInFilterOmim(TestCase):
+    """ The OMIM built in filter matches variants whose gene has OMIM terms in the analysis's
+        GeneAnnotationVersion - other versions of the same gene annotation are not visible """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.grch37 = GenomeBuild.get_name_or_alias("GRCh37")
+        cls.annotation_version = get_fake_annotation_version(cls.grch37)
+        cls.vav = cls.annotation_version.variant_annotation_version
+        cls.gene_annotation_version = cls.annotation_version.gene_annotation_version
+        cls.annotation_run = AnnotationRun.objects.create()
+
+        cls.omim_gene = cls._create_gene("ENSG00000000001")
+        cls.other_gene = cls._create_gene("ENSG00000000002")
+        cls._create_gene_annotation(cls.gene_annotation_version, cls.omim_gene, omim_terms="OMIM:123456")
+        cls._create_gene_annotation(cls.gene_annotation_version, cls.other_gene, omim_terms=None)
+
+        # Another version where the genes have swapped OMIM status - none of this should be visible
+        old_gene_annotation_version = GeneAnnotationVersion.objects.create(
+            gene_annotation_release=cls.gene_annotation_version.gene_annotation_release,
+            ontology_version=cls.gene_annotation_version.ontology_version,
+            gnomad_import_date=cls.gene_annotation_version.gnomad_import_date)
+        cls._create_gene_annotation(old_gene_annotation_version, cls.omim_gene, omim_terms=None)
+        cls._create_gene_annotation(old_gene_annotation_version, cls.other_gene, omim_terms="OMIM:999999")
+
+        cls.omim_variant = slowly_create_test_variant("1", 1000, "A", "T", cls.grch37)
+        cls.other_variant = slowly_create_test_variant("1", 2000, "A", "T", cls.grch37)
+        cls._create_variant_annotation(cls.omim_variant, cls.omim_gene)
+        cls._create_variant_annotation(cls.other_variant, cls.other_gene)
+
+    @classmethod
+    def _create_gene(cls, identifier) -> Gene:
+        return Gene.objects.create(identifier=identifier, annotation_consortium=AnnotationConsortium.ENSEMBL)
+
+    @classmethod
+    def _create_gene_annotation(cls, version: GeneAnnotationVersion, gene: Gene, omim_terms):
+        with temporary_db_table(GeneAnnotation, version.get_partition_table()):
+            GeneAnnotation.objects.create(version=version, gene=gene, omim_terms=omim_terms)
+
+    @classmethod
+    def _create_variant_annotation(cls, variant, gene: Gene):
+        partition_table = cls.vav.get_partition_table(
+            base_table_name=VariantAnnotationVersion.REPRESENTATIVE_TRANSCRIPT_ANNOTATION)
+        with temporary_db_table(VariantAnnotation, partition_table):
+            VariantAnnotation.objects.create(version=cls.vav, variant=variant, gene=gene,
+                                             annotation_run=cls.annotation_run,
+                                             predictions_num_pathogenic=0, predictions_num_benign=0)
+
+    def test_omim_filter_matches_current_version_only(self):
+        qs = get_variant_queryset_for_annotation_version(self.annotation_version)
+        omim_variant_ids = set(qs.filter(get_omim_q(self.annotation_version)).values_list("pk", flat=True))
+        self.assertEqual(omim_variant_ids, {self.omim_variant.pk})


### PR DESCRIPTION
🤖 Written by Claude.

Closes out the OMIM item from #1722 that #1726 deliberately left for a measured change. Details and numbers in #1733.

### What changed

`get_extra_filters_q` now takes the `AnnotationVersion` rather than the `GenomeBuild`, and the OMIM filter resolves gene ids from that version's `GeneAnnotation`:

```python
gene_annotation_qs = GeneAnnotation.objects.filter(omim_terms__isnull=False)
if gene_annotation_version_id := annotation_version.gene_annotation_version_id:
    gene_annotation_qs = gene_annotation_qs.filter(version_id=gene_annotation_version_id)
return Q(variantannotation__gene__in=gene_annotation_qs.values_list("gene_id", flat=True))
```

`variantannotation__gene__geneannotation` walked `VariantAnnotation → Gene → GeneAnnotation`, and the `genes_gene` hop carried no filter — it only bridged `variantannotation.gene_id` to `geneannotation.gene_id`, which are the same value. `EXPLAIN (ANALYZE, BUFFERS)` of a whole-build count showed it as a parallel seq scan + hash build over 72,782 rows (5,399 shared buffers) per count. The subquery form drops that join and the reverse join, leaving a hashed SubPlan over the 26,390-row version partition (4,141 rows with OMIM terms).

All four callers pass `analysis.annotation_version`; `genome_build` for the classification filters comes off the annotation version.

### Counts are unchanged

#1722 flagged the missing `version=` as a correctness bug. It isn't one: every caller applies this Q to a queryset from `get_variant_queryset_for_annotation_version`, whose SQL transformer already rewrites `"annotation_geneannotation"` to the version's inherits-partition. Filtering `version_id` in Python makes that scoping explicit rather than dependent on string rewriting — which matters if the Q is ever applied to a queryset without the transformer hook, or with `ANNOTATION_GENE_ANNOTATION_VERSION_ENABLED = False`.

Verified empirically: every node of every analysis on a dev DB (17M variants) counted both ways — 0 mismatches.

### Measurements (dev DB, 17M variants, GRCh38, warm cache, two runs each)

| variants scanned | before | after |
| --- | --- | --- |
| 1M | 1.28s / 1.27s | 1.27s / 1.28s |
| 5M | 1.55s / 1.55s | 1.51s / 1.50s |
| 17M (whole build) | 2.49s / 2.46s | 2.19s / 2.19s |

Cold cache the gap is wider (first-ever run of the 1M window: 3.22s vs 1.27s) since the old form has to read `genes_gene` off disk. Calling it plainly: this is a modest win that removes work the query never needed, not a #1720-sized one.

### Testing

New `analysis/tests/test_built_in_filter_omim.py` — the OMIM built-in filter had no coverage. Builds two genes (one with OMIM terms, one without) plus a second `GeneAnnotationVersion` where their OMIM status is swapped, and asserts the filter returns only the variant whose gene has OMIM terms in the analysis's version.

`python3 manage.py test --keepdb analysis` — 328 tests pass.
pylint on the changed files — 10.00/10.
