### PR TITLE
Name Monarch as the cause of condition text search failures

### DIFF
--- a/classification/models/condition_text_search.py
+++ b/classification/models/condition_text_search.py
@@ -1,7 +1,18 @@
-import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from library.constants import MINUTE_SECS
 from ontology.models import OntologyService, OntologyTerm
+
+MONARCH_SEARCH_URL = 'https://api.monarchinitiative.org/v3/api/search'
+
+# Monarch intermittently returns a gateway error, so retry once before letting the failure through
+# (raise_on_status=False so the caller's raise_for_status reports the actual status, not a RetryError)
+_retry = Retry(total=1, status_forcelist=[500, 502, 503, 504], allowed_methods=["GET"],
+               backoff_factor=1, raise_on_status=False)
+_session = Session()
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
 
 
 def condition_text_search(search_text: str, row_limit: int = 10) -> list[OntologyTerm]:
@@ -10,12 +21,21 @@ def condition_text_search(search_text: str, row_limit: int = 10) -> list[Ontolog
         # This is probably not what you want, so return early without API call
         return []
 
-    response = requests.get(
-        'https://api.monarchinitiative.org/v3/api/search', {
+    http_response = _session.get(
+        MONARCH_SEARCH_URL, {
             "q": search_text,
             "category": "biolink:Disease",
             "limit": row_limit
-        }, timeout=MINUTE_SECS).json()
+        }, timeout=MINUTE_SECS)
+    http_response.raise_for_status()
+    try:
+        response = http_response.json()
+    except ValueError as ve:
+        # Monarch can return 200 with a non-JSON body (e.g. a proxy error page) - say who sent what,
+        # otherwise this propagates as a bare JSONDecodeError that looks like a bug in our parsing
+        content_type = http_response.headers.get("Content-Type")
+        raise ValueError(f"Monarch search returned non-JSON ({content_type}): "
+                         f"{http_response.text[:200]}") from ve
 
     results = response.get("items") or []
 

--- a/classification/tests/models/test_condition_text_search.py
+++ b/classification/tests/models/test_condition_text_search.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
+from requests import HTTPError
+from requests.exceptions import JSONDecodeError
 
 from classification.models.condition_text_search import condition_text_search
 
@@ -13,7 +15,7 @@ def _mock_response(*, json_data=None) -> MagicMock:
 
 class ConditionTextSearchTestCase(TestCase):
 
-    @patch("classification.models.condition_text_search.requests.get")
+    @patch("classification.models.condition_text_search._session.get")
     def test_unsupported_ontology_prefix_is_skipped(self, mock_get):
         """ #1603 - a result whose prefix isn't an OntologyService (e.g. MPATH) must not abort the
         whole search; supported results around it are still returned. """
@@ -26,7 +28,7 @@ class ConditionTextSearchTestCase(TestCase):
 
         self.assertEqual(["MONDO:0000001"], [term.id for term in terms])
 
-    @patch("classification.models.condition_text_search.requests.get")
+    @patch("classification.models.condition_text_search._session.get")
     def test_aliased_prefix_is_kept(self, mock_get):
         """ A supported ontology under an alias spelling (Orphanet -> ORPHA) must not be skipped. """
         mock_get.return_value = _mock_response(json_data={"items": [
@@ -37,7 +39,7 @@ class ConditionTextSearchTestCase(TestCase):
 
         self.assertEqual(["ORPHA:12345"], [term.id for term in terms])
 
-    @patch("classification.models.condition_text_search.requests.get")
+    @patch("classification.models.condition_text_search._session.get")
     def test_malformed_id_is_skipped_without_aborting(self, mock_get):
         """ A malformed id from Monarch must not abort the whole search - it's skipped like any other
         id we can't turn into a supported ontology term, and valid results around it survive. """
@@ -49,3 +51,32 @@ class ConditionTextSearchTestCase(TestCase):
         terms = condition_text_search("anything")
 
         self.assertEqual(["MONDO:0000001"], [term.id for term in terms])
+
+    @patch("classification.models.condition_text_search._session.get")
+    def test_non_json_body_names_monarch(self, mock_get):
+        """ #1742 - a 200 with a non-JSON body has to propagate as an error that identifies Monarch
+        and what it sent, rather than a bare JSONDecodeError. """
+        response = MagicMock()
+        response.json.side_effect = JSONDecodeError("Expecting value", "\n<html>502</html>", 1)
+        response.headers = {"Content-Type": "text/html"}
+        response.text = "\n<html>502 Bad Gateway</html>"
+        mock_get.return_value = response
+
+        with self.assertRaises(ValueError) as cm:
+            condition_text_search("anything")
+
+        message = str(cm.exception)
+        self.assertIn("Monarch", message)
+        self.assertIn("text/html", message)
+        self.assertIn("502 Bad Gateway", message)
+
+    @patch("classification.models.condition_text_search._session.get")
+    def test_http_error_propagates(self, mock_get):
+        """ #1742 - an error status propagates as an HTTPError (which names the status and Monarch's
+        URL) instead of dying on the JSON parse. """
+        response = MagicMock()
+        response.raise_for_status.side_effect = HTTPError("503 Server Error for url: monarch")
+        mock_get.return_value = response
+
+        with self.assertRaises(HTTPError):
+            condition_text_search("anything")


### PR DESCRIPTION
🤖 Written by Claude

Addresses #1742.

## Changes

`classification/models/condition_text_search.py`

- **`raise_for_status()` before `.json()`** — restores the line dropped as collateral in 8c6c45aad. An upstream 5xx now reports as `503 Server Error: ... for url: https://api.monarchinitiative.org/v3/api/search` instead of dying on the parse with no status code.
- **Named error for a non-JSON 200** — `.json()` failure is re-raised (chained from the original) as `Monarch search returned non-JSON (text/html): <first 200 chars of body>`, so the report says who sent what.
- **Retry once on 5xx** — module-level `Session` with a mounted `Retry(total=1, status_forcelist=[500, 502, 503, 504])`, following the pattern in `library/utils/misc_utils.py`. `raise_on_status=False` so an exhausted retry still yields the real response and `raise_for_status()` reports the actual status rather than a `RetryError`.

Failures keep propagating to the existing `report_exc_info()` handlers in `condition_text_matching.search_suggestion` and `ontology_matching` — the #1603 decision to let Monarch outages stay visible is unchanged, only the message improves.

## Testing

`classification/tests/models/test_condition_text_search.py` — 5 tests pass. The three existing ones move their patch target to `_session.get`; two new ones cover a non-JSON 200 (error names Monarch, the content type and the body) and an error status propagating as `HTTPError`.

Checked against the live API outside the test suite:

- Monarch search over the mounted session returns `200` and parses — `['MONDO:0009061', 'MONDO:1010544', 'MONDO:1010543']` for "cystic fibrosis".
- A forced `503` retries and surfaces as `HTTPError: 503 Server Error: SERVICE UNAVAILABLE for url: ...`, confirming `raise_on_status=False` keeps the status visible.

Also probed while diagnosing #1742: Solr metacharacters (`"`, `[`, `(`, `\`, `^`, `~`, `a:b`, bare `AND`/`OR`) and query texts up to 10k chars all return valid JSON 200s, so this is a transient upstream failure rather than a particular condition text.
