### PR TITLE
Backfill VariantAnnotation columns from an annotated VCF - #1675 #1673

### DIFF
--- a/annotation/annotation_run_files.py
+++ b/annotation/annotation_run_files.py
@@ -5,9 +5,10 @@ Split out of annotation.tasks.annotate_variants so the pipeline runners (annotat
 cleanup receiver (annotation.signals.annotation_run_cleanup) can share it without importing the celery
 tasks - the tasks import the runners, so the dependency has to run the other way.
 """
-import gzip
+import io
 import os
 
+from bgzip import BGZipWriter
 from django.conf import settings
 
 from library.utils.file_utils import name_from_filename
@@ -43,14 +44,28 @@ def write_qs_to_vcf(vcf_filename, genome_build, qs, info_dict=VARIANT_GRID_INFO_
     else:
         chrom_key = "locus__contig__name"
 
+    # Streamed (server side cursor) rather than materialised - a whole-version dump (#1675) is millions
+    # of rows, and each is written and forgotten
     sorted_values = qs.values("id", chrom_key, "locus__position",
-                              "locus__ref__seq", "alt__seq", "end", "svlen")
+                              "locus__ref__seq", "alt__seq", "end", "svlen").iterator(chunk_size=10_000)
 
-    # External dumps are written .vcf.gz (see AnnotationRun.get_dump_filename) - gzip on the way out
+    # External dumps are written .vcf.gz (see AnnotationRun.get_dump_filename). bgzip rather than plain
+    # gzip - reads anywhere gzip did, and tabix can index it, which is what lets a dump be the target of
+    # a `bcftools annotate` (@see annotation.backfill_columns)
     if vcf_filename.endswith(".gz"):
-        f = gzip.open(vcf_filename, "wt", compresslevel=6)
-    else:
-        f = open(vcf_filename, "w")
-    with f:
+        with open(vcf_filename, "wb") as raw:
+            with BGZipWriter(raw) as bgzip_f:
+                # bgzip is binary; wrap as text so VCFWriter only ever deals with str
+                f = io.TextIOWrapper(bgzip_f, encoding="utf-8", write_through=True)
+                try:
+                    return write_contig_sorted_values_to_vcf_file(genome_build, sorted_values, f,
+                                                                  info_dict=info_dict,
+                                                                  use_accession=use_accession, samples=samples)
+                finally:
+                    # flush + detach so the BGZipWriter (closed by its 'with') is closed exactly once
+                    f.flush()
+                    f.detach()
+
+    with open(vcf_filename, "w") as f:
         return write_contig_sorted_values_to_vcf_file(genome_build, sorted_values, f, info_dict=info_dict,
                                                       use_accession=use_accession, samples=samples)

--- a/annotation/backfill_columns.py
+++ b/annotation/backfill_columns.py
@@ -1,0 +1,406 @@
+"""
+Backfill individual VariantAnnotation columns from an annotated VCF (#1675).
+
+Corrects or fills in named columns of an existing VariantAnnotationVersion without re-running VEP over
+every variant. The driving case is #1673 - COSMIC keeps renaming the INFO field carrying its sample count
+(CNT in v95/97, SAMPLE_COUNT in v99, GENOME_SCREEN_SAMPLE_COUNT in v101) so deployments hold cosmic_count
+null, and re-annotating from scratch to recover one integer costs weeks.
+
+Three steps, of which we own the first and third:
+
+1. dump - write a VCF of the variants already annotated in a version, carrying variant_id in INFO
+2. annotate - the operator annotates that VCF outside VariantGrid (`bcftools annotate` against a COSMIC
+   VCF is the fast path; VEP works too)
+3. import - read the annotated VCF back and UPDATE the named columns in batches
+
+This is the mirror image of annotation.external_annotation at each step: it dumps variants that *are*
+annotated, leaves AnnotationRun / range-lock state alone, UPDATEs named columns rather than INSERTing
+whole rows, and its input deliberately comes from a different annotation source than the one that
+produced the version.
+
+See claude/plans/1675_backfill_annotation_column_plan.md.
+"""
+import csv
+import io
+import logging
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import cyvcf2
+from django.db import connection, transaction
+
+from annotation import vep_columns as vep_columns_registry
+from annotation.annotation_run_files import write_qs_to_vcf
+from annotation.annotation_version_querysets import get_variants_qs_for_annotation
+from annotation.models.models import (
+    VariantAnnotation,
+    VariantAnnotationVersion,
+    VariantTranscriptAnnotation,
+)
+from annotation.vep_field_formatters import EMPTY_VALUES, VEP_SEPARATOR
+from library.django_utils import get_model_fields
+from snpdb.variants_to_vcf import VARIANT_ID
+from upload.vcf.sql_copy_files import sql_copy_csv_file
+
+# Records per COPY -> UPDATE cycle. A batch's rows are held in memory as CSV, so this trades memory for
+# the number of times the partition is joined against.
+DEFAULT_BATCH_SIZE = 1_000_000
+
+# Temp table the batch is COPY'd into before being joined to the partition
+TEMP_TABLE = "annotation_backfill_columns"
+
+# VEP writes its per-transcript annotations into this INFO field; --csq targets read from the PICK'd entry
+CSQ_INFO_FIELD = "CSQ"
+CSQ_FORMAT_SEPARATOR = "Format: "
+CSQ_PICK_FIELD = "PICK"
+
+IMPORT_PROGRESS_INTERVAL_SECONDS = 10
+
+
+class BackfillColumnError(ValueError):
+    """ A requested column can't be resolved against this version's VEPColumnDef registry entries. """
+
+
+@dataclass(frozen=True)
+class BackfillTarget:
+    """ One VariantGrid column to backfill: where to read it from in the annotated VCF, how to clean the
+        value, and which annotation tables hold it. """
+    column: str  # VariantGridColumn id, which is also the model field / DB column name
+    source_field: str  # INFO field (or CSQ field, when from_csq) to read it from
+    from_csq: bool
+    formatter: Optional[Callable]
+    base_table_names: tuple[str, ...]
+
+    @property
+    def source_description(self) -> str:
+        source = "CSQ" if self.from_csq else "INFO"
+        return f"{source}/{self.source_field}"
+
+
+def _version_column_defs(variant_annotation_version: VariantAnnotationVersion) -> tuple:
+    """ Registry entries that apply to this version. Pipeline type is left open - a variant-level column
+        can be backfilled regardless of which pipeline originally wrote it. """
+    return vep_columns_registry.filter_for(
+        genome_build_name=variant_annotation_version.genome_build.name,
+        columns_version=variant_annotation_version.columns_version,
+        vep_version=variant_annotation_version.vep,
+        gnomad4_minor_version=variant_annotation_version.gnomad,
+    )
+
+
+def _base_table_names_for_column(column: str, from_csq: bool) -> tuple[str, ...]:
+    """ Which annotation tables a column lives in. A CSQ target is read off the PICK'd entry, which is
+        only the representative transcript's annotation, so it can't speak for the per-transcript table.
+        An INFO field is variant-level - the same value the pipeline copies into every transcript row. """
+    if column not in set(get_model_fields(VariantAnnotation)):
+        raise BackfillColumnError(f"Column '{column}' is not a field of VariantAnnotation")
+
+    base_table_names = [VariantAnnotationVersion.REPRESENTATIVE_TRANSCRIPT_ANNOTATION]
+    if not from_csq and column in set(get_model_fields(VariantTranscriptAnnotation)):
+        base_table_names.append(VariantAnnotationVersion.TRANSCRIPT_ANNOTATION)
+    return tuple(base_table_names)
+
+
+def resolve_backfill_columns(variant_annotation_version: VariantAnnotationVersion,
+                             column_ids: Iterable[str],
+                             info_overrides: dict[str, str] = None,
+                             csq_overrides: dict[str, str] = None) -> list[BackfillTarget]:
+    """ Turn requested VariantGrid column ids into BackfillTargets, using the VEPColumnDef registry for
+        the formatter and the default source field. Anything that can't be resolved raises, so a typo or
+        a column that doesn't exist at this version's columns_version fails before anything is dumped. """
+    info_overrides = dict(info_overrides or {})
+    csq_overrides = dict(csq_overrides or {})
+    column_ids = list(column_ids)
+
+    if both := set(info_overrides) & set(csq_overrides):
+        raise BackfillColumnError(f"Columns given both --info and --csq sources: {', '.join(sorted(both))}")
+    if unknown := (set(info_overrides) | set(csq_overrides)) - set(column_ids):
+        raise BackfillColumnError(f"--info/--csq given for columns not in --columns: {', '.join(sorted(unknown))}")
+
+    version_defs = _version_column_defs(variant_annotation_version)
+    targets = []
+    for column in column_ids:
+        column_defs = [c for c in version_defs if column in c.variant_grid_columns]
+        if not column_defs:
+            known = [c for c in vep_columns_registry.VEP_COLUMNS if column in c.variant_grid_columns]
+            if known:
+                reason = (f"it is not populated by {variant_annotation_version} "
+                          f"(columns_version={variant_annotation_version.columns_version}, "
+                          f"vep={variant_annotation_version.vep})")
+            else:
+                reason = "no VEPColumnDef writes it"
+            raise BackfillColumnError(f"Can't backfill column '{column}' - {reason}")
+
+        formatters = {c.formatter for c in column_defs}
+        if len(formatters) > 1:
+            raise BackfillColumnError(f"Column '{column}' has {len(formatters)} different registry "
+                                      f"formatters for {variant_annotation_version} - can't tell which "
+                                      f"one wrote the existing values")
+        formatter = formatters.pop()
+
+        if column in csq_overrides:
+            source_field, from_csq = csq_overrides[column], True
+        elif column in info_overrides:
+            source_field, from_csq = info_overrides[column], False
+        else:
+            source_fields = {c.vep_info_field for c in column_defs if c.vep_info_field}
+            if not source_fields:
+                raise BackfillColumnError(f"Column '{column}' is calculated at insert time, not read from "
+                                          f"a VEP field - name its source with --info or --csq")
+            if len(source_fields) > 1:
+                fields = ", ".join(sorted(source_fields))
+                raise BackfillColumnError(f"Column '{column}' is written from several fields ({fields}) - "
+                                          f"name the one to read with --info or --csq")
+            source_field, from_csq = source_fields.pop(), False
+
+        targets.append(BackfillTarget(column=column, source_field=source_field, from_csq=from_csq,
+                                      formatter=formatter,
+                                      base_table_names=_base_table_names_for_column(column, from_csq)))
+    return targets
+
+
+def dump_annotated_variants(variant_annotation_version: VariantAnnotationVersion, output_filename: str,
+                            targets: list[BackfillTarget] = None, only_missing: bool = False,
+                            min_variant_id: int = None, max_variant_id: int = None) -> int:
+    """ Write the variants annotated in this version to a VCF carrying variant_id in INFO, ready to be
+        annotated externally. Returns the number of records written.
+
+        only_missing restricts to rows where every target column is null - the common backfill shape, and
+        much smaller than a full dump. """
+    annotation_version = variant_annotation_version.get_any_annotation_version()
+    qs = get_variants_qs_for_annotation(annotation_version, annotated=True,
+                                        min_variant_id=min_variant_id, max_variant_id=max_variant_id)
+    # get_variants_qs_for_annotation(annotated=True) only stops it excluding annotated variants - to dump
+    # the ones that *have* annotation for this version we have to join to the partition ourselves.
+    # One filter() call, so the multi-valued relation is joined once (a column's __isnull=True on its own
+    # would also match variants with no annotation row at all)
+    annotation_filter = {"variantannotation__isnull": False}
+    if only_missing:
+        if not targets:
+            raise ValueError("only_missing requires the resolved targets")
+        for target in targets:
+            annotation_filter[f"variantannotation__{target.column}__isnull"] = True
+    qs = qs.filter(**annotation_filter)
+
+    return write_qs_to_vcf(output_filename, variant_annotation_version.genome_build, qs)
+
+
+class _CSQPicker:
+    """ Reads a field off the PICK'd CSQ entry of a VEP-annotated record. """
+
+    def __init__(self, reader: cyvcf2.VCF):
+        try:
+            description = reader.get_header_type(CSQ_INFO_FIELD)["Description"]
+        except KeyError:
+            raise BackfillColumnError(f"VCF has no {CSQ_INFO_FIELD} INFO field - it wasn't annotated by "
+                                      f"VEP, so --csq has nothing to read") from None
+        _, _, csq_format = description.partition(CSQ_FORMAT_SEPARATOR)
+        if not csq_format:
+            raise BackfillColumnError(f"VCF {CSQ_INFO_FIELD} header has no '{CSQ_FORMAT_SEPARATOR}' - "
+                                      f"can't tell which field is which")
+        self.fields = csq_format.strip().strip('"').split("|")
+        self.pick_index = self.fields.index(CSQ_PICK_FIELD) if CSQ_PICK_FIELD in self.fields else None
+
+    def index_of(self, source_field: str) -> int:
+        try:
+            return self.fields.index(source_field)
+        except ValueError:
+            raise BackfillColumnError(f"'{source_field}' is not a {CSQ_INFO_FIELD} field of this VCF "
+                                      f"({', '.join(self.fields)})") from None
+
+    def picked_entry(self, variant) -> Optional[list[str]]:
+        csq = variant.INFO.get(CSQ_INFO_FIELD)
+        if not csq:
+            return None
+        entries = [entry.split("|") for entry in csq.split(",")]
+        if self.pick_index is not None:
+            for entry in entries:
+                if entry[self.pick_index] == "1":
+                    return entry
+        return entries[0]
+
+
+def normalise_source_value(value) -> Optional[str]:
+    """ cyvcf2 hands back an int/float/str for a single INFO value and a tuple for a multi-valued one,
+        while the registry formatters take the '&'-joined string VEP produces. Normalising to that string
+        is what lets one code path serve both bcftools and VEP input. """
+    if value is None or value is False:
+        return None
+    if value is True:  # INFO flag
+        return "1"
+    if isinstance(value, (tuple, list)):
+        values = [str(v) for v in value if v is not None and str(v) not in EMPTY_VALUES]
+        value = VEP_SEPARATOR.join(values)
+    else:
+        value = str(value)
+    value = value.strip()
+    if value in EMPTY_VALUES:
+        return None
+    return value
+
+
+def _format_value(target: BackfillTarget, raw_value) -> Optional[str]:
+    value = normalise_source_value(raw_value)
+    if value is None:
+        return None
+    if target.formatter:
+        value = target.formatter(value)
+    return value
+
+
+def _csv_value(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _create_temp_table(variant_annotation_version: VariantAnnotationVersion, targets: list[BackfillTarget]):
+    """ Temp table shaped like the columns we're about to write, taking its types from the version's own
+        partition so a COPY of formatted values lands in exactly the type the UPDATE compares against. """
+    partition = variant_annotation_version.get_partition_table(
+        base_table_name=VariantAnnotationVersion.REPRESENTATIVE_TRANSCRIPT_ANNOTATION)
+    columns = ", ".join(f'"{t.column}"' for t in targets)
+    with connection.cursor() as cursor:
+        cursor.execute(f"DROP TABLE IF EXISTS {TEMP_TABLE}")
+        cursor.execute(f"CREATE TEMP TABLE {TEMP_TABLE} AS "
+                       f"SELECT variant_id, {columns} FROM {partition} WITH NO DATA")
+
+
+def _drop_temp_table():
+    with connection.cursor() as cursor:
+        cursor.execute(f"DROP TABLE IF EXISTS {TEMP_TABLE}")
+
+
+def _new_value_sql(column: str, clear_missing: bool) -> str:
+    """ What the column becomes. By default a source with no value leaves the existing value alone, so a
+        partial annotation file fills in what it knows; clear_missing makes the file authoritative for
+        the dumped variants, writing NULL where the source is silent. """
+    if clear_missing:
+        return f't."{column}"'
+    return f'COALESCE(t."{column}", a."{column}")'
+
+
+def _update_batch(variant_annotation_version: VariantAnnotationVersion, targets: list[BackfillTarget],
+                  clear_missing: bool, dry_run: bool) -> int:
+    """ Join the temp table to each partition holding the targets. Returns rows changed (or, for dry_run,
+        rows that would change). """
+    rows_changed = 0
+    with connection.cursor() as cursor:
+        cursor.execute(f"ANALYZE {TEMP_TABLE}")
+        for base_table_name in VariantAnnotationVersion.RECORDS_BASE_TABLE_NAMES:
+            columns = [t.column for t in targets if base_table_name in t.base_table_names]
+            if not columns:
+                continue
+            partition = variant_annotation_version.get_partition_table(base_table_name=base_table_name)
+            # IS DISTINCT FROM lets postgres skip rewriting rows whose value is unchanged - for COSMIC
+            # only a small fraction of variants carry a count, which is most of why this is quick
+            changed = " OR ".join(f'a."{c}" IS DISTINCT FROM {_new_value_sql(c, clear_missing)}'
+                                  for c in columns)
+            if dry_run:
+                cursor.execute(f"SELECT count(*) FROM {partition} a "
+                               f"INNER JOIN {TEMP_TABLE} t ON a.variant_id = t.variant_id "
+                               f"WHERE {changed}")
+                rows_changed += cursor.fetchone()[0]
+            else:
+                set_clause = ", ".join(f'"{c}" = {_new_value_sql(c, clear_missing)}' for c in columns)
+                cursor.execute(f"UPDATE {partition} a SET {set_clause} FROM {TEMP_TABLE} t "
+                               f"WHERE a.variant_id = t.variant_id AND ({changed})")
+                rows_changed += cursor.rowcount
+        cursor.execute(f"TRUNCATE {TEMP_TABLE}")
+    return rows_changed
+
+
+def _copy_and_update(variant_annotation_version: VariantAnnotationVersion, targets: list[BackfillTarget],
+                     buffer: io.StringIO, clear_missing: bool, dry_run: bool) -> int:
+    columns = ["variant_id"] + [t.column for t in targets]
+    data = io.BytesIO(buffer.getvalue().encode())
+    with transaction.atomic():
+        sql_copy_csv_file(data, TEMP_TABLE, columns, quote='"')
+        rows_changed = _update_batch(variant_annotation_version, targets, clear_missing, dry_run)
+        if dry_run:
+            transaction.set_rollback(True)
+    return rows_changed
+
+
+def import_backfill_vcf(variant_annotation_version: VariantAnnotationVersion, vcf_filename: str,
+                        targets: list[BackfillTarget], batch_size: int = DEFAULT_BATCH_SIZE,
+                        clear_missing: bool = False, dry_run: bool = False, emit: Callable = None) -> dict:
+    """ Read an annotated VCF and update the target columns of the version's partitions in batches.
+        Returns counts of records read / rows COPY'd / rows changed. """
+    def _emit(message):
+        if emit:
+            emit(message)
+        else:
+            logging.info(message)
+
+    reader = cyvcf2.VCF(vcf_filename)
+    csq_picker = None
+    csq_indexes = {}
+    if any(t.from_csq for t in targets):
+        csq_picker = _CSQPicker(reader)
+        csq_indexes = {t.column: csq_picker.index_of(t.source_field) for t in targets if t.from_csq}
+
+    records_read = 0
+    rows_copied = 0
+    rows_changed = 0
+    batch_rows = 0
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    last_progress = time.time()
+
+    _create_temp_table(variant_annotation_version, targets)
+    try:
+        for variant in reader:
+            records_read += 1
+            variant_id = variant.INFO.get(VARIANT_ID)
+            if variant_id is None:
+                raise BackfillColumnError(f"{vcf_filename} record {variant.CHROM}:{variant.POS} has no "
+                                          f"'{VARIANT_ID}' INFO field - it wasn't dumped by "
+                                          f"annotation_backfill_columns --dump")
+
+            csq_entry = csq_picker.picked_entry(variant) if csq_picker else None
+            values = []
+            for target in targets:
+                if target.from_csq:
+                    index = csq_indexes[target.column]
+                    raw_value = csq_entry[index] if csq_entry and index < len(csq_entry) else None
+                else:
+                    raw_value = variant.INFO.get(target.source_field)
+                values.append(_format_value(target, raw_value))
+
+            # Without clear_missing a record the source says nothing about can't change anything, so it's
+            # not worth COPYing - which for COSMIC is the great majority of the dump
+            if clear_missing or any(v is not None for v in values):
+                writer.writerow([variant_id] + [_csv_value(v) for v in values])
+                batch_rows += 1
+
+            if batch_rows >= batch_size:
+                rows_changed += _copy_and_update(variant_annotation_version, targets, buffer,
+                                                 clear_missing, dry_run)
+                rows_copied += batch_rows
+                _emit(f"Read {records_read} records, {rows_copied} written, {rows_changed} rows "
+                      f"{'would change' if dry_run else 'changed'}")
+                buffer = io.StringIO()
+                writer = csv.writer(buffer)
+                batch_rows = 0
+                last_progress = time.time()
+            elif time.time() - last_progress > IMPORT_PROGRESS_INTERVAL_SECONDS:
+                _emit(f"Read {records_read} records ({batch_rows} pending in batch)")
+                last_progress = time.time()
+
+        if batch_rows:
+            rows_changed += _copy_and_update(variant_annotation_version, targets, buffer,
+                                             clear_missing, dry_run)
+            rows_copied += batch_rows
+    finally:
+        reader.close()
+        _drop_temp_table()
+
+    columns = ", ".join(t.column for t in targets)
+    _emit(f"Backfilled {columns}: read {records_read} records, wrote {rows_copied}, "
+          f"{rows_changed} rows {'would change' if dry_run else 'changed'}")
+    return {"records_read": records_read, "rows_copied": rows_copied, "rows_changed": rows_changed}

--- a/annotation/management/commands/annotation_backfill_columns.py
+++ b/annotation/management/commands/annotation_backfill_columns.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Backfill VariantAnnotation columns from an annotated VCF (#1675).
+
+--dump writes the variants already annotated in a version to a VCF carrying variant_id in INFO; the
+operator annotates that file however suits the column (bcftools annotate against a COSMIC VCF, or VEP);
+--import reads it back and updates the named columns.
+
+See claude/plans/1675_backfill_annotation_column_plan.md.
+"""
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+
+from annotation.backfill_columns import (
+    DEFAULT_BATCH_SIZE,
+    BackfillColumnError,
+    dump_annotated_variants,
+    import_backfill_vcf,
+    resolve_backfill_columns,
+)
+from annotation.models.models import VariantAnnotationVersion
+from snpdb.models.models_genome import GenomeBuild
+
+
+class Command(BaseCommand):
+    help = "Dump/import a VCF to backfill VariantAnnotation columns (#1675)"
+
+    def add_arguments(self, parser):
+        mode = parser.add_mutually_exclusive_group(required=True)
+        mode.add_argument("--dump", action="store_true",
+                          help="Write the version's annotated variants to a VCF for external annotation")
+        mode.add_argument("--import", action="store_true", dest="import_mode",
+                          help="Read an annotated VCF back, updating --columns")
+
+        parser.add_argument("--genome-build", required=True)
+        parser.add_argument("--variant-annotation-version", type=int,
+                            help="VariantAnnotationVersion pk (default: the build's ACTIVE version)")
+        parser.add_argument("--columns", required=True,
+                            help="Comma separated VariantGrid column ids, eg 'cosmic_count,cosmic_legacy_id'")
+        parser.add_argument("--info", action="append", default=[], metavar="COLUMN=INFO_FIELD",
+                            help="Read a column from this INFO field instead of the registry default "
+                                 "(the source file's naming varies by release). Repeatable")
+        parser.add_argument("--csq", action="append", default=[], metavar="COLUMN=CSQ_FIELD",
+                            help="Read a column off the PICK'd VEP CSQ entry rather than a top level "
+                                 "INFO field. Repeatable")
+        parser.add_argument("--output", help="--dump: VCF to write (.gz writes bgzip, which tabix can index)")
+        parser.add_argument("--only-missing", action="store_true",
+                            help="--dump: only variants where every --columns value is null")
+        parser.add_argument("--min-variant-id", type=int,
+                            help="--dump: split a large dump into pieces that can be annotated in parallel")
+        parser.add_argument("--max-variant-id", type=int, help="--dump: see --min-variant-id")
+        parser.add_argument("--vcf", help="--import: the externally annotated VCF")
+        parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE,
+                            help="--import: records per COPY/UPDATE cycle (default %(default)s)")
+        parser.add_argument("--clear-missing", action="store_true",
+                            help="--import: write NULL where the source has no value, making the file "
+                                 "authoritative for the dumped variants (default: leave it alone)")
+        parser.add_argument("--dry-run", action="store_true",
+                            help="--import: report how many rows would change, changing nothing")
+
+    def handle(self, *args, **options):
+        genome_build = GenomeBuild.get_name_or_alias(options["genome_build"])
+        variant_annotation_version = self._get_variant_annotation_version(genome_build, options)
+        column_ids = [c.strip() for c in options["columns"].split(",") if c.strip()]
+        if not column_ids:
+            raise CommandError("--columns needs at least one VariantGrid column id")
+
+        try:
+            targets = resolve_backfill_columns(variant_annotation_version, column_ids,
+                                               info_overrides=self._parse_overrides(options["info"], "--info"),
+                                               csq_overrides=self._parse_overrides(options["csq"], "--csq"))
+        except BackfillColumnError as e:
+            raise CommandError(str(e))
+
+        for target in targets:
+            tables = ", ".join(target.base_table_names)
+            self.stdout.write(f"{target.column} <- {target.source_description} ({tables})")
+
+        if options["dump"]:
+            self._run_dump(variant_annotation_version, targets, options)
+        else:
+            self._run_import(variant_annotation_version, targets, options)
+
+    @staticmethod
+    def _get_variant_annotation_version(genome_build, options) -> VariantAnnotationVersion:
+        if pk := options["variant_annotation_version"]:
+            try:
+                variant_annotation_version = VariantAnnotationVersion.objects.get(pk=pk)
+            except VariantAnnotationVersion.DoesNotExist:
+                raise CommandError(f"No VariantAnnotationVersion with pk={pk}")
+            if variant_annotation_version.genome_build != genome_build:
+                raise CommandError(f"VariantAnnotationVersion pk={pk} is "
+                                   f"{variant_annotation_version.genome_build}, not {genome_build}")
+        else:
+            variant_annotation_version = VariantAnnotationVersion.latest(genome_build)
+            if variant_annotation_version is None:
+                raise CommandError(f"No ACTIVE VariantAnnotationVersion for {genome_build} - name one "
+                                   f"with --variant-annotation-version")
+        return variant_annotation_version
+
+    @staticmethod
+    def _parse_overrides(values, arg_name) -> dict[str, str]:
+        overrides = {}
+        for value in values:
+            column, sep, source_field = value.partition("=")
+            if not (sep and column.strip() and source_field.strip()):
+                raise CommandError(f"{arg_name} '{value}' must be COLUMN=FIELD")
+            overrides[column.strip()] = source_field.strip()
+        return overrides
+
+    def _run_dump(self, variant_annotation_version, targets, options):
+        output_filename = options.get("output")
+        if not output_filename:
+            raise CommandError("--dump requires --output")
+
+        count = dump_annotated_variants(variant_annotation_version, output_filename, targets=targets,
+                                        only_missing=options["only_missing"],
+                                        min_variant_id=options["min_variant_id"],
+                                        max_variant_id=options["max_variant_id"])
+        self.stdout.write(f"Dumped {count} variants annotated by {variant_annotation_version} "
+                          f"to '{output_filename}'")
+
+    def _run_import(self, variant_annotation_version, targets, options):
+        vcf_filename = options.get("vcf")
+        if not vcf_filename:
+            raise CommandError("--import requires --vcf")
+        if not os.path.exists(vcf_filename):
+            raise CommandError(f"--vcf '{vcf_filename}' does not exist")
+
+        def emit(message):
+            self.stdout.write(message)
+            self.stdout.flush()
+
+        try:
+            report = import_backfill_vcf(variant_annotation_version, vcf_filename, targets,
+                                         batch_size=options["batch_size"],
+                                         clear_missing=options["clear_missing"],
+                                         dry_run=options["dry_run"], emit=emit)
+        except BackfillColumnError as e:
+            raise CommandError(str(e))
+
+        verb = "would change" if options["dry_run"] else "changed"
+        self.stdout.write(f"{variant_annotation_version}: read {report['records_read']} records, "
+                          f"{verb} {report['rows_changed']} rows")

--- a/annotation/tests/test_backfill_columns.py
+++ b/annotation/tests/test_backfill_columns.py
@@ -1,0 +1,228 @@
+"""
+Backfilling VariantAnnotation columns from an annotated VCF (#1675).
+
+@see claude/plans/1675_backfill_annotation_column_plan.md
+"""
+import os
+import tempfile
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from annotation.backfill_columns import (
+    BackfillColumnError,
+    dump_annotated_variants,
+    import_backfill_vcf,
+    normalise_source_value,
+    resolve_backfill_columns,
+)
+from annotation.fake_annotation import get_fake_annotation_settings_dict, get_fake_vep_version
+from annotation.models import AnnotationVersion, VariantAnnotation, VariantAnnotationVersion
+from annotation.models.models import AnnotationRangeLock, AnnotationRun
+from annotation.vep_field_formatters import format_pick_highest_int
+from genes.models_enums import AnnotationConsortium
+from library.django_utils.django_partition import temporary_db_table
+from snpdb.models import GenomeBuild
+from snpdb.tests.utils.vcf_testing_utils import slowly_create_test_variant
+
+COSMIC_V101_SAMPLE_COUNT = "GENOME_SCREEN_SAMPLE_COUNT"
+
+
+@override_settings(**get_fake_annotation_settings_dict(columns_version=3))
+class BackfillColumnResolutionTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.genome_build = GenomeBuild.get_name_or_alias("GRCh37")
+        kwargs = get_fake_vep_version(cls.genome_build, AnnotationConsortium.ENSEMBL, 3)
+        cls.vav = VariantAnnotationVersion.objects.create(**kwargs,
+                                                          status=VariantAnnotationVersion.Status.ACTIVE)
+
+    def test_registry_supplies_source_field_and_formatter(self):
+        target, = resolve_backfill_columns(self.vav, ["cosmic_count"])
+        # columns_version 3 reads COSMIC's v99 SAMPLE_COUNT, under the --custom label prefix
+        self.assertEqual(target.source_field, "COSMIC_SAMPLE_COUNT")
+        self.assertFalse(target.from_csq)
+        self.assertEqual(target.formatter, format_pick_highest_int)
+        # cosmic_count is variant-level, so only the representative transcript table holds it
+        self.assertEqual(target.base_table_names,
+                         (VariantAnnotationVersion.REPRESENTATIVE_TRANSCRIPT_ANNOTATION,))
+
+    def test_info_override_wins(self):
+        target, = resolve_backfill_columns(self.vav, ["cosmic_count"],
+                                           info_overrides={"cosmic_count": COSMIC_V101_SAMPLE_COUNT})
+        self.assertEqual(target.source_field, COSMIC_V101_SAMPLE_COUNT)
+        self.assertEqual(target.formatter, format_pick_highest_int)
+
+    def test_csq_override_targets_representative_table_only(self):
+        target, = resolve_backfill_columns(self.vav, ["impact"], csq_overrides={"impact": "IMPACT"})
+        self.assertTrue(target.from_csq)
+        self.assertEqual(target.base_table_names,
+                         (VariantAnnotationVersion.REPRESENTATIVE_TRANSCRIPT_ANNOTATION,))
+
+    def test_column_outside_columns_version_reported(self):
+        # cadd_raw arrived in columns_version 4
+        with self.assertRaises(BackfillColumnError) as cm:
+            resolve_backfill_columns(self.vav, ["cadd_raw"])
+        self.assertIn("cadd_raw", str(cm.exception))
+
+    def test_unknown_column_reported(self):
+        with self.assertRaises(BackfillColumnError) as cm:
+            resolve_backfill_columns(self.vav, ["not_a_column"])
+        self.assertIn("not_a_column", str(cm.exception))
+
+    def test_override_for_column_not_being_backfilled_reported(self):
+        with self.assertRaises(BackfillColumnError):
+            resolve_backfill_columns(self.vav, ["cosmic_count"],
+                                     info_overrides={"cosmic_legacy_id": "LEGACY_ID"})
+
+
+class NormaliseSourceValueTests(TestCase):
+    def test_multi_valued_info_formats_as_vep_joined_string(self):
+        """ cyvcf2 hands back a tuple where VEP would have written 12&7 - the registry formatter has to
+            see the same thing either way """
+        self.assertEqual(normalise_source_value((12, 7)), "12&7")
+        self.assertEqual(format_pick_highest_int(normalise_source_value((12, 7))), 12)
+
+    def test_single_value(self):
+        self.assertEqual(normalise_source_value(12), "12")
+        self.assertEqual(format_pick_highest_int(normalise_source_value(12)), 12)
+
+    def test_empty_values(self):
+        for empty in (None, "", ".", " "):
+            self.assertIsNone(normalise_source_value(empty), empty)
+
+    def test_info_flag(self):
+        self.assertEqual(normalise_source_value(True), "1")
+
+
+@override_settings(**get_fake_annotation_settings_dict(columns_version=3))
+class BackfillColumnRoundTripTests(TestCase):
+    """ Dump an annotated version, hand back a VCF carrying a COSMIC count, import it. """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.genome_build = GenomeBuild.get_name_or_alias("GRCh37")
+        kwargs = get_fake_vep_version(cls.genome_build, AnnotationConsortium.ENSEMBL, 3)
+        cls.vav = VariantAnnotationVersion.objects.create(**kwargs,
+                                                          status=VariantAnnotationVersion.Status.ACTIVE)
+        AnnotationVersion.latest(cls.genome_build, validate=False)
+
+        cls.variants = [
+            slowly_create_test_variant("1", 100 + i, "A", "G", cls.genome_build) for i in range(3)
+        ]
+        annotation_range_lock = AnnotationRangeLock.objects.create(version=cls.vav,
+                                                                   min_variant=cls.variants[0],
+                                                                   max_variant=cls.variants[-1],
+                                                                   count=len(cls.variants))
+        annotation_run = AnnotationRun.objects.create(annotation_range_lock=annotation_range_lock)
+        # The pipeline COPYs annotation straight into the version's partition (the base table is
+        # partitioned by INHERITS, with no routing trigger), and that's the table the backfill updates
+        partition = cls.vav.get_partition_table(
+            base_table_name=VariantAnnotationVersion.REPRESENTATIVE_TRANSCRIPT_ANNOTATION)
+        with temporary_db_table(VariantAnnotation, partition):
+            for variant in cls.variants:
+                VariantAnnotation.objects.create(version=cls.vav, variant=variant,
+                                                 annotation_run=annotation_run,
+                                                 symbol="RUNX1", cosmic_legacy_id="COSM1")
+        # An existing value the file has nothing to say about - what --clear-missing decides the fate of
+        VariantAnnotation.objects.filter(version=cls.vav, variant=cls.variants[2]).update(cosmic_count=3)
+
+    def setUp(self):
+        self.targets = resolve_backfill_columns(self.vav, ["cosmic_count"],
+                                                info_overrides={"cosmic_count": COSMIC_V101_SAMPLE_COUNT})
+
+    def _cosmic_counts(self) -> list:
+        qs = VariantAnnotation.objects.filter(version=self.vav).order_by("variant_id")
+        return list(qs.values_list("cosmic_count", flat=True))
+
+    @staticmethod
+    def _annotate_dump(dump_filename: str, annotated_filename: str, counts: dict[int, str]):
+        """ Stand in for the operator's `bcftools annotate`: add a COSMIC count to the dumped records. """
+        info_header = (f'##INFO=<ID={COSMIC_V101_SAMPLE_COUNT},Number=1,Type=Integer,'
+                       f'Description="How many genome screens samples have this mutation">\n')
+        with open(dump_filename) as f_in, open(annotated_filename, "w") as f_out:
+            for line in f_in:
+                if line.startswith("#CHROM"):
+                    f_out.write(info_header)
+                if line.startswith("#"):
+                    f_out.write(line)
+                    continue
+                columns = line.rstrip("\n").split("\t")
+                variant_id = int(columns[7].split("variant_id=")[1].split(";")[0])
+                if count := counts.get(variant_id):
+                    columns[7] += f";{COSMIC_V101_SAMPLE_COUNT}={count}"
+                f_out.write("\t".join(columns) + "\n")
+
+    def _dump_and_annotate(self, tmp_dir: str, counts: dict[int, str], only_missing: bool = False) -> str:
+        dump_filename = os.path.join(tmp_dir, "dump.vcf")
+        count = dump_annotated_variants(self.vav, dump_filename, targets=self.targets,
+                                        only_missing=only_missing)
+        self.assertEqual(count, 2 if only_missing else 3)
+        annotated_filename = os.path.join(tmp_dir, "annotated.vcf")
+        self._annotate_dump(dump_filename, annotated_filename, counts)
+        return annotated_filename
+
+    def test_round_trip_writes_formatted_values(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # The '&'-joined form COSMIC produces where several records overlap a variant
+            counts = {self.variants[0].pk: "12&7", self.variants[1].pk: "5"}
+            annotated_filename = self._dump_and_annotate(tmp_dir, counts)
+            report = import_backfill_vcf(self.vav, annotated_filename, self.targets)
+
+        self.assertEqual(report["records_read"], 3)
+        # Third variant keeps its existing value - the file said nothing about it
+        self.assertEqual(self._cosmic_counts(), [12, 5, 3])
+        # Neighbouring columns untouched
+        annotation = VariantAnnotation.objects.get(version=self.vav, variant=self.variants[0])
+        self.assertEqual(annotation.symbol, "RUNX1")
+        self.assertEqual(annotation.cosmic_legacy_id, "COSM1")
+
+    def test_clear_missing_nulls_values_the_file_is_silent_on(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            annotated_filename = self._dump_and_annotate(tmp_dir, {self.variants[0].pk: "12"})
+            import_backfill_vcf(self.vav, annotated_filename, self.targets, clear_missing=True)
+
+        self.assertEqual(self._cosmic_counts(), [12, None, None])
+
+    def test_dry_run_changes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            annotated_filename = self._dump_and_annotate(tmp_dir, {self.variants[0].pk: "12"})
+            report = import_backfill_vcf(self.vav, annotated_filename, self.targets, dry_run=True)
+
+        self.assertEqual(report["rows_changed"], 1)
+        self.assertEqual(self._cosmic_counts(), [None, None, 3])
+
+    def test_only_missing_skips_populated_rows(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # variants[2] already has a count, so it isn't dumped (asserted in _dump_and_annotate)
+            annotated_filename = self._dump_and_annotate(tmp_dir, {self.variants[1].pk: "5"},
+                                                         only_missing=True)
+            import_backfill_vcf(self.vav, annotated_filename, self.targets)
+
+        self.assertEqual(self._cosmic_counts(), [None, 5, 3])
+
+    def test_batches_smaller_than_the_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            counts = {v.pk: str(i + 1) for i, v in enumerate(self.variants)}
+            annotated_filename = self._dump_and_annotate(tmp_dir, counts)
+            report = import_backfill_vcf(self.vav, annotated_filename, self.targets, batch_size=2)
+
+        self.assertEqual(report["rows_copied"], 3)
+        self.assertEqual(self._cosmic_counts(), [1, 2, 3])
+
+    def test_record_without_variant_id_reported(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            annotated_filename = self._dump_and_annotate(tmp_dir, {})
+            stripped_filename = os.path.join(tmp_dir, "no_variant_id.vcf")
+            with open(annotated_filename) as f_in, open(stripped_filename, "w") as f_out:
+                for line in f_in:
+                    if not line.startswith("#"):
+                        columns = line.rstrip("\n").split("\t")
+                        columns[7] = "."
+                        line = "\t".join(columns) + "\n"
+                    f_out.write(line)
+
+            with self.assertRaises(BackfillColumnError):
+                import_backfill_vcf(self.vav, stripped_filename, self.targets)


### PR DESCRIPTION
Implements the plan in `claude/plans/1675_backfill_annotation_column_plan.md`.

Corrects or fills in individual `VariantAnnotation` columns for an existing `VariantAnnotationVersion` without re-running the whole VEP pipeline. The driving case is #1673: COSMIC keeps renaming the INFO field carrying its sample count (`CNT` v95/97 → `SAMPLE_COUNT` v99 → `GENOME_SCREEN_SAMPLE_COUNT` v101), so deployments have `cosmic_count` null across their annotation partitions.

## What's here

`manage.py annotation_backfill_columns`, in the shape of `annotation_external`:

- **`--dump`** writes the variants already annotated in a version to a VCF carrying `variant_id` in INFO. `--only-missing` restricts to rows where every target column is null; `--min-variant-id` / `--max-variant-id` split a large dump for parallel annotation.
- The operator annotates that file outside VariantGrid — `bcftools annotate` against a COSMIC VCF is the fast path, VEP works too.
- **`--import`** reads it back and UPDATEs the named columns in batches.

Columns are named as `VariantGridColumn` ids and resolved through the `VEPColumnDef` registry, which supplies the formatter (so a backfilled value is identical to a pipeline-written one), the default source field, and which columns exist at this version's `columns_version` / `vep_version`. `--info cosmic_count=GENOME_SCREEN_SAMPLE_COUNT` overrides the source field where a release renamed it; `--csq` reads off the PICK'd CSQ entry instead.

Per batch, inside one transaction: COPY into a temp table keyed on `variant_id`, `ANALYZE`, `UPDATE <partition> … FROM tmp … WHERE a.variant_id = t.variant_id AND a.col IS DISTINCT FROM t.col`, `TRUNCATE`. `IS DISTINCT FROM` lets postgres skip rewriting unchanged rows, which is most of why it's quick. By default a source with no value leaves the existing column alone; `--clear-missing` makes the file authoritative. `--dry-run` reports how many rows would change.

`AnnotationRun` / range-lock state is left alone entirely.

## Also changed

`annotation_run_files.write_qs_to_vcf` writes bgzip rather than plain gzip (tabix can index it, which `bcftools annotate` needs; reads fine anywhere gzip did, so external-annotation dumps gain indexability too), and streams its queryset via `.iterator()` — the first full-version dump attempt reached 3.8GB RSS in under a minute, and streaming holds it at ~350MB.

## Run for #1673

Against the COSMIC v101 VCFs in the annotation build dirs, on the ACTIVE versions:

| version | rows | `cosmic_count` before | after |
|---|---|---|---|
| v7 GRCh37 | 5,489,033 | 0 | 621,482 |
| v8 GRCh38 | 8,427,888 | 57 | 747,038 |

~6 min per build end to end. The totals land slightly above each version's `cosmic_legacy_id` counts (577k / 680k, written by VEP from v99), which is what a newer release should give, and the top values are the expected hotspots — BRAF V600E 1740, KRAS G12D 1104, IDH1 R132H 654, PIK3CA E545K 648, TP53 R175H 631.

## Still open on #1673

The forward fix. Recent columns_version 5 GRCh38 annotated VCFs carry `COSMIC_CNT` in their CSQ header, not the `COSMIC_SAMPLE_COUNT` that columns_version >= 3 expects, even though `get_vep_command` requests `fields=LEGACY_ID%SAMPLE_COUNT` — so newly annotated variants keep getting a null count. Separate from this PR.

## Tests

16 in `annotation/tests/test_backfill_columns.py` — column resolution, cyvcf2 value normalisation, and dump → annotate → import round trips covering `--clear-missing`, `--dry-run`, `--only-missing` and batching. Full `annotation` suite passes (427 tests).

Docs: [Backfill Annotation](https://github.com/SACGF/variantgrid/wiki/Backfill-Annotation) on the wiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LTGmtYR5iG47p2ZZ92MK4