### PR TITLE
Register annotation pipeline versions from the runs page, AnnotSV T2T support - #720

### DIFF
--- a/annotation/management/commands/create_new_annotation_pipeline_version.py
+++ b/annotation/management/commands/create_new_annotation_pipeline_version.py
@@ -35,6 +35,9 @@ class Command(BaseCommand):
 
         runner = get_runner(pipeline_type)
         for genome_build in genome_builds:
+            if not runner.supports_genome_build(genome_build):
+                self.stdout.write(f"{genome_build}: not supported by {pipeline_type.label} - skipping")
+                continue
             pipeline_version, created = runner.get_or_create_current_version(genome_build)
             if created:
                 logging.info("Created: %s", pipeline_version)

--- a/annotation/pipelines/annotsv.py
+++ b/annotation/pipelines/annotsv.py
@@ -29,6 +29,9 @@ class AnnotSVRunner(AnnotationPipelineRunner):
     # only feeds its Samples_ID reporting.
     dump_samples = ["variantgrid"]
 
+    def supports_genome_build(self, genome_build) -> bool:
+        return genome_build.name in settings.ANNOTATION_ANNOTSV_GENOME_BUILD
+
     def get_current_tool_version(self, genome_build) -> dict:
         return {
             "code_version": get_annotsv_command_line_version(),

--- a/annotation/pipelines/base.py
+++ b/annotation/pipelines/base.py
@@ -37,6 +37,12 @@ class AnnotationPipelineRunner(abc.ABC):
     # what VEP takes - set by a pipeline whose tool rejects a VCF with no FORMAT column.
     dump_samples: list[str] = None
 
+    def supports_genome_build(self, genome_build) -> bool:
+        """ Whether this pipeline's tool can annotate this build at all. A tool only ships annotations for
+            some of the builds we run, so an unsupported build is a permanent property of the install
+            rather than something an admin registers their way out of. """
+        return True
+
     def get_current_tool_version(self, genome_build) -> dict:
         """ code_version/data_version of the tool as installed right now - AnnotationPipelineVersion
             field values, for a versioned pipeline. Usually shells out to the tool, so callers are

--- a/annotation/tasks/annotation_scheduler_task.py
+++ b/annotation/tasks/annotation_scheduler_task.py
@@ -140,11 +140,14 @@ def _scheduled_pipeline_versions(
         VariantAnnotationVersion).
 
         A versioned pipeline with nothing ACTIVE is enabled but unregistered, so it is skipped rather than
-        scheduled against nothing - the annotation runs page says which command registers it. """
+        scheduled against nothing - the annotation runs page offers the button that registers it. """
     pipeline_versions = {}
     for pipeline_type in enabled_pipeline_types():
+        runner = get_runner(pipeline_type)
+        if not runner.supports_genome_build(genome_build):
+            continue  # tool ships no annotations for this build - nothing to schedule against
         pipeline_version = None
-        if get_runner(pipeline_type).versioned:
+        if runner.versioned:
             pipeline_version = AnnotationPipelineVersion.get_active(pipeline_type, genome_build)
             if pipeline_version is None:
                 logging.warning("%s is enabled for %s but has no ACTIVE AnnotationPipelineVersion - run "

--- a/annotation/templates/annotation/variant_annotation_runs.html
+++ b/annotation/templates/annotation/variant_annotation_runs.html
@@ -141,14 +141,22 @@
                             <h6 class="mt-3">{{ panel.label }} ({{ panel.genome_build }})</h6>
                             {% if not panel.enabled %}
                                 {% labelled label="Status" %}<span class="text-muted">Disabled in settings</span>{% endlabelled %}
-                            {% elif panel.active %}
-                                {% labelled label="Active" %}{{ panel.active }}{% endlabelled %}
+                            {% elif not panel.supported %}
+                                {% labelled label="Status" %}<span class="text-muted">Not supported for this genome build</span>{% endlabelled %}
                             {% else %}
-                                <div class="alert alert-warning" role="alert">
-                                    <i class="fas fa-exclamation-triangle"></i>
-                                    Enabled, but no version registered - no runs are being created. Register the installed tool with:
-                                    <div><code>{{ panel.register_command }}</code></div>
-                                </div>
+                                {% if panel.active %}
+                                    {% labelled label="Active" %}{{ panel.active }}{% endlabelled %}
+                                {% else %}
+                                    <div class="alert alert-warning" role="alert">
+                                        <i class="fas fa-exclamation-triangle"></i>
+                                        Enabled, but no version registered - no runs are being created.
+                                        Register the installed tool below, or with:
+                                        <div><code>{{ panel.register_command }}</code></div>
+                                    </div>
+                                {% endif %}
+                                <button name="{{ panel.register_name }}" class="btn btn-primary">
+                                    Register installed tool
+                                </button>
                             {% endif %}
                             {% if panel.new %}
                                 {% labelled label="New" %}{{ panel.new }}{% endlabelled %}

--- a/annotation/tests/test_annotation_pipelines.py
+++ b/annotation/tests/test_annotation_pipelines.py
@@ -234,6 +234,67 @@ class PromotePipelineVersionViewTest(TestCase):
         scheduler.si.assert_called_once()
 
 
+@override_settings(ANNOTATION_ANNOTSV_ENABLED=True,
+                   ANNOTATION_ANNOTSV_GENOME_BUILD={"GRCh37": "GRCh37"},
+                   ANNOTATION_ANNOTSV_BUNDLE_VERSION="3.5")
+class RegisterPipelineVersionViewTest(TestCase):
+    """ #720: registering the installed tool from the runs page rather than the command line - the button
+        the template posts and the handler that reads it have to keep agreeing. """
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_superuser("register_test_admin", "register@test.com", "password")
+        self.genome_build = GenomeBuild.get_name_or_alias("GRCh37")
+        self.client.force_login(self.user)
+        self.post_name = f"register-pipeline-version-{ANNOTSV}-{self.genome_build.name}"
+
+    def test_page_offers_the_register_button(self):
+        response = self.client.get(reverse("variant_annotation_runs"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.post_name)
+
+    def test_registering_creates_active_version_and_queues_the_scheduler(self):
+        with mock.patch("annotation.pipelines.annotsv.get_annotsv_command_line_version",
+                        return_value="3.5.10"), \
+                mock.patch("annotation.views.annotation_scheduler") as scheduler:
+            response = self.client.post(reverse("variant_annotation_runs"), {self.post_name: "1"})
+        self.assertEqual(response.status_code, 200)
+        pipeline_version = AnnotationPipelineVersion.get_active(ANNOTSV, self.genome_build)
+        self.assertEqual(pipeline_version.code_version, "3.5.10")
+        self.assertEqual(pipeline_version.data_version, "3.5")
+        scheduler.si.assert_called_once()
+
+    def test_registering_an_upgrade_creates_a_new_version_to_promote(self):
+        AnnotationPipelineVersion.objects.create(
+            pipeline_type=ANNOTSV, genome_build=self.genome_build, code_version="3.5.8",
+            data_version="3.5", status=AnnotationPipelineVersion.Status.ACTIVE)
+        with mock.patch("annotation.pipelines.annotsv.get_annotsv_command_line_version",
+                        return_value="3.5.10"):
+            self.client.post(reverse("variant_annotation_runs"), {self.post_name: "1"})
+        new_version = AnnotationPipelineVersion.get_new(ANNOTSV, self.genome_build)
+        self.assertEqual(new_version.code_version, "3.5.10")
+        self.assertEqual(AnnotationPipelineVersion.get_active(ANNOTSV, self.genome_build).code_version,
+                         "3.5.8")
+
+    def test_missing_binary_reports_an_error_rather_than_500(self):
+        with mock.patch("annotation.pipelines.annotsv.get_annotsv_command_line_version",
+                        side_effect=FileNotFoundError("/fake/AnnotSV")):
+            response = self.client.post(reverse("variant_annotation_runs"), {self.post_name: "1"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(AnnotationPipelineVersion.get_active(ANNOTSV, self.genome_build))
+
+    def test_unsupported_build_is_neither_offered_nor_registered(self):
+        t2t = GenomeBuild.t2tv2()
+        post_name = f"register-pipeline-version-{ANNOTSV}-{t2t.name}"
+        response = self.client.get(reverse("variant_annotation_runs"))
+        self.assertNotContains(response, post_name)
+        with mock.patch("annotation.pipelines.annotsv.get_annotsv_command_line_version",
+                        return_value="3.5.10"):
+            self.client.post(reverse("variant_annotation_runs"), {post_name: "1"})
+        self.assertFalse(AnnotationPipelineVersion.objects.filter(pipeline_type=ANNOTSV,
+                                                                 genome_build=t2t).exists())
+
+
 class ExecuteCmdTimeoutTest(TestCase):
     """ #720: AnnotSV needs a timeout on execute_cmd before it can move off subprocess.run and onto the
         lease heartbeat's process_callback. """

--- a/annotation/views.py
+++ b/annotation/views.py
@@ -33,7 +33,7 @@ from annotation.models.models import (
 )
 from annotation.models.models_citations import CitationFetchRequest
 from annotation.models.models_enums import AnnotationStatus, VariantAnnotationPipelineType
-from annotation.pipelines import get_pipeline, versioned_pipeline_types, vep_pipeline_types
+from annotation.pipelines import get_pipeline, get_runner, versioned_pipeline_types, vep_pipeline_types
 from annotation.models.models_version_diff import VersionDiff
 from annotation.pathogenicity_predictions import TOOLS
 from annotation.tasks.annotate_variants import annotation_run_retry
@@ -387,6 +387,49 @@ def view_version_diff(request, version_diff_id):
     return render(request, "annotation/view_version_diff.html", context)
 
 
+def _register_pipeline_version_post_name(pipeline_type, genome_build) -> str:
+    return f"register-pipeline-version-{pipeline_type}-{genome_build.name}"
+
+
+def _handle_register_pipeline_version_post(request):
+    """ #720: the runs page equivalent of create_new_annotation_pipeline_version - reads the installed
+        tool's version and registers it, so rolling out an upgrade doesn't need shell access. """
+    for pipeline_type in versioned_pipeline_types():
+        runner = get_runner(pipeline_type)
+        label = VariantAnnotationPipelineType(pipeline_type).label
+        for genome_build in GenomeBuild.builds_with_annotation():
+            if _register_pipeline_version_post_name(pipeline_type, genome_build) not in request.POST:
+                continue
+            if not get_pipeline(pipeline_type).enabled:
+                messages.add_message(request, messages.ERROR, f"{label} is not enabled in settings")
+                continue
+            if not runner.supports_genome_build(genome_build):
+                messages.add_message(request, messages.ERROR,
+                                     f"{label} does not support {genome_build}")
+                continue
+            try:
+                pipeline_version, created = runner.get_or_create_current_version(genome_build)
+            except OSError as e:
+                # Reading the version shells out to the tool, which the web worker may not have installed
+                messages.add_message(request, messages.ERROR,
+                                     f"{label} ({genome_build}) - couldn't read the installed version: {e}")
+                continue
+
+            if not created:
+                messages.add_message(request, messages.INFO,
+                                     f"{label} ({genome_build}) - installed tool is already registered as "
+                                     f"{pipeline_version} [{pipeline_version.get_status_display()}]")
+            elif pipeline_version.is_active:
+                annotation_scheduler.si().apply_async()
+                messages.add_message(request, messages.INFO,
+                                     f"{label} ({genome_build}) - registered {pipeline_version} as ACTIVE "
+                                     f"and queued the scheduler to create its annotation runs")
+            else:
+                messages.add_message(request, messages.INFO,
+                                     f"{label} ({genome_build}) - registered {pipeline_version} as NEW. "
+                                     f"Promote it to re-annotate every range with it.")
+
+
 @require_superuser
 def variant_annotation_runs(request):
     as_display = dict(AnnotationStatus.choices)
@@ -424,6 +467,8 @@ def variant_annotation_runs(request):
                 messages.add_message(request, messages.INFO,
                                      f"Promoted {pipeline_version} to ACTIVE - queued the scheduler to "
                                      f"create its annotation runs")
+
+        _handle_register_pipeline_version_post(request)
 
         for genome_build in GenomeBuild.builds_with_annotation():
             if f"promote-to-active-{genome_build.name}" in request.POST:
@@ -541,11 +586,13 @@ def variant_annotation_runs(request):
                 "genome_build": genome_build,
                 "label": VariantAnnotationPipelineType(pipeline_type).label,
                 "enabled": get_pipeline(pipeline_type).enabled,
+                "supported": get_runner(pipeline_type).supports_genome_build(genome_build),
                 "active": AnnotationPipelineVersion.get_active(pipeline_type, genome_build),
                 "new": AnnotationPipelineVersion.get_new(pipeline_type, genome_build),
                 "historical_count": AnnotationPipelineVersion.objects.filter(
                     pipeline_type=pipeline_type, genome_build=genome_build,
                     status=AnnotationPipelineVersion.Status.HISTORICAL).count(),
+                "register_name": _register_pipeline_version_post_name(pipeline_type, genome_build),
                 "register_command": f"python3 manage.py create_new_annotation_pipeline_version "
                                     f"--pipeline-type={pipeline_type} --genome-build={genome_build}",
             })

--- a/variantgrid/settings/components/annotation_settings.py
+++ b/variantgrid/settings/components/annotation_settings.py
@@ -370,10 +370,14 @@ ANNOTATION_ANNOTSV_BIN = "/data/annotation/AnnotSV/bin/AnnotSV"
 # Passed as -annotationsDir: the directory *containing* Annotations_Human (and Annotations_Exomiser),
 # ie <install>/share/AnnotSV - not Annotations_Human itself
 ANNOTATION_ANNOTSV_ANNOTATIONS_DIR = "/data/annotation/AnnotSV/share/AnnotSV"
-# Map our genome build name -> AnnotSV's -genomeBuild value
+# Map our genome build name -> AnnotSV's -genomeBuild value. A build absent from here is one this
+# AnnotSV cannot annotate, so the runs page offers no registration for it and the scheduler skips it.
+# CHM13 arrived in AnnotSV 3.5 (Annotations_Human 3.5 bundle) - deployments on an older AnnotSV drop
+# that entry in their env settings file.
 ANNOTATION_ANNOTSV_GENOME_BUILD = {
     BUILD_GRCH37: "GRCh37",
     BUILD_GRCH38: "GRCh38",
+    BUILD_T2TV2: "CHM13",
 }
 # Annotations bundle has no version stamp file; admin sets this to the bundle release string they
 # installed (eg "3.5.8"). Becomes AnnotationPipelineVersion.data_version, so a new bundle is registered


### PR DESCRIPTION
## Register button (admin)

The annotation runs page reported `AnnotSV (GRCh37) Enabled, but no version registered` and told the admin to go run `create_new_annotation_pipeline_version` on the command line. It now offers a button that does the same thing, on the same superuser-only, CSRF-protected form as the existing promote button:

- first version for a build → registered ACTIVE, scheduler queued to create its runs
- an upgrade over an existing ACTIVE → registered NEW, for the existing **Promote to ACTIVE** button to roll out
- a missing or broken binary reports an error message (reading the version shells out to `AnnotSV -version`, which the web worker may not have)

The management command still works unchanged.

## AnnotSV on T2T

AnnotSV 3.5 (Jul 2025) added T2T-CHM13v2.0 annotations, taking `-genomeBuild CHM13`. `ANNOTATION_ANNOTSV_GENOME_BUILD` only mapped GRCh37/GRCh38, so registering T2T would have raised a `KeyError` in `get_annotsv_command` at run time — mapped it.

The 3.5 bundle has CHM13 dirs for Genes (RefSeq + ENSEMBL), CytoBand, GCcontent, Repeat, SegDup, PathogenicSNVindel, PathogenicSV, RegulatoryElements and BenignSV; it has no CHM13 ENCODEblacklist, Gap, COSMIC or TAD. The gene-based annotations (ACMG, ClinGen, OMIM, DDD, gnomAD pLI) are gene-symbol keyed, so ranking works.

## Unsupported builds

Which builds a tool can annotate is now something runners answer (`AnnotationPipelineRunner.supports_genome_build`), read off the build map for AnnotSV. Such a build shows *Not supported for this genome build* with no button, instead of the misleading unregistered-version warning, and the scheduler and management command skip it — so a deployment on an older AnnotSV drops the CHM13 entry in its env settings and everything stays consistent.

## Testing

5 new tests in `annotation/tests/test_annotation_pipelines.py` — button rendering, first registration, upgrade → NEW, missing binary, unsupported build. `annotation.tests.test_annotsv` passes (23).

One pre-existing failure, unrelated and identical on a clean checkout: `test_annotsv_runs_not_created_while_disabled` asserts the packaged default `ANNOTATION_ANNOTSV_ENABLED = False`, which fails on any host whose env settings turn AnnotSV on (eg vgtest2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D26Dgc7cm35fR2QJDvsWcE