### PR TITLE
Patient / specimen detail on the variant page samples grid private#2837

### DIFF
--- a/snpdb/tests/test_variant_sample_genotypes.py
+++ b/snpdb/tests/test_variant_sample_genotypes.py
@@ -1,13 +1,15 @@
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.utils import timezone
 
 from annotation.fake_annotation import get_fake_annotation_version
 from classification.enums import ShareLevel, SpecialEKeys, SubmissionSource
 from classification.models import Classification
 from classification.tests.models.test_utils import ClassificationTestUtils
 from library.guardian_utils import all_users_group, assign_permission_to_user_and_groups
-from patients.models_enums import Zygosity
+from patients.models import Extraction, Patient, Specimen, Tissue
+from patients.models_enums import NucleicAcid, TissueStatus, Zygosity
 from snpdb.models import (
     CohortGenotype,
     CohortGenotypeCollection,
@@ -288,3 +290,81 @@ class VariantSampleGenotypesClassificationsTest(TestCase):
         self.assertEqual([], by_sample_name["proband"], "Not shared outside the lab's organisation")
         lab_by_sample_name = self._classifications_by_sample_name(self.lab_user)
         self.assertEqual(1, len(lab_by_sample_name["proband"]), "Visible to the lab that curated it")
+
+
+class VariantSampleGenotypesSampleDetailsTest(TestCase):
+    """ The patient/specimen/extraction detail behind the grid's expandable row (private#2837) """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.grch37 = GenomeBuild.get_name_or_alias("GRCh37")
+        get_fake_annotation_version(cls.grch37)
+
+        cls.user = User.objects.get_or_create(username='vsg_details_user')[0]
+        cls.user.groups.add(all_users_group())
+        cls.cohort = create_fake_cohort(cls.user, cls.grch37)
+        cls.samples = {s.name: s for s in cls.cohort.get_samples()}
+        for sample in cls.samples.values():
+            assign_permission_to_user_and_groups(cls.user, sample)
+
+        cls.patient = Patient.objects.create(patient_code="PAT-1")
+        cls.tissue = Tissue.objects.create(name="Blood", description="Whole blood")
+        cls.specimen = Specimen.objects.create(patient=cls.patient, reference_id="SPEC-1", tissue=cls.tissue,
+                                               tissue_status=TissueStatus.AFFECTED,
+                                               collection_date=timezone.now())
+        cls.extraction = Extraction.objects.create(specimen=cls.specimen, reference_id="EXT-1",
+                                                   nucleic_acid_source=NucleicAcid.DNA)
+        proband = cls.samples["proband"]
+        proband.patient = cls.patient
+        proband.extraction = cls.extraction
+        proband.save()
+
+        cls.variant = slowly_create_test_variant("3", 7000, "A", "T", cls.grch37)
+        cgc = CohortGenotypeCollection.objects.get(cohort=cls.cohort)
+        CohortGenotype.objects.create(collection=cgc, variant=cls.variant,
+                                      samples_zygosity=Zygosity.HET * 3,
+                                      samples_allele_depth=[20] * 3, samples_allele_frequency=[100] * 3,
+                                      samples_read_depth=[30] * 3, samples_genotype_quality=[30] * 3,
+                                      samples_phred_likelihood=[0] * 3)
+
+    def _rows_by_sample_name(self, user) -> dict:
+        data = VariantSampleGenotypes(user, self.variant).to_json()
+        return {row["sample_name"]: row for row in data["rows"]}
+
+    def test_details_for_visible_patient(self):
+        assign_permission_to_user_and_groups(self.user, self.patient)
+
+        rows = self._rows_by_sample_name(self.user)
+        proband = rows["proband"]
+        self.assertEqual("PAT-1", proband["patient_code"])
+        self.assertEqual("SPEC-1", proband["specimen"])
+        self.assertEqual("Blood", proband["specimen_tissue"])
+        self.assertEqual(TissueStatus.AFFECTED.label, proband["specimen_tissue_status"])
+        self.assertEqual("EXT-1", proband["extraction"])
+        self.assertEqual(NucleicAcid.DNA.label, proband["nucleic_acid"])
+        self.assertNotIn("patient_code", rows["mother"], "Sample with no patient has no detail")
+
+    def test_details_hidden_for_patient_user_cannot_view(self):
+        rows = self._rows_by_sample_name(self.user)
+        proband = rows["proband"]
+        self.assertNotIn("patient_code", proband, "Sample is visible but its patient isn't")
+        self.assertNotIn("specimen", proband)
+        self.assertNotIn("extraction", proband)
+
+    def test_patient_falls_back_to_specimen_patient(self):
+        assign_permission_to_user_and_groups(self.user, self.patient)
+        proband = self.samples["proband"]
+        proband.patient = None  # Linked to an extraction by the pipeline, never matched to a patient
+        proband.save()
+
+        row = self._rows_by_sample_name(self.user)["proband"]
+        self.assertEqual("PAT-1", row["patient_code"], "Patient came via the specimen")
+
+    def test_unknown_tissue_status_omitted(self):
+        assign_permission_to_user_and_groups(self.user, self.patient)
+        self.specimen.tissue_status = TissueStatus.UNKNOWN
+        self.specimen.save()
+
+        proband = self._rows_by_sample_name(self.user)["proband"]
+        self.assertNotIn("specimen_tissue_status", proband, "Unknown is the default, not an answer")

--- a/snpdb/variant_sample_information.py
+++ b/snpdb/variant_sample_information.py
@@ -14,7 +14,8 @@ from classification.models.evidence_mixin_summary_cache import clinical_signific
 from library.log_utils import log_traceback
 from library.unit_percent import format_af
 from ontology.models import OntologyService
-from patients.models_enums import Zygosity
+from patients.models import Patient
+from patients.models_enums import NucleicAcid, TissueStatus, Zygosity
 from snpdb.models import (
     CohortGenotype,
     CohortGenotypeCollection,
@@ -27,10 +28,36 @@ from snpdb.models import (
     VCFFilter,
 )
 from upload.models import ModifiedImportedVariant
+from variantgrid.perm_path import get_visible_url_names
 
 SAMPLE_ENRICHMENT_KIT_PATH = "samplefromsequencingsample__sequencing_sample__enrichment_kit__name"
 # Sample fields a row copies across under a "sample__" prefix
 COPY_SAMPLE_FIELDS = ["id", "name", "patient", "patient__patient_code", SAMPLE_ENRICHMENT_KIT_PATH]
+# Patient / specimen / extraction identifiers behind the grid's expandable row detail (private#2837).
+# Copied across under their own names, and only shown for patients the user can view
+SAMPLE_DETAIL_FIELDS = [
+    "patient__external_pk__code",
+    "extraction",
+    "extraction__reference_id",
+    "extraction__external_pk__code",
+    "extraction__nucleic_acid_source",
+    "extraction__specimen",
+    "extraction__specimen__patient",
+    "extraction__specimen__patient__patient_code",
+    "extraction__specimen__patient__external_pk__code",
+    "extraction__specimen__reference_id",
+    "extraction__specimen__external_pk__code",
+    "extraction__specimen__tissue__name",
+    "extraction__specimen__tissue_status",
+    "extraction__specimen__collection_date",
+]
+# Where a row's patient comes from, in order of preference - the sequencing pipeline links a sample to
+# an Extraction without touching Sample.patient, so the specimen's patient is often the only one there
+PATIENT_DETAIL_PATHS = [
+    ("sample__patient", "sample__patient__patient_code", "patient__external_pk__code"),
+    ("extraction__specimen__patient", "extraction__specimen__patient__patient_code",
+     "extraction__specimen__patient__external_pk__code"),
+]
 # CohortGenotype rows are streamed in chunks, so an early stop leaves the rest of a common variant's
 # VCFs unfetched. Collections are bulk loaded per chunk, so this also sets the queries-per-scan rate.
 COHORT_GENOTYPE_CHUNK_SIZE = 100
@@ -275,7 +302,7 @@ class VariantZygosityCounts:
                                                         distinct=True, output_field=TextField())}
         samples_qs = Sample.objects.filter(pk__in=sample_ids).order_by("pk").annotate(**annotation_kwargs)
         sample_values = samples_qs.values("vcf__allele_frequency_percent", *COPY_SAMPLE_FIELDS,
-                                          *list(annotation_kwargs.keys()))
+                                          *SAMPLE_DETAIL_FIELDS, *list(annotation_kwargs.keys()))
         return {s_values["id"]: s_values for s_values in sample_values}
 
     @staticmethod
@@ -410,8 +437,56 @@ class VariantSampleGenotypes(VariantZygosityCounts):
             log_traceback()
             return None
 
+    @cached_property
+    def _visible_patient_ids(self) -> set[int]:
+        """ A sample carries its VCF's permissions while a patient carries its own, so the identifying
+            detail is only given for patients the user may view (private#2837) """
+        patient_ids = {row["sample__patient"] for row in self.visible_rows}
+        patient_ids |= {row["extraction__specimen__patient"] for row in self.visible_rows}
+        patient_ids.discard(None)
+        if not patient_ids:
+            return set()
+        visible_qs = Patient.filter_for_user(self.user).filter(pk__in=patient_ids)
+        return set(visible_qs.values_list("pk", flat=True))
+
     @staticmethod
-    def _row_to_json(row: dict) -> dict:
+    def _url_if_visible(url_name: str, **kwargs) -> Optional[str]:
+        """ A deployment without patients (eg Shariant) unregisters these urls entirely """
+        if get_visible_url_names().get(url_name):
+            return reverse(url_name, kwargs=kwargs)
+        return None
+
+    def _get_patient_detail(self, row: dict) -> dict:
+        for patient_path, code_path, external_pk_path in PATIENT_DETAIL_PATHS:
+            if (patient_id := row[patient_path]) in self._visible_patient_ids:
+                return {
+                    "patient_code": row[code_path] or row[external_pk_path],
+                    "patient_url": self._url_if_visible("view_patient", patient_id=patient_id),
+                }
+        return {}
+
+    def _get_sample_details(self, row: dict) -> dict:
+        """ Patient/specimen/extraction identifiers, drawn in the grid's expandable row detail """
+        details = self._get_patient_detail(row)
+        if row["extraction__specimen__patient"] in self._visible_patient_ids:
+            details["specimen"] = (row["extraction__specimen__reference_id"]
+                                   or row["extraction__specimen__external_pk__code"])
+            details["specimen_url"] = self._url_if_visible("view_specimen",
+                                                           specimen_id=row["extraction__specimen"])
+            details["specimen_tissue"] = row["extraction__specimen__tissue__name"]
+            # Unknown is the default for a specimen nobody has said anything about, so it's not worth a line
+            tissue_status = row["extraction__specimen__tissue_status"]
+            if tissue_status and tissue_status != TissueStatus.UNKNOWN:
+                details["specimen_tissue_status"] = TissueStatus(tissue_status).label
+            if collection_date := row["extraction__specimen__collection_date"]:
+                details["specimen_collection_date"] = collection_date.strftime(settings.DATE_FORMAT)
+            details["extraction"] = row["extraction__reference_id"] or row["extraction__external_pk__code"]
+            details["extraction_url"] = self._url_if_visible("view_extraction", extraction_id=row["extraction"])
+            if nucleic_acid := row["extraction__nucleic_acid_source"]:
+                details["nucleic_acid"] = NucleicAcid(nucleic_acid).label
+        return {k: v for k, v in details.items() if v}
+
+    def _row_to_json(self, row: dict) -> dict:
         sample_id = row["sample"]
         allele_frequency_unit = row["allele_frequency_unit"]
         if allele_frequency_unit == CohortGenotype.MISSING_NUMBER_VALUE:
@@ -435,7 +510,7 @@ class VariantSampleGenotypes(VariantZygosityCounts):
             "patient_hpo": row["patient_hpo"],
             "patient_omim": row["patient_omim"],
             "patient_mondo": row["patient_mondo"],
-        }
+        } | self._get_sample_details(row)
 
     def _get_locus_counts(self) -> list[dict]:
         """ Zygosity counts for every variant at this locus, this variant first """

--- a/variantgrid/static_files/default_static/js/variant_sample_information.js
+++ b/variantgrid/static_files/default_static/js/variant_sample_information.js
@@ -29,6 +29,17 @@ const VariantSampleInformation = (function () {
     // Graphs share a line, sizing themselves to their flex column - see .graph-row
     const RESPONSIVE = {responsive: true};
     const MAX_GRAPH_TERMS = 20;
+    // The expandable row detail - patient/specimen/extraction identifiers that would make an
+    // already wide grid wider (private#2837). The server leaves out anything it has no value for
+    const DETAIL_FIELDS = [
+        {key: 'patient_code', label: 'Patient', urlKey: 'patient_url'},
+        {key: 'specimen', label: 'Specimen', urlKey: 'specimen_url'},
+        {key: 'specimen_tissue', label: 'Tissue'},
+        {key: 'specimen_tissue_status', label: 'Tissue Status'},
+        {key: 'specimen_collection_date', label: 'Collected'},
+        {key: 'extraction', label: 'Extraction', urlKey: 'extraction_url'},
+        {key: 'nucleic_acid', label: 'Nucleic Acid'},
+    ];
     const GRAPH_HEIGHT = 384;
     const ALLELE_VARIANTS_EVENT = "allele-variants-loaded";
 
@@ -144,8 +155,50 @@ const VariantSampleInformation = (function () {
         return MISSING_FORMAT_VALUES.has(data) ? '.' : data;
     }
 
+    function hasDetails(row) {
+        return DETAIL_FIELDS.some(field => row[field.key]);
+    }
+
+    function renderDetailsControl(data, type, row) {
+        if (type !== 'display' || !hasDetails(row)) {
+            return '';
+        }
+        return $('<i>', {class: 'fas fa-plus-circle', title: 'Patient / specimen details'}).prop('outerHTML');
+    }
+
+    function detailsList(row) {
+        const list = $('<dl>', {class: 'row sample-details'});
+        for (const field of DETAIL_FIELDS) {
+            const value = row[field.key];
+            if (!value) {
+                continue;
+            }
+            const url = field.urlKey && row[field.urlKey];
+            const dd = $('<dd>', {class: 'col-sm-9'});
+            dd.append(url ? $('<a>', {href: url, text: value}) : document.createTextNode(value));
+            list.append($('<dt>', {class: 'col-sm-3', text: field.label}), dd);
+        }
+        return list;
+    }
+
+    function toggleDetails() {
+        const tr = $(this).closest('tr');
+        const row = dataTable.row(tr);
+        if (!row.data() || !hasDetails(row.data())) {
+            return;
+        }
+        if (row.child.isShown()) {
+            row.child.hide();
+        } else {
+            row.child(detailsList(row.data())).show();
+        }
+        $(this).find('i').toggleClass('fa-plus-circle fa-minus-circle');
+    }
+
     function columns() {
         return [
+            {data: null, name: 'details', title: '', className: 'details-control',
+                orderable: false, searchable: false, render: renderDetailsControl},
             {data: 'sample_name', title: 'Sample Name', render: renderSampleLink},
             {data: 'genome_build', name: 'genome_build', title: 'Genome Build', visible: false},
             {data: 'zygosity', title: 'Zygosity', render: renderZygosity},
@@ -162,6 +215,11 @@ const VariantSampleInformation = (function () {
             {data: 'patient_omim', title: 'Patient OMIM', className: 'no-word-wrap', render: ontologyRenderer('OMIM')},
             {data: 'patient_mondo', title: 'Patient MONDO', className: 'no-word-wrap', render: ontologyRenderer('MONDO')},
             {data: 'vcf', title: 'VCF', defaultContent: ''},
+            // Drawn in the row detail rather than taking up width, but still columns so that the
+            // search box and the CSV reach them - that's how you spot rows sharing a patient
+            {data: 'patient_code', title: 'Patient', visible: false, defaultContent: ''},
+            {data: 'specimen', title: 'Specimen', visible: false, defaultContent: ''},
+            {data: 'extraction', title: 'Extraction', visible: false, defaultContent: ''},
         ];
     }
 
@@ -205,11 +263,14 @@ const VariantSampleInformation = (function () {
             buttons: [{
                 extend: 'csv',
                 text: 'CSV',
-                exportOptions: {orthogonal: 'export'},
+                // Everything but the expand control, so the detail columns are in the download too
+                exportOptions: {orthogonal: 'export', columns: ':not(.details-control)'},
                 filename: csvFilename,
                 action: exportCsv,
             }],
         });
+
+        $("#genotype-grid tbody").on('click', 'td.details-control', toggleDetails);
 
         $.fn.dataTable.ext.search.push(function (settings, searchData, dataIndex, rowData) {
             if (settings.nTable.id !== 'genotype-grid') {
@@ -572,6 +633,7 @@ const VariantSampleInformation = (function () {
             dataTable.column('genome_build:name').visible(Object.keys(genomeBuildCounts()).length > 1, false);
             const hasClassifications = allRows.some(row => row.classifications && row.classifications.length);
             dataTable.column('classifications:name').visible(hasClassifications, false);
+            dataTable.column('details:name').visible(allRows.some(hasDetails), false);
             dataTable.rows.add(allRows);
             graphedFilter = null;  // The rows changed, so the graphs have to follow
             dataTable.draw();  // 'draw' redraws the graphs

--- a/variantopedia/templates/variantopedia/variant_sample_information.html
+++ b/variantopedia/templates/variantopedia/variant_sample_information.html
@@ -44,6 +44,19 @@
     .separator {
         padding: 0 5px 0 5px;
     }
+
+    td.details-control {
+        cursor: pointer;
+        color: #6c757d;
+    }
+
+    dl.sample-details {
+        margin: 0.5rem 0 0.5rem 1.5rem;
+    }
+
+    dl.sample-details dd {
+        margin-bottom: 0;
+    }
 </style>
 
 <div id='locus' class="container">


### PR DESCRIPTION
[#1706](https://github.com/SACGF/variantgrid/issues/1706) put the specimen columns on the samples *list* grid (`SamplesListGrid`), not on the variant details samples grid — so the variant page still had no way to tell which rows came off the same patient or block (private#2837).

That grid already scrolls sideways, so the identifiers go behind a click-to-expand row rather than into more columns.

## Grid

- New leftmost expand column, rendered only on rows that have detail; the column hides entirely when nothing in the grid does (same pattern as the classifications column).
- Child row shows patient code, specimen reference, tissue, tissue status, collection date, extraction reference and nucleic acid — each linked to its page.
- Patient / Specimen / Extraction are also hidden columns, so the search box filters the grid by specimen id and the CSV carries them. Reading a specimen off one row at a time is not how you spot rows sharing one.

## Server

- The identifiers join onto the existing single `_get_sample_values()` query — no extra queries per row.
- A sample carries its VCF's permissions while a patient carries its own, so detail is only given for patients passing `Patient.filter_for_user` (one query for the page). Only the patient **code** is shown, never the name — private#2837 hid the whole lot in 2020 because names were visible.
- Patient falls back to the specimen's patient: the sequencing pipeline links a sample to an `Extraction` without ever touching `Sample.patient`, so on TSO 500 data that is usually the only patient there.
- `view_patient` / `view_specimen` / `view_extraction` are unregistered on deployments without patients (Shariant), so they go through `get_visible_url_names()` and values are drawn unlinked rather than raising.

## Testing

4 tests added to `snpdb/tests/test_variant_sample_genotypes.py` (payload, permission gate, specimen-patient fallback, unknown-tissue-status omission). `snpdb.tests.test_variant_sample_genotypes`, `snpdb.tests.test_variant_sample_information`, `variantopedia.tests.test_urls` and `beacon` all pass.

The expand interaction has not been checked in a browser.

## Follow-up worth considering

The three ontology columns (Patient HPO/OMIM/MONDO) are now the widest thing left and are already summarised by the phenotype graphs below — they could move into the expand too. They also show patient phenotype terms without any patient permission check (pre-existing, untouched here), which is inconsistent with the gating added above.