### PR TITLE
Split liftover into batches, run them in parallel

### DIFF
--- a/snpdb/liftover.py
+++ b/snpdb/liftover.py
@@ -3,16 +3,15 @@
 """
 import itertools
 import logging
-import operator
 import os
 from collections import defaultdict
 from collections.abc import Iterable
-from functools import reduce
+from functools import lru_cache
 from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.db.models.query_utils import Q
+from django.db.models import Prefetch, QuerySet
 
 from genes.hgvs import HGVSMatcher
 from library.django_utils.django_file_utils import get_import_processing_dir
@@ -45,8 +44,37 @@ def create_liftover_pipelines(user: User, alleles: Iterable[Allele],
                               import_source: ImportSource,
                               inserted_genome_build: GenomeBuild,
                               destination_genome_builds: list[GenomeBuild] = None):
-    """ Creates and runs a liftover pipeline for each destination GenomeBuild (default = all other builds) """
+    """ Creates and runs a liftover pipeline for each destination GenomeBuild (default = all other builds)
 
+        Alleles are handled in batches of settings.LIFTOVER_BATCH_SIZE - a batch's alleles, coordinates and
+        AlleleLiftover records are all held in memory while its VCF is written, and anything that goes wrong
+        only takes out the batch rather than the whole run """
+
+    for allele_batch in _batch_alleles(alleles):
+        _create_liftover_pipelines_for_batch(user, allele_batch, import_source,
+                                             inserted_genome_build, destination_genome_builds)
+
+
+def _batch_alleles(alleles: Iterable[Allele]) -> Iterable[list[Allele]]:
+    """ QuerySets are paged by pk rather than iterated, so we don't hold a cursor open for the
+        (potentially hours) it takes to create the pipelines. Re-querying also skips alleles that
+        earlier batches have since lifted over """
+    batch_size = settings.LIFTOVER_BATCH_SIZE
+    if isinstance(alleles, QuerySet):
+        allele_qs = alleles.order_by("pk")
+        last_pk = 0
+        while allele_batch := list(allele_qs.filter(pk__gt=last_pk)[:batch_size]):
+            last_pk = allele_batch[-1].pk
+            yield allele_batch
+    else:
+        for allele_batch in itertools.batched(alleles, batch_size):
+            yield list(allele_batch)
+
+
+def _create_liftover_pipelines_for_batch(user: User, alleles: list[Allele],
+                                         import_source: ImportSource,
+                                         inserted_genome_build: GenomeBuild,
+                                         destination_genome_builds: list[GenomeBuild] = None):
     build_liftover_existing_allele_and_variants, build_liftover_allele_variant_coordinate_error = _get_build_liftover_dicts(alleles, inserted_genome_build, destination_genome_builds)
     for genome_build, liftover_tuples in build_liftover_existing_allele_and_variants.items():
         for conversion_tool, av_tuples in liftover_tuples.items():
@@ -138,37 +166,56 @@ def _non_standard_contig_error(vcf_genome_build: GenomeBuild, variant_coordinate
     return f"Liftover VCFs only contain standard contigs - {description}"
 
 
+def _liftover_allele_qs(allele_ids: list[int]) -> QuerySet[Allele]:
+    """ Everything the per-allele liftover methods below look at, fetched up front for the whole batch """
+    variant_allele_qs = VariantAllele.objects.select_related("genome_build", "variant__locus__contig",
+                                                            "variant__locus__ref",
+                                                            "variant__alt").order_by("genome_build__name")
+    return Allele.objects.filter(pk__in=allele_ids).select_related("clingen_allele") \
+        .prefetch_related(Prefetch("variantallele_set", queryset=variant_allele_qs))
+
+
+@lru_cache
+def _genome_build_contig_ids(genome_build: GenomeBuild) -> frozenset[int]:
+    """ Cached as it's checked once per allele """
+    return frozenset(genome_build.contig_ids)
+
+
+def _variant_allele_for_build(allele, genome_build: GenomeBuild) -> Optional['VariantAllele']:
+    """ Uses the prefetch (@see _liftover_allele_qs) rather than a query per allele """
+    for variant_allele in allele.variantallele_set.all():
+        if variant_allele.genome_build_id == genome_build.pk:
+            return variant_allele
+    return None
+
+
 def _get_build_liftover_dicts(alleles: Iterable[Allele], inserted_genome_build: GenomeBuild,
                               destination_genome_builds: list[GenomeBuild] = None) -> tuple[dict, dict]:
     """ ID column set to allele_id """
     if destination_genome_builds is None:
         destination_genome_builds = GenomeBuild.builds_with_annotation()
 
-    other_build_contigs_q_list = []
     other_builds = set()
+    other_build_contig_ids = set()
     for genome_build in destination_genome_builds:
         if genome_build != inserted_genome_build:
             other_builds.add(genome_build)
-            q = Q(variantallele__variant__locus__contig__in=genome_build.contigs)
-            other_build_contigs_q_list.append(q)
+            other_build_contig_ids.update(genome_build.contig_ids)
 
     if not other_builds:
         return {}, {}  # Nothing to do
 
-    other_build_contigs_q = reduce(operator.or_, other_build_contigs_q_list)
-
-    # Store builds where alleles have already been lifted over
-    allele_builds = defaultdict(set)
     allele_ids = [allele.pk for allele in alleles]
-    qs = Allele.objects.filter(other_build_contigs_q, pk__in=allele_ids)
-    for allele_id, genome_build_name in qs.values_list("pk", "variantallele__genome_build"):
-        allele_builds[allele_id].add(genome_build_name)
+    alleles = _liftover_allele_qs(allele_ids)
+    build_failed_tools = {gb: AlleleLiftover.get_failed_conversion_tools(allele_ids, gb) for gb in other_builds}
 
     build_liftover_existing_allele_and_variants = defaultdict(lambda: defaultdict(list))  # Already lifted over
     build_liftover_allele_variant_coordinate_error = defaultdict(lambda: defaultdict(list))  # Need to run pipelines
 
     for allele in alleles:
-        existing_builds = allele_builds[allele.pk]
+        # Builds this allele already has variants for
+        existing_builds = {va.genome_build_id for va in allele.variantallele_set.all()
+                           if va.variant.locus.contig_id in other_build_contig_ids}
         for genome_build in other_builds:
             if genome_build.pk in existing_builds:
                 # logging.info("%s already lifted over to %s", allele, genome_build)
@@ -183,11 +230,14 @@ def _get_build_liftover_dicts(alleles: Iterable[Allele], inserted_genome_build: 
                 continue
 
             hgvs_matcher = HGVSMatcher.instance(genome_build)
+            failed_tools = build_failed_tools[genome_build].get(allele.pk, set())
 
             for tool_coordinate_error in itertools.chain(
                     _liftover_using_dest_variant_coordinate(allele, genome_build,
-                                                            hgvs_matcher=hgvs_matcher),
-                    _liftover_using_source_variant_coordinate(allele, inserted_genome_build, genome_build),
+                                                            hgvs_matcher=hgvs_matcher,
+                                                            failed_tools=failed_tools),
+                    _liftover_using_source_variant_coordinate(allele, inserted_genome_build, genome_build,
+                                                              failed_tools=failed_tools),
             ):
                 conversion_tool, variant_coordinate, error_string = tool_coordinate_error
                 allele_vc_err = (allele, variant_coordinate, error_string)
@@ -242,9 +292,11 @@ def _liftover_using_existing_contig(allele, dest_genome_build: GenomeBuild) -> t
     variant = None
 
     # Check if the other build shares existing contig and the variant already exists
-    genome_build_contigs = set(c.pk for c in dest_genome_build.chrom_contig_mappings.values())
+    genome_build_contigs = _genome_build_contig_ids(dest_genome_build)
     # We shouldn't be here if a variant for build is already linked to allele - don't return these
-    for variant_allele in allele.variantallele_set.exclude(genome_build=dest_genome_build):
+    for variant_allele in allele.variantallele_set.all():
+        if variant_allele.genome_build_id == dest_genome_build.pk:
+            continue
         if variant_allele.variant.locus.contig_id in genome_build_contigs:
             conversion_tool = AlleleConversionTool.SAME_CONTIG
             # Return variant_id so we can create it directly
@@ -253,22 +305,27 @@ def _liftover_using_existing_contig(allele, dest_genome_build: GenomeBuild) -> t
 
 
 def _liftover_using_dest_variant_coordinate(allele, dest_genome_build: GenomeBuild,
-                                            hgvs_matcher=None) -> Iterable[LIFTOVER_TUPLE]:
+                                            hgvs_matcher=None,
+                                            failed_tools: set[str] = None) -> Iterable[LIFTOVER_TUPLE]:
     """ This returns tuples FOR a genome build (if something can look them up)
 
         Used by to write VCF coordinates during liftover. Can be slow (API call)
 
         If you know a VariantAllele exists for your build, use variant_for_build(genome_build).as_tuple()
 
-        Optionally pass in hgvs_matcher to save re-instantiating it all the time """
+        Optionally pass in hgvs_matcher to save re-instantiating it all the time, and failed_tools
+        (@see AlleleLiftover.get_failed_conversion_tools) to save a query per allele """
 
     from annotation.models import VariantAnnotationVersion
     from genes.hgvs import get_hgvs_variant_coordinate
     from snpdb.models.models_dbsnp import DbSNP
 
+    if failed_tools is None:
+        failed_tools = AlleleLiftover.get_failed_conversion_tools([allele.pk], dest_genome_build).get(allele.pk, set())
+
     conversion_tool = None
     g_hgvs = None
-    if not AlleleLiftover.has_existing_failure(allele, dest_genome_build, AlleleConversionTool.CLINGEN_ALLELE_REGISTRY):
+    if AlleleConversionTool.CLINGEN_ALLELE_REGISTRY not in failed_tools:
         clingen_failure_message = None
         if allele.clingen_allele:
             try:
@@ -278,11 +335,9 @@ def _liftover_using_dest_variant_coordinate(allele, dest_genome_build: GenomeBui
                 clingen_failure_message = f"{allele.clingen_allele} did not contain g.HGVS for {dest_genome_build}"
         else:
             # allele.clingen_allele is None — ClinGen was skipped, not tried-and-failed
-            # (a real failure would be stored via AlleleLiftover, caught by has_existing_failure above)
+            # (a real failure would be stored via AlleleLiftover, caught by failed_tools above)
             skip_reason = None
-            if va := allele.variantallele_set.select_related(
-                "variant__locus__ref", "variant__alt"
-            ).first():
+            if va := next(iter(allele.variantallele_set.all()), None):
                 skip_reason = va.variant.clingen_allele_skip_reason()
             clingen_failure_message = skip_reason or "ClinGen skipped: no ClinGen allele registered for this variant"
 
@@ -292,11 +347,10 @@ def _liftover_using_dest_variant_coordinate(allele, dest_genome_build: GenomeBui
 
     if g_hgvs is None:
         if settings.LIFTOVER_DBSNP_ENABLED:
-            if not AlleleLiftover.has_existing_failure(allele, dest_genome_build,
-                                                       AlleleConversionTool.DBSNP):
+            if AlleleConversionTool.DBSNP not in failed_tools:
                 conversion_tool = AlleleConversionTool.DBSNP
                 error_message = None
-                if va := allele.variantallele_set.all().first():
+                if va := next(iter(allele.variantallele_set.all()), None):
                     if dbsnp := DbSNP.get_for_variant(va.variant, VariantAnnotationVersion.latest(va.genome_build)):
                         g_hgvs = dbsnp.get_g_hgvs(dest_genome_build, alt=va.variant.alt)
                     else:
@@ -316,14 +370,20 @@ def _liftover_using_dest_variant_coordinate(allele, dest_genome_build: GenomeBui
 
 
 def _liftover_using_source_variant_coordinate(allele, source_genome_build: GenomeBuild,
-                                             dest_genome_build: GenomeBuild) -> Iterable[LIFTOVER_TUPLE]:
-    """ This gets tuples from another build to run through a tool """
+                                             dest_genome_build: GenomeBuild,
+                                             failed_tools: set[str] = None) -> Iterable[LIFTOVER_TUPLE]:
+    """ This gets tuples from another build to run through a tool
+
+        Optionally pass in failed_tools (@see AlleleLiftover.get_failed_conversion_tools) to save a query """
 
     # If we have >=3 builds, sometimes this will be called for us when we don't have the variant in this build
-    variant = allele.variant_for_build_optional(source_genome_build)
-    if not variant:
+    variant_allele = _variant_allele_for_build(allele, source_genome_build)
+    if not variant_allele:
         return
-    variant_coordinate = variant.coordinate
+    variant_coordinate = variant_allele.variant.coordinate
+
+    if failed_tools is None:
+        failed_tools = AlleleLiftover.get_failed_conversion_tools([allele.pk], dest_genome_build).get(allele.pk, set())
 
     # BCFTools fails with "Unable to fetch sequence" if any variant is outside contig size
     variant_errors = Variant.validate(source_genome_build, variant_coordinate.chrom,
@@ -338,7 +398,7 @@ def _liftover_using_source_variant_coordinate(allele, source_genome_build: Genom
 
     for enabled, conversion_tool, check_liftover_errors in options:
         if enabled:
-            if AlleleLiftover.has_existing_failure(allele, dest_genome_build, conversion_tool):
+            if conversion_tool in failed_tools:
                 continue  # Skip as already failed liftover method to desired build
 
             if variant_errors_str:
@@ -363,7 +423,9 @@ def allele_can_attempt_liftover(allele, genome_build) -> bool:
         if conversion_tool and variant_coordinate:
             return True
 
-    for va in allele.variantallele_set.exclude(genome_build=genome_build):
+    for va in allele.variantallele_set.all():
+        if va.genome_build_id == genome_build.pk:
+            continue
         for conversion_tool, variant_coordinate, _error_message in _liftover_using_source_variant_coordinate(allele, va.genome_build, genome_build):
             if conversion_tool and variant_coordinate:
                 return True

--- a/snpdb/models/models_variant.py
+++ b/snpdb/models/models_variant.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import cached_property
@@ -211,7 +212,8 @@ class Allele(FlagsMixin, PreviewModelMixin, models.Model):
     @staticmethod
     def missing_variants_for_build(genome_build) -> QuerySet['Allele']:
         alleles_with_variants_qs = Allele.objects.filter(variantallele__isnull=False)
-        return alleles_with_variants_qs.filter(~Q(variantallele__genome_build=genome_build))
+        # distinct as the variantallele join returns an allele once per build it's already in
+        return alleles_with_variants_qs.filter(~Q(variantallele__genome_build=genome_build)).distinct()
 
     def __str__(self):
         name = f"Allele {self.pk}"
@@ -1146,6 +1148,8 @@ class LiftoverRun(TimeStampedModel):
 
 class AlleleLiftover(models.Model):
     ERROR_JSON_MESSAGE_KEY = "message"
+    # bulk_update writes a CASE per record, so keep batches small or Postgres crawls on big liftovers
+    BULK_UPDATE_BATCH_SIZE = 1000
 
     liftover = models.ForeignKey(LiftoverRun, on_delete=CASCADE)
     allele = models.ForeignKey(Allele, on_delete=CASCADE)
@@ -1194,10 +1198,16 @@ class AlleleLiftover(models.Model):
         return s
 
     @staticmethod
-    def has_existing_failure(allele, dest_genome_build, conversion_tool) -> bool:
-        return allele.alleleliftover_set.filter(liftover__genome_build=dest_genome_build,
-                                                liftover__conversion_tool=conversion_tool,
-                                                status=ProcessingStatus.ERROR).exists()
+    def get_failed_conversion_tools(allele_ids: Iterable[int], dest_genome_build) -> dict[int, set[str]]:
+        """ allele_id -> conversion tools that have already failed lifting it over to dest_genome_build
+            Done for a batch of alleles at once, as liftover checks this for every allele/tool """
+        qs = AlleleLiftover.objects.filter(allele__in=allele_ids,
+                                           liftover__genome_build=dest_genome_build,
+                                           status=ProcessingStatus.ERROR)
+        failed_conversion_tools = defaultdict(set)
+        for allele_id, conversion_tool in qs.values_list("allele_id", "liftover__conversion_tool"):
+            failed_conversion_tools[allele_id].add(conversion_tool)
+        return failed_conversion_tools
 
     @staticmethod
     def get_last_failed_liftover_run(allele, genome_build) -> Optional['LiftoverRun']:

--- a/snpdb/tasks/liftover_tasks.py
+++ b/snpdb/tasks/liftover_tasks.py
@@ -1,7 +1,11 @@
+import itertools
 import logging
+from collections.abc import Iterable
 
 import celery
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.db.models import QuerySet
 
 from library.log_utils import log_traceback
 from snpdb.liftover import create_liftover_pipelines
@@ -10,15 +14,39 @@ from snpdb.models import Allele, GenomeBuild, ImportSource
 
 @celery.shared_task
 def liftover_alleles(username, genome_build_name):
-    user = User.objects.get(username=username)
+    """ Queues a task per batch of alleles - the db_workers pool caps how many run at once """
     genome_build = GenomeBuild.get_name_or_alias(genome_build_name)
-    alleles = Allele.missing_variants_for_build(genome_build)
+    allele_qs = Allele.missing_variants_for_build(genome_build)
 
     for other_build in GenomeBuild.builds_with_annotation():
         if not GenomeBuild.is_equivalent(genome_build, other_build):
-            try:
-                logging.info("creating liftover pipelines from %s to %s", other_build, genome_build)
-                create_liftover_pipelines(user, alleles, ImportSource.WEB, other_build, [genome_build])
-                logging.info("/ finished creating pipelines")
-            except Exception:
-                log_traceback()
+            num_batches = 0
+            for min_allele_id, max_allele_id in _allele_id_batches(allele_qs):
+                liftover_allele_batch.si(username, genome_build.name, other_build.name,
+                                         min_allele_id, max_allele_id).apply_async()
+                num_batches += 1
+            logging.info("Queued %d liftover batches from %s to %s", num_batches, other_build, genome_build)
+
+
+def _allele_id_batches(allele_qs: QuerySet) -> Iterable[tuple[int, int]]:
+    """ Inclusive (min, max) allele id ranges, each covering LIFTOVER_BATCH_SIZE alleles """
+    batch_size = settings.LIFTOVER_BATCH_SIZE
+    allele_id_qs = allele_qs.order_by("pk").values_list("pk", flat=True)
+    for allele_ids in itertools.batched(allele_id_qs.iterator(chunk_size=batch_size), batch_size):
+        yield allele_ids[0], allele_ids[-1]
+
+
+@celery.shared_task
+def liftover_allele_batch(username, genome_build_name, other_build_name, min_allele_id, max_allele_id):
+    user = User.objects.get(username=username)
+    genome_build = GenomeBuild.get_name_or_alias(genome_build_name)
+    other_build = GenomeBuild.get_name_or_alias(other_build_name)
+    # Re-query, so any alleles lifted over since the batches were worked out drop out
+    alleles = Allele.missing_variants_for_build(genome_build).filter(pk__gte=min_allele_id,
+                                                                     pk__lte=max_allele_id)
+    try:
+        logging.info("creating liftover pipelines from %s to %s for alleles %d-%d",
+                     other_build, genome_build, min_allele_id, max_allele_id)
+        create_liftover_pipelines(user, alleles, ImportSource.WEB, other_build, [genome_build])
+    except Exception:
+        log_traceback()

--- a/snpdb/tests/test_liftover.py
+++ b/snpdb/tests/test_liftover.py
@@ -1,16 +1,21 @@
-from django.test import TestCase
+from django.db import connection
+from django.test import TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 
 from annotation.fake_annotation import get_fake_annotation_version
 from snpdb.clingen_allele import get_clingen_allele
 from snpdb.liftover import (
+    _batch_alleles,
+    _get_build_liftover_dicts,
     _liftover_using_dest_variant_coordinate,
     _liftover_using_existing_contig,
     _liftover_using_source_variant_coordinate,
     _non_standard_contig_error,
 )
-from snpdb.models import AlleleConversionTool, GenomeBuild, VariantCoordinate
+from snpdb.models import Allele, AlleleConversionTool, GenomeBuild, VariantCoordinate
+from snpdb.tasks.liftover_tasks import _allele_id_batches
 from snpdb.tests.utils.mock_clingen_api import MockClinGenAlleleRegistryAPI
-from snpdb.tests.utils.vcf_testing_utils import slowly_create_test_variant
+from snpdb.tests.utils.vcf_testing_utils import create_mock_allele, slowly_create_test_variant
 
 
 class TestLiftover(TestCase):
@@ -81,3 +86,61 @@ class TestLiftover(TestCase):
         scaffold_vc = VariantCoordinate(chrom=scaffold.name, position=1000, ref='A', alt='T')
         error = _non_standard_contig_error(grch37, scaffold_vc)
         self.assertIn(scaffold.get_role_display(), error)
+
+
+class TestLiftoverBatching(TestCase):
+    NUM_ALLELES = 5
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.alleles = [Allele.objects.create() for _ in range(cls.NUM_ALLELES)]
+
+    @override_settings(LIFTOVER_BATCH_SIZE=2)
+    def test_batch_alleles_pages_queryset(self):
+        allele_qs = Allele.objects.filter(pk__in=[a.pk for a in self.alleles])
+        batches = list(_batch_alleles(allele_qs))
+        self.assertEqual([len(b) for b in batches], [2, 2, 1])
+        # Paging by pk needs to cover every allele exactly once
+        batched_pks = [allele.pk for batch in batches for allele in batch]
+        self.assertEqual(sorted(batched_pks), sorted(a.pk for a in self.alleles))
+
+    @override_settings(LIFTOVER_BATCH_SIZE=2)
+    def test_batch_alleles_handles_list(self):
+        batches = list(_batch_alleles(self.alleles))
+        self.assertEqual([len(b) for b in batches], [2, 2, 1])
+
+    @override_settings(LIFTOVER_BATCH_SIZE=2)
+    def test_allele_id_batches(self):
+        allele_qs = Allele.objects.filter(pk__in=[a.pk for a in self.alleles])
+        pks = sorted(a.pk for a in self.alleles)
+        expected = [(pks[0], pks[1]), (pks[2], pks[3]), (pks[4], pks[4])]
+        self.assertEqual(list(_allele_id_batches(allele_qs)), expected)
+
+
+class TestLiftoverQueries(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        for genome_build in [GenomeBuild.grch37(), GenomeBuild.grch38()]:
+            get_fake_annotation_version(genome_build)
+
+    @staticmethod
+    def _create_alleles(num_alleles: int, start_position: int) -> list[Allele]:
+        grch37 = GenomeBuild.grch37()
+        return [create_mock_allele(slowly_create_test_variant("3", start_position + i, 'A', 'T', grch37), grch37)
+                for i in range(num_alleles)]
+
+    @override_settings(LIFTOVER_BCFTOOLS_ENABLED=False)
+    def test_queries_do_not_scale_with_alleles(self):
+        """ The liftover checks used to query per allele (ClinGen failures, VariantAlleles, ...) """
+        grch37 = GenomeBuild.grch37()
+        grch38 = GenomeBuild.grch38()
+
+        def _num_queries(alleles) -> int:
+            with CaptureQueriesContext(connection) as context:
+                _get_build_liftover_dicts(alleles, grch37, [grch38])
+            return len(context.captured_queries)
+
+        _num_queries(self._create_alleles(1, 1000))  # Warm up cached contigs/HGVS matcher
+        one_allele = _num_queries(self._create_alleles(1, 2000))
+        five_alleles = _num_queries(self._create_alleles(5, 3000))
+        self.assertEqual(one_allele, five_alleles)

--- a/upload/tasks/vcf/import_vcf_tasks.py
+++ b/upload/tasks/vcf/import_vcf_tasks.py
@@ -121,7 +121,8 @@ class LiftoverPreprocessVCFTask(ImportVCFStepTask):
             al.error = {"message": "BCFTools liftover SWAP=1: variant is reference allele in destination build"}
             records.append(al)
         if records:
-            AlleleLiftover.objects.bulk_update(records, fields=["status", "error"])
+            AlleleLiftover.objects.bulk_update(records, fields=["status", "error"],
+                                               batch_size=AlleleLiftover.BULK_UPDATE_BATCH_SIZE)
 
 
 class CheckStartAnnotationTask(ImportVCFStepTask):

--- a/upload/vcf/bulk_allele_linking_vcf_processor.py
+++ b/upload/vcf/bulk_allele_linking_vcf_processor.py
@@ -103,7 +103,8 @@ class BulkAlleleLinkingVCFProcessor(BulkMinimalVCFProcessor):
             al.status = ProcessingStatus.SUCCESS
 
         if updated_allele_liftovers:
-            AlleleLiftover.objects.bulk_update(updated_allele_liftovers, fields=["status", "data", "error"])
+            AlleleLiftover.objects.bulk_update(updated_allele_liftovers, fields=["status", "data", "error"],
+                                              batch_size=AlleleLiftover.BULK_UPDATE_BATCH_SIZE)
 
         if variant_alleles:
             logging.info("Inserting %d variant_alleles", len(variant_alleles))
@@ -149,5 +150,6 @@ class FailedLiftoverVCFProcessor(BulkMinimalVCFProcessor):
             allele_liftover.error = {"message": f"BCFTools +liftover rejected variant: {reject_reason}"}
             records.append(allele_liftover)
 
-        AlleleLiftover.objects.bulk_update(records, fields=["status", "error"])
+        AlleleLiftover.objects.bulk_update(records, fields=["status", "error"],
+                                           batch_size=AlleleLiftover.BULK_UPDATE_BATCH_SIZE)
         self.rows_processed = len(records)

--- a/variantgrid/settings/components/default_settings.py
+++ b/variantgrid/settings/components/default_settings.py
@@ -456,6 +456,9 @@ PARTITION_ARCHIVE_DIR = "/data/database/partition_dumps/"
 LIFTOVER_CLASSIFICATIONS = True
 LIFTOVER_TO_CHROMOSOMES_ONLY = True  # False = Liftover to alt/patches
 LIFTOVER_DBSNP_ENABLED = False  # Default=False - doesn't work so well due to dbSNP IDs being for loci
+# Alleles per liftover pipeline. Everything for a batch (alleles, variant coordinates, AlleleLiftover
+# records) is held in memory while the VCF is written, so a whole-database liftover needs to be split up
+LIFTOVER_BATCH_SIZE = 10_000
 
 LIFTOVER_BCFTOOLS_ENABLED = True
 # 2025-02-13 - bcftools liftover currently gives a warning about symbolic variants


### PR DESCRIPTION
🤖 Written by Claude

## Why

A whole-database liftover built the entire run up in memory before doing any work — every `Allele`, every `VariantCoordinate`, every `AlleleLiftover` record — and then wrote one enormous VCF. A big enough run took the machine down.

## Batching

`create_liftover_pipelines` now processes alleles in `settings.LIFTOVER_BATCH_SIZE` (10,000) batches, so peak memory is bounded and anything that goes wrong only takes out its own batch. Every caller benefits, including the classification-import and variant-tag-import paths that also pass unbounded querysets.

QuerySets are paged by `pk__gt` rather than `.iterator()` — a server-side cursor held open for the hours these runs take is its own problem — and re-querying means alleles that earlier batches already lifted over drop out.

## Parallelism

`liftover_alleles` is now a dispatcher: it walks the allele ids and queues a `liftover_allele_batch` task per `(min_id, max_id)` range instead of doing the work itself. The batch task re-derives its queryset from the range, and its `try/except log_traceback` means one bad batch is logged and skipped while the rest carry on. Batch tasks are unrouted so they land on `db_workers` (`--concurrency=4`), giving bounded parallelism rather than an unbounded fan-out.

## N+1 queries

The per-allele checks inside `_get_build_liftover_dicts` were issuing roughly 4–5 queries per allele:

- `AlleleLiftover.has_existing_failure()` — once per allele **per tool** (ClinGen, dbSNP, BCFTools)
- `allele.clingen_allele` — unfetched FK
- `variantallele_set.filter(...)`/`.first()` in three places, plus `variant_for_build_optional()`, which calls `variant_alleles().filter(genome_build=...)` and so can never use a prefetch
- `_liftover_using_existing_contig` also rebuilt a ~2400-entry contig set from `chrom_contig_mappings` for every allele

Now `_liftover_allele_qs()` fetches the batch with `select_related("clingen_allele")` and a `Prefetch` of `variantallele_set` carrying `variant__locus__contig`, `variant__locus__ref`, `variant__alt` and `genome_build`, and the helpers read `variantallele_set.all()` and filter in Python so they hit the prefetch cache. `has_existing_failure()` is replaced by `get_failed_conversion_tools(allele_ids, build)` → `{allele_id: {tools}}`, one query for the whole batch, threaded through as an optional `failed_tools` kwarg (self-fetching when omitted, for the single-allele UI path). The separate `allele_builds` query is gone — that now comes off the same prefetch — and `_genome_build_contig_ids()` is `lru_cache`d per build.

Measured: **3 queries for 1, 5 and 20 alleles**, versus ~4–5 per allele before (so ~45,000 for a 10k batch).

## Notes for review

- `manage.py liftover_alleles` now returns as soon as batches are queued rather than creating pipelines inline, so it needs celery running. VCF processing was always async, so the command never waited for completion anyway — but note migration `0152` invokes it via `ManualOperation`.
- A saturated liftover can hold all 4 `db_workers` slots for a while. If that starves classification imports in practice, a dedicated queue is the fix.
- Includes the pre-existing working-tree changes on the same topic: `AlleleLiftover.BULK_UPDATE_BATCH_SIZE` for the downstream `bulk_update` calls, and `.distinct()` on `Allele.missing_variants_for_build()`.
- The ClinGen registry lookup and the bcftools reference check are still per-allele, but those are API and fasta I/O rather than database round-trips.

## Testing

`test_queries_do_not_scale_with_alleles` asserts the 1-allele and 5-allele query counts are equal, so any of these regressing fails loudly. Batching tests cover the pk paging and the id-range computation.

- `snpdb` + `classification.tests` — 304 tests, OK
- `upload` + `analysis` + `variantopedia` — 530 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcpSoHj17N7uMSKiD285cS