### PR TITLE
StringAgg: wrap str delimiters in Value() #1736

### DIFF
--- a/analysis/grids.py
+++ b/analysis/grids.py
@@ -7,9 +7,8 @@ from typing import Any, Optional
 import pandas as pd
 from auditlog.models import LogEntry
 from django.conf import settings
-from django.contrib.postgres.aggregates import StringAgg
 from django.core.exceptions import PermissionDenied
-from django.db.models import F, Max, Q, QuerySet
+from django.db.models import F, Max, Q, QuerySet, StringAgg, Value
 from django.db.models.functions import Substr
 from django.shortcuts import get_object_or_404
 from django.urls.base import reverse
@@ -458,7 +457,7 @@ class AnalysesGrid(JqGridUserRowConfig):
         qs = qs.filter(visible=True, template_type__isnull=True)  # Hide templates
         q_last_lock = Q(analysislock=F("last_lock")) | Q(analysislock__isnull=True)
         qs = qs.annotate(last_lock=Max("analysislock__pk")).filter(q_last_lock)
-        qs = qs.annotate(tags=StringAgg("varianttag__tag", delimiter='|'))
+        qs = qs.annotate(tags=StringAgg("varianttag__tag", delimiter=Value('|')))
         self.queryset = qs.values(*fields)
         self.extra_config.update({'sortname': 'modified',
                                   'sortorder': 'desc'})

--- a/analysis/tasks/analysis_grid_export_tasks.py
+++ b/analysis/tasks/analysis_grid_export_tasks.py
@@ -10,7 +10,7 @@ import celery
 from celery.exceptions import Retry
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.postgres.aggregates.general import StringAgg
+from django.db.models import StringAgg, Value
 from django.utils import timezone
 
 from analysis.analysis_templates import get_cohort_analysis, get_sample_analysis
@@ -214,7 +214,7 @@ def export_node_to_downloadable_file(self, node_id, node_version, user_id, expor
                 pk=canonical_transcript_collection_id)
 
         variant_tags_qs = Variant.objects.filter(varianttag__analysis=node.analysis)
-        variant_tags_qs = variant_tags_qs.annotate(tags=StringAgg("varianttag__tag", delimiter=', ', distinct=True))
+        variant_tags_qs = variant_tags_qs.annotate(tags=StringAgg("varianttag__tag", delimiter=Value(', '), distinct=True))
         variant_tags_dict = dict(variant_tags_qs.values_list("id", "tags"))
 
         request = FakeRequest(user=user)

--- a/genes/grids.py
+++ b/genes/grids.py
@@ -4,9 +4,8 @@ from functools import reduce
 from typing import Any, Optional
 
 from django.conf import settings
-from django.contrib.postgres.aggregates.general import StringAgg
 from django.core.exceptions import PermissionDenied
-from django.db.models import Count, IntegerField, OuterRef, QuerySet, Subquery, TextField
+from django.db.models import Count, IntegerField, OuterRef, QuerySet, StringAgg, Subquery, TextField, Value
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.urls.base import reverse
@@ -288,7 +287,7 @@ class CanonicalTranscriptCollectionColumns(DatatableConfig[CanonicalTranscriptCo
 
     def get_initial_queryset(self) -> QuerySet[GeneList]:
         qs = CanonicalTranscriptCollection.objects.all()
-        return qs.annotate(enrichment_kits=StringAgg("enrichmentkit__name", ',', output_field=TextField()),
+        return qs.annotate(enrichment_kits=StringAgg("enrichmentkit__name", Value(','), output_field=TextField()),
                            num_transcripts=Count("canonicaltranscript"))
 
     def filter_queryset(self, qs: QuerySet[GeneList]) -> QuerySet[GeneList]:

--- a/genes/models.py
+++ b/genes/models.py
@@ -15,7 +15,6 @@ from urllib.error import URLError
 from cache_memoize import cache_memoize
 from django.conf import settings
 from django.contrib.auth.models import Group, User
-from django.contrib.postgres.aggregates import StringAgg
 from django.core.cache import cache
 from django.core.exceptions import (
     MultipleObjectsReturned,
@@ -24,7 +23,7 @@ from django.core.exceptions import (
     ValidationError,
 )
 from django.db import IntegrityError, models, transaction
-from django.db.models import QuerySet, TextField
+from django.db.models import QuerySet, StringAgg, TextField, Value
 from django.db.models.deletion import CASCADE, PROTECT, SET_NULL
 from django.db.models.functions import Collate, Upper
 from django.db.models.query_utils import Q
@@ -1832,7 +1831,7 @@ class GeneListGeneSymbol(models.Model):
     def get_joined_genes_qs_annotation_for_release(release: GeneAnnotationRelease):
         """ Used to annotate GeneListGeneSymbol queryset """
         return StringAgg("gene_symbol__releasegenesymbol__releasegenesymbolgene__gene",
-                         delimiter=',', distinct=True, output_field=TextField(),
+                         delimiter=Value(','), distinct=True, output_field=TextField(),
                          filter=Q(gene_symbol__releasegenesymbol__release=release))
 
     def __str__(self):

--- a/patients/grids.py
+++ b/patients/grids.py
@@ -1,7 +1,6 @@
 from functools import partial
 
-from django.contrib.postgres.aggregates.general import StringAgg
-from django.db.models import QuerySet, TextField
+from django.db.models import QuerySet, StringAgg, TextField, Value
 from django.db.models.aggregates import Count
 from django.db.models.query_utils import Q
 from django.http import HttpRequest
@@ -54,18 +53,18 @@ class PatientListGrid(JqGridUserRowConfig):
         q_mondo = Q(**{f"{PATIENT_ONTOLOGY_TERM_PATH}__ontology_service": OntologyService.MONDO})
         q_hgnc = Q(**{f"{PATIENT_ONTOLOGY_TERM_PATH}__ontology_service": OntologyService.HGNC})
         # Add sample_count to queryset
-        annotation_kwargs = {"reference_id": StringAgg("specimen__reference_id", ',',
+        annotation_kwargs = {"reference_id": StringAgg("specimen__reference_id", Value(','),
                                                        distinct=True, output_field=TextField()),
-                             "hpo": StringAgg(ontology_path, '|',
+                             "hpo": StringAgg(ontology_path, Value('|'),
                                               filter=q_hpo, distinct=True, output_field=TextField()),
-                             "omim": StringAgg(ontology_path, '|',
+                             "omim": StringAgg(ontology_path, Value('|'),
                                                filter=q_omim, distinct=True, output_field=TextField()),
-                             "mondo": StringAgg(ontology_path, '|',
+                             "mondo": StringAgg(ontology_path, Value('|'),
                                                 filter=q_mondo, distinct=True, output_field=TextField()),
-                             "hgnc": StringAgg(ontology_path, '|',
+                             "hgnc": StringAgg(ontology_path, Value('|'),
                                                filter=q_hgnc, distinct=True, output_field=TextField()),
                              "sample_count": Count("sample", distinct=True),
-                             "samples": StringAgg("sample__name", ", ", distinct=True, output_field=TextField())}
+                             "samples": StringAgg("sample__name", Value(", "), distinct=True, output_field=TextField())}
         queryset = queryset.annotate(**annotation_kwargs)
         field_names = self.get_field_names() + list(annotation_kwargs.keys())
         self.queryset = queryset.values(*field_names)

--- a/seqauto/grids/sequencing_data_grids.py
+++ b/seqauto/grids/sequencing_data_grids.py
@@ -1,8 +1,7 @@
 from typing import Any
 
 from django.conf import settings
-from django.contrib.postgres.aggregates.general import StringAgg
-from django.db.models import QuerySet, TextField
+from django.db.models import QuerySet, StringAgg, TextField, Value
 from django.db.models.aggregates import Count
 from django.db.models.functions import Cast
 from django.utils.html import format_html_join, mark_safe
@@ -39,7 +38,7 @@ class ExperimentColumns(DatatableConfig[Experiment]):
 
     def get_initial_queryset(self) -> QuerySet[Experiment]:
         queryset = Experiment.objects.all()
-        return queryset.annotate(sequencing_runs=StringAgg("sequencingrun", ',', output_field=TextField()))
+        return queryset.annotate(sequencing_runs=StringAgg("sequencingrun", Value(','), output_field=TextField()))
 
 
 class SequencingRunListGrid(JqGridUserRowConfig):
@@ -76,12 +75,12 @@ class SequencingRunListGrid(JqGridUserRowConfig):
 
         annotate = {
             "sample_count": Count("sequencingruncurrentsamplesheet__sample_sheet__sequencingsample"),
-            "vcf_ids": StringAgg(Cast("vcffromsequencingrun__vcf__pk", TextField()), ',',
-                                 output_field=TextField(), ordering="vcffromsequencingrun"),
-            "vcf_variant_caller": StringAgg("vcffromsequencingrun__variant_caller__name", ',',
-                                            output_field=TextField(), ordering="vcffromsequencingrun"),
-            "vcf_import_status": StringAgg("vcffromsequencingrun__vcf__import_status", ',',
-                                           ordering="vcffromsequencingrun"),
+            "vcf_ids": StringAgg(Cast("vcffromsequencingrun__vcf__pk", TextField()), Value(','),
+                                 output_field=TextField(), order_by="vcffromsequencingrun"),
+            "vcf_variant_caller": StringAgg("vcffromsequencingrun__variant_caller__name", Value(','),
+                                            output_field=TextField(), order_by="vcffromsequencingrun"),
+            "vcf_import_status": StringAgg("vcffromsequencingrun__vcf__import_status", Value(','),
+                                           order_by="vcffromsequencingrun"),
         }
 
         # Add sample_count to queryset

--- a/snpdb/grid_columns/custom_columns.py
+++ b/snpdb/grid_columns/custom_columns.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import User
-from django.contrib.postgres.aggregates import StringAgg
-from django.db.models import Max, OuterRef, Q, Subquery, Value
+from django.db.models import Max, OuterRef, Q, StringAgg, Subquery, Value
 from django.db.models.functions import Coalesce
 
 from analysis.models import VariantTag
@@ -69,14 +68,14 @@ def get_custom_column_fields_override_and_sample_position(custom_columns_collect
 
 def get_variantgrid_extra_annotate(user: User, exclude_analysis=None) -> dict:
     classification_qs = ClassificationModification.latest_for_user(user).filter(classification__allele__variantallele__variant_id=OuterRef("id")).order_by("pk")  # So comma sep fields line up
-    internally_classified = classification_qs.annotate(cs=Coalesce("classification__clinical_significance", Value('U'))).values("classification__allele").annotate(cs_summary=StringAgg("cs", delimiter='|')).values_list("cs_summary")
-    internally_classified_labs = classification_qs.annotate(cln=Coalesce("classification__lab__name", Value(''))).values("classification__allele").annotate(c_lab=StringAgg("cln", delimiter='|')).values_list("c_lab")
+    internally_classified = classification_qs.annotate(cs=Coalesce("classification__clinical_significance", Value('U'))).values("classification__allele").annotate(cs_summary=StringAgg("cs", delimiter=Value('|'))).values_list("cs_summary")
+    internally_classified_labs = classification_qs.annotate(cln=Coalesce("classification__lab__name", Value(''))).values("classification__allele").annotate(c_lab=StringAgg("cln", delimiter=Value('|'))).values_list("c_lab")
     max_internal_classification = classification_qs.annotate(cs=Coalesce("classification__clinical_significance", Value('0'))).values("classification__allele").annotate(cs_max=Max("classification__clinical_significance")).values_list("cs_max")
 
     tags_qs = VariantTag.filter_for_user(user).filter(allele__variantallele__variant_id=OuterRef("id"))
     if exclude_analysis:
         tags_qs = tags_qs.filter(Q(analysis__isnull=True) | Q(analysis__id__ne=exclude_analysis.pk))
-    tags_global = tags_qs.values("allele").annotate(tags=StringAgg("tag_id", delimiter='|')).values_list("tags")
+    tags_global = tags_qs.values("allele").annotate(tags=StringAgg("tag_id", delimiter=Value('|'))).values_list("tags")
 
     return {
         "internally_classified": Subquery(internally_classified[:1]),

--- a/snpdb/grids.py
+++ b/snpdb/grids.py
@@ -3,8 +3,7 @@ from functools import reduce
 from typing import Any, Optional
 
 from django.conf import settings
-from django.contrib.postgres.aggregates.general import StringAgg
-from django.db.models import F, Func, IntegerField, OuterRef, QuerySet, Subquery, Value
+from django.db.models import F, Func, IntegerField, OuterRef, QuerySet, StringAgg, Subquery, Value
 from django.db.models.aggregates import Count, Max
 from django.db.models.fields import CharField, TextField
 from django.db.models.query_utils import Q
@@ -824,7 +823,7 @@ class SampleColumns(DatatableConfig[Sample]):
         annotation_kwargs = {}
         for ot in [OntologyService.OMIM, OntologyService.HPO, OntologyService.MONDO]:
             q_ot = Q(**{f"{sample_patient_ontology_path}__ontology_service": ot})
-            annotation_kwargs[ot.label] = StringAgg(ontology_path, '|',
+            annotation_kwargs[ot.label] = StringAgg(ontology_path, Value('|'),
                                                     filter=q_ot, distinct=True,
                                                     output_field=TextField())
         return qs.annotate(**annotation_kwargs)

--- a/snpdb/variant_sample_information.py
+++ b/snpdb/variant_sample_information.py
@@ -4,8 +4,7 @@ from functools import cached_property
 from typing import Optional
 
 from django.conf import settings
-from django.contrib.postgres.aggregates.general import StringAgg
-from django.db.models import Q, TextField
+from django.db.models import Q, StringAgg, TextField, Value
 from django.urls import reverse
 
 from annotation.models.models import VariantAnnotation
@@ -268,11 +267,11 @@ class VariantZygosityCounts:
         q_hpo = Q(**{f"patient__{PATIENT_ONTOLOGY_TERM_PATH}__ontology_service": OntologyService.HPO})
         q_omim = Q(**{f"patient__{PATIENT_ONTOLOGY_TERM_PATH}__ontology_service": OntologyService.OMIM})
         q_mondo = Q(**{f"patient__{PATIENT_ONTOLOGY_TERM_PATH}__ontology_service": OntologyService.MONDO})
-        annotation_kwargs = {"patient_hpo": StringAgg(ontology_path, '|', filter=q_hpo,
+        annotation_kwargs = {"patient_hpo": StringAgg(ontology_path, Value('|'), filter=q_hpo,
                                                       distinct=True, output_field=TextField()),
-                             "patient_omim": StringAgg(ontology_path, '|', filter=q_omim,
+                             "patient_omim": StringAgg(ontology_path, Value('|'), filter=q_omim,
                                                        distinct=True, output_field=TextField()),
-                             "patient_mondo": StringAgg(ontology_path, '|', filter=q_mondo,
+                             "patient_mondo": StringAgg(ontology_path, Value('|'), filter=q_mondo,
                                                         distinct=True, output_field=TextField())}
         samples_qs = Sample.objects.filter(pk__in=sample_ids).order_by("pk").annotate(**annotation_kwargs)
         sample_values = samples_qs.values("vcf__allele_frequency_percent", *COPY_SAMPLE_FIELDS,

--- a/variantopedia/interesting_nearby.py
+++ b/variantopedia/interesting_nearby.py
@@ -4,8 +4,7 @@ from collections import Counter, defaultdict
 from functools import reduce
 
 from django.conf import settings
-from django.contrib.postgres.aggregates import StringAgg
-from django.db.models import Count, Q, Sum
+from django.db.models import Count, Q, StringAgg, Sum, Value
 
 from annotation.annotation_version_querysets import get_variant_queryset_for_annotation_version
 from annotation.models import AnnotationVersion, VariantTranscriptAnnotation
@@ -169,7 +168,7 @@ def interesting_counts(qs, user, genome_build, clinical_significance=False):
 
     agg_kwargs = {
         "total": Count("id", distinct=True),
-        "tags": StringAgg("variantallele__allele__varianttag__tag", delimiter='|'),
+        "tags": StringAgg("variantallele__allele__varianttag__tag", delimiter=Value('|')),
     }
 
     clinical_significance_list = [c[0] for c in ClinicalSignificance.SHORT_CHOICES]


### PR DESCRIPTION
🤖 Written by Claude

Addresses #1736.

Django 7.0 resolves a bare `str` delimiter passed to `StringAgg` as a **field reference** instead of a string literal — a silent behaviour change that would corrupt grid/export values rather than raise. `django.contrib.postgres.aggregates.StringAgg` is itself a `RemovedInDjango70` shim.

## Changes

All 22 call sites across 10 files:

1. `delimiter='|'` → `delimiter=Value('|')` (including the positional second-argument form)
2. Import `StringAgg` from `django.db.models` rather than `django.contrib.postgres.aggregates[.general]`

One extra change beyond the issue: `seqauto/grids/sequencing_data_grids.py` passed `ordering="vcffromsequencingrun"` on three aggregates. `ordering=` only exists on the `contrib.postgres` subclass (itself deprecated in favour of `order_by=`), so those became `order_by=`.

## Verification

- `manage.py check` and the URL/grid test suites for the touched apps (`patients`, `seqauto`, `snpdb`, `genes`, `variantopedia`, `analysis` — 87 tests) run clean under `-W error::PendingDeprecationWarning`, which turns `RemovedInDjango70Warning` into an error.
- Ran the rewritten aggregates directly against a dev DB (experiment sequencing runs, sequencing run `vcf_ids` with `order_by`, patient HPO terms, variant tags) and confirmed the delimiters still join as before.
- No `django.contrib.postgres.aggregates` imports remain in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)