### PR TITLE
Add joint_called_vcf API alias, return 404 for missing pages

### DIFF
--- a/seqauto/urls.py
+++ b/seqauto/urls.py
@@ -119,6 +119,8 @@ router.register(r'api/v1/variant_caller', VariantCallerViewSet, basename='api_va
 router.register(r'api/v1/sequencing_run', SequencingRunViewSet, basename='api_sequencing_run')
 router.register(r'api/v1/sample_sheet', SampleSheetViewSet, basename='api_sample_sheet')
 router.register(r'api/v1/vcf_file', VCFFileViewSet, basename='api_vcf_file')
+router.register(r'api/v1/joint_called_vcf', SampleSheetCombinedVCFFileViewSet, basename='api_joint_called_vcf')
+# Old name kept for clients that haven't moved to joint_called_vcf yet
 router.register(r'api/v1/sample_sheet_combined_vcf_file', SampleSheetCombinedVCFFileViewSet, basename='api_sample_sheet_combined_vcf_file')
 router.register(r'api/v1/fastqc', FastQCViewSet, basename='api_fastqc')
 router.register(r'api/v1/illumina_flowcell_qc', IlluminaFlowcellQCViewSet, basename='api_illumina_flowcell_qc')

--- a/variantgrid/views.py
+++ b/variantgrid/views.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-from django.http.response import HttpResponseServerError, JsonResponse, \
+from django.http.response import HttpResponseNotFound, HttpResponseServerError, JsonResponse, \
     HttpResponseForbidden
 from django.shortcuts import redirect, render
 from django.template.loader import get_template, render_to_string
@@ -42,25 +42,27 @@ def page_not_found(request, exception):
         message = "Could not determine page."
         exception = None
     context = {"message": message, "exception": exception}
-    return custom_error_view(request, context)
+    response = _get_custom_error_response(request, context)
+    return HttpResponseNotFound(response)
 
 
 @login_not_required
 def server_error(request):
     message = "There was an internal server error (sorry!). This has been logged and will be investigated by the development team. "
     context = {"message": message}
-    return custom_error_view(request, context)
+    response = _get_custom_error_response(request, context)
+    return HttpResponseServerError(response)
 
 
 @login_not_required
 def csrf_error(request, reason=''):
     message = "Your session token has changed. Please try your operation again."
     context = {"message": message}
-    return custom_error_view(request, context)
+    response = _get_custom_error_response(request, context)
+    return HttpResponseServerError(response)
 
 
-@login_not_required
-def custom_error_view(request, context=None):
+def _get_custom_error_response(request, context=None):
     # Django 404 and 500 pages dont pass context to templates.
     # This is a hack to do so, as I want to use static files etc.
 
@@ -69,8 +71,7 @@ def custom_error_view(request, context=None):
     else:
         template_name = "server_error_unauth.html"
     t = get_template(template_name)
-    response = t.render(request=request, context=context)
-    return HttpResponseServerError(response)
+    return t.render(request=request, context=context)
 
 
 @login_not_required


### PR DESCRIPTION
🤖 Written by Claude

TAU's pipeline failed over the weekend uploading joint called VCFs to VG3:

```
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url:
http://frgeneseq05vg:92/seqauto/api/v1/joint_called_vcf/
```

## Cause

`variantgrid_api` 1.4.0 ([SACGF/variantgrid_api#16](https://github.com/SACGF/variantgrid_api/issues/16)) renamed the combo VCF endpoint `sample_sheet_combined_vcf_file` → `joint_called_vcf`. The Python deprecation shims kept the old method and class names working, but `create_sample_sheet_combined_vcf_file()` warns and then calls `create_joint_called_vcf()`, which posts to the new URL. This branch only serves the old route, so the POST hits nothing.

Only `joint_called_vcf` is affected — the other 12 endpoints the 1.4.0 client posts to all exist here.

It surfaced as a 500 rather than a 404 because `page_not_found` delegated to `custom_error_view`, which unconditionally returned `HttpResponseServerError` — every missing page on this branch reports as a server crash, which is what made this look like a VG bug rather than a missing endpoint.

## Changes

- `seqauto/urls.py` — register `api/v1/joint_called_vcf` against the existing `SampleSheetCombinedVCFFileViewSet`, keeping the old route for clients still on it. Mirrors what master does, in reverse (master serves the old name off the new viewset).
- `variantgrid/views.py` — backport master's fix: `custom_error_view` becomes `_get_custom_error_response` returning the rendered string, and each handler wraps it in the right response class. 404s become `HttpResponseNotFound`; 500 and CSRF keep `HttpResponseServerError`.

## Compatibility

The payload needs no change — `SampleSheetCombinedVCFFileSerializer` takes `("path", "sample_sheet", "variant_caller")`, exactly what the 1.4.0 client sends. Its one new field, `sequencing_samples`, is excluded from the JSON when `None`, so single-run joint calls are unaffected. Multi-run joint calls (family trios) would silently drop it, since there's no model support for it on this branch.

## Testing

Both files are syntax-checked and the viewset import is confirmed, but I could not boot Django locally to resolve the route for real — this branch predates master's settings (`AttributeError: 'Settings' object has no attribute 'SYNC_DETAILS'` from `variantgrid/celery.py`) and the local venv is built for master. **Worth a `curl` against a VG3 test instance before this goes to prod.**

As an immediate unblock for TAU without a deploy, they can pin `variantgrid_api<1.4.0`.