### PR TITLE
Django 6: settings written where nothing reads them #1735

### DIFF
--- a/classification/views/views_uploaded_classifications_unmapped.py
+++ b/classification/views/views_uploaded_classifications_unmapped.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, Optional
 
-import django
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
@@ -243,11 +242,6 @@ class UploadedClassificationsUnmappedView(View):
             raise ValueError(f"Detected banned file extension {', '.join(sorted(detected_banned_extensions))}")
 
     def post(self, request, **kwargs):
-        # lazily have s3boto3 requirements
-
-        django.utils.encoding.force_text1 = django.utils.encoding.force_str
-        django.utils.encoding.smart_text = django.utils.encoding.smart_str
-
         lab_picker = LabPickerData.from_request(request=request, selection=kwargs.get('lab_id'))
         lab = lab_picker.selected_lab
         if not lab:

--- a/library/django_utils/unittest_utils.py
+++ b/library/django_utils/unittest_utils.py
@@ -17,6 +17,13 @@ from django.utils.http import urlencode
 QUERY_PROFILE_FILE = os.environ.get("VG_QUERY_PROFILE")
 QUERY_TRACE_PATTERN = os.environ.get("VG_QUERY_TRACE")  # regex: log stack traces for matching SQL
 
+# override_settings(STORAGES=...) replaces the whole dict, so this carries the default file storage
+# through alongside the plain (non-manifest) static files storage
+PLAIN_STATICFILES_STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+}
+
 # Models whose managers (ObjectManagerCachingImmutable/Request) cache lookups in production
 # but disable caching under settings.UNIT_TEST - so repeated gets on these tables in a test
 # are not real production queries. Used by production_query_count().
@@ -122,7 +129,7 @@ def prevent_request_warnings(original_function):
     return new_function
 
 
-@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage',
+@override_settings(STORAGES=PLAIN_STATICFILES_STORAGES,
                    VARIANT_ZYGOSITY_GLOBAL_COLLECTION="global",
                    LOG_PARTITION_WARNINGS=False,
                    GENES_DEFAULT_CANONICAL_TRANSCRIPT_COLLECTION_ID=None,

--- a/library/jqgrid/jqgrid.py
+++ b/library/jqgrid/jqgrid.py
@@ -569,8 +569,7 @@ class JqGrid:
     @staticmethod
     def add_search_options(field, colmodel):
         # See: http://www.trirand.com/jqgridwiki/doku.php?id=wiki:search_config
-        is_boolean_field = any(isinstance(field, t) for t in [fields.BooleanField, fields.NullBooleanField])
-        if is_boolean_field:
+        if isinstance(field, fields.BooleanField):
             colmodel['stype'] = 'select'
             colmodel['searchoptions'] = {'value': {'False': 'False', 'True': 'True'}}
 

--- a/sync/tests/test_classification_sync_status.py
+++ b/sync/tests/test_classification_sync_status.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from classification.enums import ShareLevel, SubmissionSource
 from classification.models.classification import Classification
 from classification.tests.models.test_utils import ClassificationTestUtils
+from library.django_utils.unittest_utils import PLAIN_STATICFILES_STORAGES
 from snpdb.models import Lab
 from sync.classification_sync_status import ClassificationSyncState, classification_sync_status
 from sync.models.enums import SyncStatus
@@ -18,7 +19,7 @@ SYNC_DETAILS = {"test_shariant": {"host": REMOTE_HOST}}
 
 @override_settings(CLASSIFICATION_MATCH_VARIANTS=False,
                    SYNC_DETAILS=SYNC_DETAILS,
-                   STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+                   STORAGES=PLAIN_STATICFILES_STORAGES)
 class ClassificationSyncStatusTestCase(TestCase):
 
     def setUp(self):

--- a/variantgrid/settings/components/default_settings.py
+++ b/variantgrid/settings/components/default_settings.py
@@ -88,8 +88,6 @@ AVATAR_THUMB_FORMAT = "PNG"
 
 MANAGERS = ADMINS
 
-CONN_MAX_AGE = 60  # Reuse DB connections
-
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 DATABASES = {
@@ -101,6 +99,10 @@ DATABASES = {
         'HOST': get_secret('DB.host'),
         # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
         'PORT': get_secret('DB.port'),  # Set to empty string for default.
+        'CONN_MAX_AGE': 60,  # Reuse DB connections
+        # Reused connections can be closed server side (restart, pg_terminate_backend) - ping and
+        # reconnect rather than handing a dead socket to the next request
+        'CONN_HEALTH_CHECKS': True,
     }
 }
 
@@ -193,10 +195,6 @@ LANGUAGE_CODE = 'en-us'
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
 USE_I18N = False
-
-# If you set this to False, Django will not format dates, numbers and
-# calendars according to the current locale.
-USE_L10N = True
 
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True
@@ -720,8 +718,6 @@ STATICFILES_FINDERS = (
     #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
     'compressor.finders.CompressorFinder'
 )
-
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
 # Needs to be unique and not checked into source control, so make
 # django_secret_key.txt in this dir (which is hidden via .gitignore)


### PR DESCRIPTION
Addresses #1735 — three settings written where nothing reads them, plus the two minor cleanups the issue turned up.

## `CONN_MAX_AGE` — never a top-level setting

Django only reads `CONN_MAX_AGE` from inside `DATABASES[alias]`, so the module-level value has never done anything: **persistent connections have never run**, and every request has opened a fresh Postgres connection.

Moved into `DATABASES['default']`, with `CONN_HEALTH_CHECKS` alongside it. The health check is what makes reuse safe — a connection idle between requests can be closed server side (Postgres restart, `pg_terminate_backend`, firewall idle timeout), and without the check Django hands that dead socket to the next request as an `OperationalError`. With it, Django pings, discards, and reconnects silently.

Before / after on the same settings module:

| | top-level `CONN_MAX_AGE` | `connections['default']` |
|---|---|---|
| before | 60 | 0 |
| after | absent | 60, health checks on |

This also makes `library/django_utils/major_operation.py:44` true for the first time — its *"Reset on exit as connections are reused (CONN_MAX_AGE)"* comment was written assuming persistent connections were on.

**Worth eyeballing before merge:** connection count. Gunicorn plus six celery workers (four at `--concurrency=4`, two at 1, per `scripts/celery_start.sh`) will now each hold a connection open for up to 60s between uses, where previously they held none. Worth a look at `max_connections` on the deploy target.

## `STATICFILES_STORAGE` and `USE_L10N` — removed in Django 5.1 / 5.0

Both deleted, which documents what already happens rather than changing it. We have been running plain `StaticFilesStorage` since the Django 5 upgrade (the hashed files and `staticfiles.json` in `STATIC_ROOT` are fossils), and localisation has been unconditionally on since 5.0, which matches the `True` we were setting.

Restoring manifest hashing via `STORAGES` is the other option in the issue and is deliberately **not** done here — it makes `collectstatic` mandatory on every deploy and hard-fails on any `{% static %}` pointing at a missing file, so it wants its own change with a full collectstatic and template sweep behind it.

The two tests overriding `STATICFILES_STORAGE` were no-ops for exactly the same reason. They move to the `STORAGES` form that actually takes effect, so `URLTestCase`'s stated protection against `ManifestStaticFilesStorage` is real again if anyone does enable it later. Shared as `PLAIN_STATICFILES_STORAGES` since `override_settings(STORAGES=...)` replaces the whole dict and both call sites need the `default` entry carried through.

## Minor cleanups

- **`views_uploaded_classifications_unmapped.py`** — drops the `force_text`/`smart_text` compat shim. The `force_text` half was misspelled `force_text1` so it never landed, and the pinned `django-storages` 1.14.6 contains zero references to either name, so the `smart_text` half was patching something nobody reads. The `# lazily have s3boto3 requirements` comment had no import under it either — the real lazy import is in `uploaded_file_types.py:127`. Removes the now-unused `import django`.
- **`library/jqgrid/jqgrid.py`** — the `NullBooleanField` branch is unreachable twice over: the field is removed except for historical migrations (`fields.E903`), and it subclasses `BooleanField`, so the remaining check already covers it.

## Out of scope

`SECURE_CSP` report-only is noted on SACGF/variantgrid_private#3756 rather than done here — it is a new feature rather than a no-op fix, and needs a report endpoint decided against `GlobalLoginRequiredMiddleware`. The venv drift in the issue (`django==6.1` pinned vs 6.0.6 installed) is an environment fix with no source change.

## Testing

`manage.py check` clean. Ran the sync test plus the jqgrid- and URL-heavy modules — `sync.tests.test_classification_sync_status`, `snpdb.tests.test_urls`, `variantopedia.tests.test_urls`, `patients.tests.test_urls`, `upload.tests.test_urls`, `analysis.tests.test_urls`, `analysis.tests.test_grid_export`, `library.tests.test_jqgrid_paginator`, `classification.tests.utils.test_urls` — 76 tests, all passing.

Note that local runs are against Django 6.0.6 while `requirements.txt` pins 6.1, per the environment drift in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)