### PR TITLE
Specimen / Extraction grids, and links to them from the samples grid #1706

### DIFF
--- a/patients/forms.py
+++ b/patients/forms.py
@@ -119,10 +119,12 @@ class PatientSearchForm(forms.Form):
     phenotype = forms.CharField(widget=TextInput(attrs={'placeholder': 'Phenotype text'}))
 
 
+# Tissue has no way to be created yet (#1747), so both editors here leave out a dropdown that
+# could only ever be empty
 PatientSpecimenFormSet = inlineformset_factory(Patient,
                                                Specimen,
                                                can_delete=True,
-                                               exclude=['external_pk'],
+                                               exclude=['external_pk', 'tissue'],
                                                widgets={'name': TextInput(),
                                                         'description': TextInput(),
                                                         'reference_id': TextInput(),
@@ -135,7 +137,7 @@ PatientSpecimenFormSet = inlineformset_factory(Patient,
 # The specimen/extraction pages edit the same fields as the patient tabs' formsets - the tabs stay the
 # bulk editor, external_pk is the tracking system's identity so both show it read only beside the form
 SpecimenForm = modelform_factory(Specimen,
-                                 exclude=['external_pk', 'patient'],
+                                 exclude=['external_pk', 'patient', 'tissue'],
                                  widgets={'description': TextInput(),
                                           'reference_id': TextInput(),
                                           'collected_by': TextInput(),

--- a/patients/grids.py
+++ b/patients/grids.py
@@ -5,14 +5,17 @@ from django.db.models.aggregates import Count
 from django.db.models.query_utils import Q
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 
 from annotation.models.models_phenotype_match import PATIENT_ONTOLOGY_TERM_PATH
 from library.jqgrid.jqgrid_user_row_config import JqGridUserRowConfig
+from library.utils import JsonDataType
 from ontology.grids import AbstractOntologyGenesGrid
 from ontology.models import OntologyService, OntologyTerm
-from patients.models import Patient, PatientRecord, PatientRecords
-from patients.models_enums import PatientRecordMatchType
-from snpdb.views.datatable_view import CellData, DatatableConfig, RichColumn
+from patients.models import Extraction, Patient, PatientRecord, PatientRecords, Specimen
+from patients.models_enums import NucleicAcid, PatientRecordMatchType, TissueStatus
+from snpdb.models import Sample
+from snpdb.views.datatable_view import CellData, DatatableConfig, RichColumn, SortOrder
 
 
 class PatientListGrid(JqGridUserRowConfig):
@@ -153,6 +156,98 @@ class PatientRecordColumns(DatatableConfig[PatientRecord]):
         patient_records = get_object_or_404(PatientRecords, pk=patient_records_id)
         patient_records.check_can_view(self.user)
         return PatientRecord.objects.filter(patient_records=patient_records)
+
+
+def _render_patient_link(row: CellData, patient_id_column: str) -> JsonDataType:
+    """ The de-identified patient_code is the text, the same as the patient grid shows """
+    patient_id = row[patient_id_column]
+    return {
+        "text": row.value or f"({patient_id})",
+        "url": reverse('view_patient', kwargs={"patient_id": patient_id}),
+    }
+
+
+class SpecimenColumns(DatatableConfig[Specimen]):
+    def __init__(self, request: HttpRequest):
+        super().__init__(request)
+        self.search_box_enabled = True
+
+        self.rich_columns = [
+            RichColumn('id', visible=False),
+            RichColumn('reference_id', label='Reference ID', orderable=True,
+                       renderer=self.view_primary_key, client_renderer='TableFormat.linkUrl'),
+            RichColumn('patient__patient_code', label='Patient', orderable=True,
+                       extra_columns=['patient_id'],
+                       renderer=partial(_render_patient_link, patient_id_column='patient_id'),
+                       client_renderer='TableFormat.linkUrl'),
+            RichColumn('tissue__name', label='Tissue', orderable=True),
+            RichColumn('tissue_status', label='Tissue Status', orderable=True, search=False,
+                       client_renderer=RichColumn.choices_client_renderer(TissueStatus.choices)),
+            RichColumn('collection_date', label='Collected', orderable=True,
+                       client_renderer='TableFormat.timestamp'),
+            RichColumn('received_date', label='Received', orderable=True,
+                       client_renderer='TableFormat.timestamp'),
+            RichColumn('external_pk__code', label='External ID', orderable=True),
+            RichColumn('extraction_count', label='# Extractions', orderable=True, search=False,
+                       css_class='num'),
+            RichColumn('modified', orderable=True, search=False, default_sort=SortOrder.DESC,
+                       client_renderer='TableFormat.timestamp'),
+        ]
+
+    def get_initial_queryset(self) -> QuerySet[Specimen]:
+        qs = Specimen.filter_for_user(self.user)
+        return qs.annotate(extraction_count=Count("extraction", distinct=True))
+
+
+class ExtractionColumns(DatatableConfig[Extraction]):
+    def __init__(self, request: HttpRequest):
+        super().__init__(request)
+        self.search_box_enabled = True
+
+        self.rich_columns = [
+            RichColumn('id', visible=False),
+            RichColumn('reference_id', label='Reference ID', orderable=True,
+                       renderer=self.render_reference_id, client_renderer='TableFormat.linkUrl'),
+            RichColumn('specimen__reference_id', label='Specimen', orderable=True,
+                       extra_columns=['specimen_id'],
+                       renderer=self.render_specimen_link, client_renderer='TableFormat.linkUrl'),
+            RichColumn('specimen__patient__patient_code', label='Patient', orderable=True,
+                       extra_columns=['specimen__patient_id'],
+                       renderer=partial(_render_patient_link, patient_id_column='specimen__patient_id'),
+                       client_renderer='TableFormat.linkUrl'),
+            RichColumn('nucleic_acid_source', label='Nucleic Acid', orderable=True, search=False,
+                       client_renderer=RichColumn.choices_client_renderer(NucleicAcid.choices)),
+            RichColumn('extraction_date', label='Extracted', orderable=True,
+                       client_renderer='TableFormat.timestamp'),
+            RichColumn('external_pk__code', label='External ID', orderable=True),
+            RichColumn('sample_count', label='# Samples', orderable=True, search=False, css_class='num'),
+            RichColumn('modified', orderable=True, search=False, default_sort=SortOrder.DESC,
+                       client_renderer='TableFormat.timestamp'),
+        ]
+
+    @staticmethod
+    def render_reference_id(row: CellData) -> JsonDataType:
+        """ An extraction's own reference is optional - fall back to the pk, as the preview does """
+        extraction_id = row["id"]
+        return {
+            "text": row.value or f"({extraction_id})",
+            "url": reverse('view_extraction', kwargs={"extraction_id": extraction_id}),
+        }
+
+    @staticmethod
+    def render_specimen_link(row: CellData) -> JsonDataType:
+        specimen_id = row["specimen_id"]
+        return {
+            "text": row.value or f"({specimen_id})",
+            "url": reverse('view_specimen', kwargs={"specimen_id": specimen_id}),
+        }
+
+    def get_initial_queryset(self) -> QuerySet[Extraction]:
+        """ Samples carry their VCF's permissions rather than their patient's, so the count is of the
+            samples this user can see rather than of every sample off the extraction """
+        qs = Extraction.filter_for_user(self.user)
+        visible_samples_q = Q(sample__in=Sample.filter_for_user(self.user))
+        return qs.annotate(sample_count=Count("sample", filter=visible_samples_q, distinct=True))
 
 
 class PatientOntologyGenesGrid(AbstractOntologyGenesGrid):

--- a/patients/models.py
+++ b/patients/models.py
@@ -285,7 +285,7 @@ class Patient(GuardianPermissionsMixin, HasPhenotypeDescriptionMixin, Externally
         HasPhenotypeDescriptionMixin.save_phenotype(self, pheno_kwargs)
 
     def get_samples(self):
-        return self.sample_set.all().order_by("vcf__date")
+        return self.sample_set.all().select_related("vcf", "extraction__specimen").order_by("vcf__date")
 
     def __str__(self):
         # De-identified patients have no name, so fall back to the code they're known by

--- a/patients/templates/patients/extractions.html
+++ b/patients/templates/patients/extractions.html
@@ -1,0 +1,7 @@
+{% extends menu_patients_base %}
+{% block title %}Extractions{% endblock title %}
+
+{% block submenu_page_content %}
+    <h3>Extractions</h3>
+    <table id="extraction-datatable" data-datatable-url="{% url 'extraction_datatables' %}" class="sticky-header"></table>
+{% endblock submenu_page_content %}

--- a/patients/templates/patients/specimens.html
+++ b/patients/templates/patients/specimens.html
@@ -1,0 +1,7 @@
+{% extends menu_patients_base %}
+{% block title %}Specimens{% endblock title %}
+
+{% block submenu_page_content %}
+    <h3>Specimens</h3>
+    <table id="specimen-datatable" data-datatable-url="{% url 'specimen_datatables' %}" class="sticky-header"></table>
+{% endblock submenu_page_content %}

--- a/patients/tests/test_specimen_extraction.py
+++ b/patients/tests/test_specimen_extraction.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 from django.utils import timezone
 
 from classification.autopopulate_evidence_keys.evidence_from_sample_and_patient import (
@@ -377,3 +378,64 @@ class TestAutocompleteForwarding(TestCase):
     def test_nothing_forwarded_returns_all_visible(self):
         self.assertEqual(self._queryset(SpecimenAutocompleteView).count(), 3)
         self.assertEqual(self._queryset(ExtractionAutocompleteView).count(), 4)
+
+
+class TestSpecimenExtractionGrids(TestCase):
+    """ The top level Specimen / Extraction grids off the patients menu (#1706) """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = User.objects.create_user("grid_user", password="x")
+        cls.patient = Patient.objects.create(first_name="GRID", last_name="PATIENT", patient_code="GRIDCODE")
+        assign_permission_to_user_and_groups(cls.user, cls.patient)
+        cls.specimen = Specimen.objects.create(reference_id="2600000002", patient=cls.patient)
+        cls.dna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000002C",
+                                            nucleic_acid_source=NucleicAcid.DNA)
+        cls.rna = Extraction.objects.create(specimen=cls.specimen, reference_id="2600000002B",
+                                            nucleic_acid_source=NucleicAcid.RNA)
+
+        genome_build = GenomeBuild.get_name_or_alias("GRCh37")
+        vcf = VCF.objects.create(name="grid_test.vcf", genotype_samples=1, genome_build=genome_build,
+                                 import_status=ImportStatus.SUCCESS, user=cls.user, date=timezone.now())
+        cls.dna_sample = Sample.objects.create(name="grid_dna_arm", vcf=vcf, patient=cls.patient,
+                                               extraction=cls.dna)
+        assign_permission_to_user_and_groups(cls.user, cls.dna_sample)
+
+    def _grid_rows(self, url_name, search=None):
+        self.client.force_login(self.user)
+        params = {"search[value]": search} if search else {}
+        response = self.client.get(reverse(url_name), params)
+        self.assertEqual(200, response.status_code)
+        return {row["id"]: row for row in response.json()["data"]}
+
+    def test_specimen_grid_counts_extractions(self):
+        rows = self._grid_rows("specimen_datatables")
+        self.assertEqual(rows[self.specimen.pk]["extraction_count"], 2)
+
+    def test_extraction_grid_counts_samples_the_user_can_see(self):
+        """ A sample carries its VCF's permissions rather than its patient's """
+        rows = self._grid_rows("extraction_datatables")
+        self.assertEqual(rows[self.dna.pk]["sample_count"], 1)
+        self.assertEqual(rows[self.rna.pk]["sample_count"], 0)
+
+        other_user = User.objects.create_user("grid_other_user", password="x")
+        assign_permission_to_user_and_groups(other_user, self.patient)
+        self.client.force_login(other_user)
+        response = self.client.get(reverse("extraction_datatables"))
+        rows = {row["id"]: row for row in response.json()["data"]}
+        self.assertEqual(rows[self.dna.pk]["sample_count"], 0)
+
+    def test_search_finds_one_arm_by_its_own_reference(self):
+        rows = self._grid_rows("extraction_datatables", search="2600000002C")
+        self.assertEqual(list(rows), [self.dna.pk])
+
+    def test_search_by_patient_code(self):
+        rows = self._grid_rows("specimen_datatables", search="GRIDCODE")
+        self.assertEqual(list(rows), [self.specimen.pk])
+
+    def test_unnamed_extraction_links_by_pk(self):
+        """ An extraction's own reference is optional, so the link falls back to the pk """
+        unnamed = Extraction.objects.create(specimen=self.specimen)
+        rows = self._grid_rows("extraction_datatables")
+        self.assertEqual(rows[unnamed.pk]["reference_id"]["text"], f"({unnamed.pk})")

--- a/patients/tests/test_urls.py
+++ b/patients/tests/test_urls.py
@@ -77,6 +77,11 @@ class Test(URLTestCase):
             ("patient_grid", {}, cls.patient)
         ]
 
+        cls.PRIVATE_DATATABLES_GRID_LIST_URLS = [
+            ("specimen_datatables", {}, cls.specimen),
+            ("extraction_datatables", {}, cls.extraction),
+        ]
+
     def testUrls(self):
         """ No permissions on any objects """
         URL_NAMES_AND_KWARGS = [
@@ -86,6 +91,8 @@ class Test(URLTestCase):
             ("example_upload_csv_all", {}, 200),
             ("example_upload_csv_no_patients", {}, 200),
             ("patients", {}, 200),
+            ("specimens", {}, 200),
+            ("extractions", {}, 200),
             ("patient_term_matches", {}, 200),
             ("bulk_patient_term", {}, 200),
             ("patient_term_approvals", {}, 200),
@@ -149,6 +156,13 @@ class Test(URLTestCase):
     @prevent_request_warnings
     def testJqGridListNoPermission(self):
         self._test_jqgrid_urls_contains_objs(self.PRIVATE_GRID_LIST_URLS, self.user_non_owner, False)
+
+    def testDatatableListPermission(self):
+        self._test_datatables_grid_urls_contains_objs(self.PRIVATE_DATATABLES_GRID_LIST_URLS, self.user_owner, True)
+
+    @prevent_request_warnings
+    def testDatatableListNoPermission(self):
+        self._test_datatables_grid_urls_contains_objs(self.PRIVATE_DATATABLES_GRID_LIST_URLS, self.user_non_owner, False)
 
 if __name__ == "__main__":
     unittest.main()

--- a/patients/urls.py
+++ b/patients/urls.py
@@ -4,10 +4,12 @@ from rest_framework import routers
 from library.django_utils.jqgrid_view import JQGridView
 from patients import views, views_autocomplete
 from patients.grids import (
+    ExtractionColumns,
     PatientListGrid,
     PatientOntologyGenesGrid,
     PatientRecordColumns,
     PatientRecordsColumns,
+    SpecimenColumns,
 )
 from patients.views_rest import (
     ExtractionViewSet,
@@ -34,6 +36,8 @@ urlpatterns = [
     path('view_patient/contact/<int:patient_id>', views.view_patient_contact_tab, name='view_patient_contact_tab'),
     path('view_patient/patient_specimens/<int:patient_id>', views.view_patient_specimens, name='view_patient_specimens'),
     path('view_patient/patient_extractions/<int:patient_id>', views.view_patient_extractions, name='view_patient_extractions'),
+    path('specimens', views.specimens, name='specimens'),
+    path('extractions', views.extractions, name='extractions'),
     path('view_specimen/<int:specimen_id>', views.view_specimen, name='view_specimen'),
     path('view_extraction/<int:extraction_id>', views.view_extraction, name='view_extraction'),
     path('extraction/<int:extraction_id>/samples', views.extraction_samples, name='extraction_samples'),
@@ -60,6 +64,10 @@ urlpatterns = [
          name='patient_records_datatables'),
     path('patient_record/datatables/', DatabaseTableView.as_view(column_class=PatientRecordColumns),
          name='patient_record_datatables'),
+    path('specimen/datatables/', DatabaseTableView.as_view(column_class=SpecimenColumns),
+         name='specimen_datatables'),
+    path('extraction/datatables/', DatabaseTableView.as_view(column_class=ExtractionColumns),
+         name='extraction_datatables'),
     path('patient/ontology/genes/grid/<int:patient_id>/<slug:op>/', JQGridView.as_view(grid=PatientOntologyGenesGrid),
          name='patient_ontology_genes_grid'),
 

--- a/patients/views.py
+++ b/patients/views.py
@@ -124,6 +124,14 @@ def view_patient_extractions(request, patient_id):
     return render(request, 'patients/view_patient_extractions.html', context)
 
 
+def specimens(request):
+    return render(request, 'patients/specimens.html')
+
+
+def extractions(request):
+    return render(request, 'patients/extractions.html')
+
+
 def view_specimen(request, specimen_id):
     specimen = Specimen.get_for_user(request.user, specimen_id)
     form = forms.SpecimenForm(request.POST or None, instance=specimen)

--- a/snpdb/grids.py
+++ b/snpdb/grids.py
@@ -123,8 +123,9 @@ class SamplesListGrid(JqGridUserRowConfig):
               "somaliersampleextract__somalierancestry__predicted_ancestry",
               "patient__patient_code", "patient__first_name", "patient__last_name", "patient__sex",
               "patient__date_of_birth", "patient__date_of_death",
-              "extraction__specimen__reference_id", "extraction__specimen__tissue__name",
-              "extraction__specimen__collection_date", "vcf__id"]
+              "extraction__specimen__id", "extraction__specimen__reference_id",
+              "extraction__id", "extraction__reference_id",
+              "extraction__specimen__tissue__name", "extraction__specimen__collection_date", "vcf__id"]
     colmodel_overrides = {
         'id': {"hidden": True},
         "name": {"width": 400,
@@ -158,7 +159,22 @@ class SamplesListGrid(JqGridUserRowConfig):
         'patient__date_of_death': {'hidden': True},
         'het_hom_count': {'name': 'het_hom_count', "model_field": False, 'sorttype': 'int',
                           'label': 'Het/Hom Count'},
-        "extraction__specimen__reference_id": {'label': 'Specimen'},
+        'extraction__specimen__id': {'hidden': True},
+        "extraction__specimen__reference_id": {
+            'label': 'Specimen',
+            'formatter': 'optionalLinkFormatter',
+            'formatter_kwargs': {"url_name": "view_specimen",
+                                 "url_object_column": "extraction__specimen__id"}},
+        'extraction__id': {'hidden': True},
+        # The DNA and RNA arms of one block share a specimen, so the specimen reference alone can't
+        # tell those rows apart
+        "extraction__reference_id": {
+            'label': 'Extraction',
+            'formatter': 'optionalLinkFormatter',
+            'formatter_kwargs': {"url_name": "view_extraction",
+                                 "url_object_column": "extraction__id"}},
+        "extraction__specimen__tissue__name": {'label': 'Tissue'},
+        "extraction__specimen__collection_date": {'label': 'Collected'},
         # These urls are only there for CSV export
         "sample_url": {'name': 'sample_url', 'label': 'Sample URL', "model_field": False, 'hidden': True},
         "vcf_url": {'name': 'vcf_url', 'label': 'VCF URL', "model_field": False, 'hidden': True},

--- a/snpdb/templates/snpdb/grids/samples_grid.html
+++ b/snpdb/templates/snpdb/grids/samples_grid.html
@@ -26,6 +26,15 @@
 
     	return "<div class='sample_id-container'>" + sample_selector + view_details_link + "</div>";
 	},
+    optionalLinkFormatter : function(cellvalue, options, rowObject) {
+        // A sample doesn't have to have come through an extraction, and an extraction's own
+        // reference is optional - so only draw a link when there's something to link to
+        const pk = rowObject[options.colModel.formatter_kwargs.url_object_column];
+        if (!pk) {
+            return cellvalue || "";
+        }
+        return linkFormatter(cellvalue || `(${pk})`, options, rowObject);
+    },
     viewImportStatus : function(importStatus) {
         if (importStatus == 'Annotation Required') { 
             importStatus = "<a href='{% url "variant_annotation_runs" %}'>" + importStatus + "</a>";

--- a/snpdb/templates/snpdb/tags/related_data_for_patient.html
+++ b/snpdb/templates/snpdb/tags/related_data_for_patient.html
@@ -13,7 +13,7 @@
             <th>Sample Name
             <th>VCF
             <th>VCF date
-            <th>Tissue
+            <th>Specimen
             </tr>
             </thead>
             <tbody>
@@ -23,7 +23,7 @@
             <td>{{ sample.name }}
             <td><a href="{% url 'view_vcf' sample.vcf.pk %}">{{ sample.vcf.name }}</a>
             <td>{{ sample.vcf.date }}
-            <td>{{ sample.tissue }}
+            <td>{% if sample.specimen %}<a href="{{ sample.specimen.get_absolute_url }}">{{ sample.specimen }}</a>{% endif %}
             </tr>
         {% endfor %}
         </tbody>

--- a/uicore/templates/uicore/menus/menu_bar_patients.html
+++ b/uicore/templates/uicore/menus/menu_bar_patients.html
@@ -3,6 +3,8 @@
 {% menu_item 'cases' %}
 {% menu_item 'cohorts' %}
 {% menu_item 'patients' %}
+{% menu_item 'specimens' other_urls='view_specimen' %}
+{% menu_item 'extractions' other_urls='view_extraction' %}
 {% menu_item 'pedigrees' %}
 {% menu_item 'trios' %}
 {% menu_item 'quads' %}

--- a/variantgrid/settings/env/shariantcommon.py
+++ b/variantgrid/settings/env/shariantcommon.py
@@ -190,6 +190,8 @@ URLS_NAME_REGISTER.update({  # Disable selected snpdb urls
     "patient_imports": False,
     "patient_term_approvals": False,
     "patients": False,
+    "specimens": False,
+    "extractions": False,
     "view_specimen": False,
     "view_extraction": False,
 


### PR DESCRIPTION
The last of [#1706](https://github.com/SACGF/variantgrid/issues/1706) — the detail pages, search and previews landed with #1715, leaving the grid half. Spec is `claude/plans/1706_remaining_work_plan.md`.

## Specimen and Extraction grids

Top level DataTables grids off the patients menu (`specimens`, `extractions`). Both models take their confidentiality from their patient, so both querysets go through `filter_for_user`.

- The extraction grid's sample count is annotated over `Sample.filter_for_user` rather than the raw related set — a sample carries its VCF's permissions rather than its patient's, so seeing an extraction doesn't mean seeing what was sequenced off it.
- The patient column shows `patient_code`, the de-identified column the patient grid leads with.
- An extraction's own reference is optional, so that column and the specimen column fall back to the pk, the same as the previews do.
- Shariant has no patients menu, so both url names are turned off there.

## Links on the samples grid

The samples grid had the specimen reference as plain text and no extraction column at all — the DNA and RNA arms of one block share a specimen, so the specimen reference alone cannot tell those rows apart. Both are now links, drawn as plain text for a sample that didn't come through an extraction.

`related_data_for_patient.html` rendered `{{ sample.tissue }}`, which has been blank since the FK moved to the extraction in phase 1. It's the specimen, linked.

## Tissue

The dropdown on the specimen page and the patient page's Specimens tab can have no options until #1747 gives `Tissue` a way to be created, so it's excluded from both forms until then.

## Testing

`python3 manage.py test --keepdb patients snpdb.tests.test_urls snpdb.tests.test_query_counts` — 161 tests pass. New tests cover the two annotated counts (including the sample-visibility case), power search, the pk fallback, and datatable permissions. Both pages and both datatable endpoints were also rendered against a dev database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D26Dgc7cm35fR2QJDvsWcE