### PR TITLE
Gate the COSMIC sample count on the installed release - #1673

### DIFF
--- a/annotation/fake_annotation.py
+++ b/annotation/fake_annotation.py
@@ -25,6 +25,7 @@ from annotation.models.models import (
     VariantAnnotationVersion,
 )
 from annotation.models.models_citations import CitationIdNormalized, CitationSource
+from annotation.vep_config import VEPConfig
 from genes.hgvs import HGVSMatcher
 from genes.models import GeneAnnotationImport
 from genes.models_enums import AnnotationConsortium
@@ -86,6 +87,22 @@ def get_fake_annotation_settings_dict(columns_version: int) -> dict:
 
     # Pin gnomAD so a developer's local override doesn't shift VEP CSQ fields and break fixture parsing.
     TEST_ANNOTATION[settings.BUILD_GRCH38]["vep_config"]["gnomad4"] = gnomad4_path
+
+    # COSMIC names the sample count INFO field differently per release (#1673) and the fixtures carry
+    # whichever CSQ column the release they were generated against produced - CNT for v1/v2,
+    # SAMPLE_COUNT from v3. Pin the release so the columns the importer expects match the fixture.
+    if columns_version < 3:
+        cosmic_paths = {
+            settings.BUILD_GRCH37: "annotation_data/GRCh37/CosmicCodingMuts_v95_20211101_grch37.normal.vcf.gz",
+            settings.BUILD_GRCH38: "annotation_data/GRCh38/CosmicCodingMuts_v95_20211101_grch38.normal.vcf.gz",
+        }
+    else:
+        cosmic_paths = {
+            settings.BUILD_GRCH37: "annotation_data/GRCh37/Cosmic_GenomeScreensMutant_v99_GRCh37.vcf.gz",
+            settings.BUILD_GRCH38: "annotation_data/GRCh38/Cosmic_GenomeScreensMutant_v99_GRCh38.vcf.gz",
+        }
+    for build_name, cosmic_path in cosmic_paths.items():
+        TEST_ANNOTATION[build_name]["vep_config"]["cosmic"] = cosmic_path
 
     # Same for the columns_version 5 plugin data (#1638) - a deployment pinned below cv5 calls
     # _disable_columns_version_5_plugins(), which nulls these and would drop the columns entirely.
@@ -149,6 +166,9 @@ def get_fake_vep_version(genome_build: GenomeBuild, annotation_consortium, colum
         else:
             continue
         fake_version[f.name] = value
+    # Real COSMIC release from the (test-pinned) vep_config, as the sample count INFO field is
+    # gated on it - see the cosmic_count VEPColumnDefs
+    fake_version["cosmic"] = VEPConfig(genome_build).cosmic_version
     return fake_version
 
 

--- a/annotation/models/models.py
+++ b/annotation/models/models.py
@@ -2030,6 +2030,7 @@ class VariantAnnotation(AbstractVariantAnnotation):
             pipeline_type=self.annotation_run.pipeline_type,
             columns_version=self.version.columns_version,
             vep_version=self.version.vep,
+            cosmic_version=self.version.cosmic,
             gnomad4_minor_version=self.version.gnomad,
         )
 

--- a/annotation/tests/test_vep_columns.py
+++ b/annotation/tests/test_vep_columns.py
@@ -49,6 +49,7 @@ class VepColumnsRegistryTest(TestCase):
             k = (c.source_field, c.vep_plugin, c.vep_custom,
                  c.min_columns_version, c.max_columns_version,
                  c.min_vep_version, c.max_vep_version,
+                 c.min_cosmic_version, c.max_cosmic_version,
                  c.genome_builds, c.pipeline_types,
                  c.variant_grid_columns)
             if k in seen:
@@ -77,6 +78,27 @@ class VepColumnsRegistryTest(TestCase):
         self.assertEqual(rows_40[0].source_field, "gnomad_filtered")
         self.assertEqual(len(rows_41), 1)
         self.assertEqual(rows_41[0].source_field, "FILTER")
+
+    def test_cosmic_count_source_field_per_release(self):
+        """ #1673: COSMIC renames the sample count INFO field, so the release picks the field - and
+            with it the CSQ column the inserter reads. """
+        expected_source_fields = {
+            95: "CNT",
+            97: "CNT",
+            99: "SAMPLE_COUNT",
+            101: "GENOME_SCREEN_SAMPLE_COUNT",
+        }
+        for cosmic_version, source_field in expected_source_fields.items():
+            with self.subTest(cosmic_version=cosmic_version):
+                rows = [c for c in filter_for(genome_build_name="GRCh37",
+                                              pipeline_type=VariantAnnotationPipelineType.STANDARD,
+                                              columns_version=5,
+                                              vep_custom=VEPCustom.COSMIC,
+                                              cosmic_version=cosmic_version)
+                        if "cosmic_count" in c.variant_grid_columns]
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(rows[0].source_field, source_field)
+                self.assertEqual(rows[0].vep_info_field, f"COSMIC_{source_field}")
 
     def test_gnomad4_helper_defaults(self):
         c = _gnomad4('AF_afr', 'gnomad_afr_af')

--- a/annotation/tests/test_vep_command.py
+++ b/annotation/tests/test_vep_command.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -132,3 +133,42 @@ class GetVepCommandColumnsVersion5Tests(TestCase):
         self.assertTrue(any(p.startswith("OpenTargets,file=") for p in plugins))
         self.assertFalse(any(p.startswith("EVE,file=") for p in plugins))
         self.assertFalse(any(p.startswith("PromoterAI,file=") for p in plugins))
+
+
+def _cosmic_settings(cosmic_basename: str) -> dict:
+    """ columns_version 5, with the COSMIC custom VCF swapped for a given release. """
+    d = get_fake_annotation_settings_dict(columns_version=5)
+    d["ANNOTATION"][settings.BUILD_GRCH38]["vep_config"]["cosmic"] = \
+        f"annotation_data/GRCh38/{cosmic_basename}"
+    return d
+
+
+class GetVepCommandCosmicTests(TestCase):
+    """ #1673 - COSMIC renames the sample count INFO field per release, and VEP silently writes an
+        empty CSQ column for a --custom field the file doesn't have, so asking for the wrong name
+        leaves cosmic_count null rather than failing. """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.grch38 = GenomeBuild.get_name_or_alias("GRCh38")
+
+    def _cosmic_custom_fields(self) -> list[str]:
+        cmd = get_vep_command(
+            "in.vcf", "out.vcf", self.grch38, AnnotationConsortium.ENSEMBL,
+            VariantAnnotationPipelineType.STANDARD,
+        )
+        customs = [cmd[i + 1] for i, x in enumerate(cmd) if x == "--custom"]
+        cosmic = [c for c in customs if "short_name=COSMIC," in c]
+        self.assertEqual(len(cosmic), 1)
+        params = dict(p.split("=", 1) for p in cosmic[0].split(","))
+        return params["fields"].split("%")
+
+    def test_v99_asks_for_sample_count(self):
+        with override_settings(**_cosmic_settings("Cosmic_GenomeScreensMutant_v99_GRCh38.vcf.gz")):
+            fields = self._cosmic_custom_fields()
+        self.assertEqual(sorted(fields), ["LEGACY_ID", "SAMPLE_COUNT"])
+
+    def test_v101_asks_for_genome_screen_sample_count(self):
+        with override_settings(**_cosmic_settings("Cosmic_GenomeScreensMutant_Normal_v101_GRCh38.vcf.gz")):
+            fields = self._cosmic_custom_fields()
+        self.assertEqual(sorted(fields), ["GENOME_SCREEN_SAMPLE_COUNT", "LEGACY_ID"])

--- a/annotation/tests/test_vep_component_versions.py
+++ b/annotation/tests/test_vep_component_versions.py
@@ -6,7 +6,7 @@ from django.test.utils import override_settings
 
 from annotation.fake_annotation import get_fake_annotation_settings_dict, get_fake_vep_version
 from annotation.models import VariantAnnotationVersion
-from annotation.vep_config import vep_component_version_kwargs
+from annotation.vep_config import parse_cosmic_version_from_filename, vep_component_version_kwargs
 from genes.models_enums import AnnotationConsortium
 from snpdb.models import GenomeBuild
 
@@ -128,6 +128,25 @@ class VEPComponentVersionKwargsTests(TestCase):
         kwargs = vep_component_version_kwargs(GRCH38_SETTINGS)
         self.assertIsNone(kwargs["vep_args"])
         self.assertIsNone(kwargs["pick_order"])
+
+
+class ParseCosmicVersionTests(TestCase):
+    """ #1673 - the release drives which INFO field carries the sample count, and it's only ever
+        written down in the distributed VCF's name. """
+
+    def test_release_parsed_from_distributed_names(self):
+        expected = {
+            "annotation_data/GRCh37/CosmicCodingMuts_v95_20211101_grch37.normal.vcf.gz": 95,
+            "annotation_data/GRCh38/Cosmic_GenomeScreensMutant_v99_GRCh38.vcf.gz": 99,
+            "annotation_data/GRCh37/Cosmic_GenomeScreensMutant_Normal_v101_GRCh37.vcf.gz": 101,
+        }
+        for path, cosmic_version in expected.items():
+            with self.subTest(path=path):
+                self.assertEqual(parse_cosmic_version_from_filename(path), cosmic_version)
+
+    def test_unversioned_name_is_none(self):
+        self.assertIsNone(
+            parse_cosmic_version_from_filename("annotation_data/GRCh37/CosmicCodingMuts.normal.grch37.vcf.gz"))
 
 
 @override_settings(**get_fake_annotation_settings_dict(columns_version=2))

--- a/annotation/vep_annotation.py
+++ b/annotation/vep_annotation.py
@@ -14,6 +14,7 @@ from annotation.models.models_enums import VariantAnnotationPipelineType, VEPCus
 from annotation.vep_columns import VEPColumnDef
 from annotation.vep_config import (
     VEPConfig,
+    parse_cosmic_version_from_filename,
     parse_gnomad_version_from_filename,
     vep_component_version_kwargs,
 )
@@ -462,9 +463,8 @@ def vep_dict_to_variant_annotation_version_kwargs(vep_config, vep_version_dict: 
         # COSMIC isn't in T2T
         cosmic_filename = vep_config["cosmic"]
         if os.path.exists(cosmic_filename):
-            cosmic_basename = os.path.basename(cosmic_filename)
-            if m := re.match(r"^Cosmic.*_v(\d{2,})_.*.vcf.gz", cosmic_basename):
-                kwargs["cosmic"] = int(m.group(1))
+            if cosmic_version := parse_cosmic_version_from_filename(cosmic_filename):
+                kwargs["cosmic"] = cosmic_version
     except KeyError:
         pass
 

--- a/annotation/vep_columns.py
+++ b/annotation/vep_columns.py
@@ -40,6 +40,8 @@ class VEPColumnDef:
     max_columns_version: Optional[int] = None
     min_vep_version: Optional[int] = None
     max_vep_version: Optional[int] = None
+    min_cosmic_version: Optional[int] = None
+    max_cosmic_version: Optional[int] = None
     gnomad4_minor_version: Optional[str] = None
     summary_stats: Optional[str] = None
     source_field_processing_description: Optional[str] = None
@@ -70,6 +72,7 @@ class VEPColumnDef:
         pipeline_type: Optional[VariantAnnotationPipelineType] = None,
         columns_version: Optional[int] = None,
         vep_version: Optional[int] = None,
+        cosmic_version: Optional[int] = None,
         gnomad4_minor_version: Optional[str] = None,
     ) -> bool:
         if genome_build_name is not None and self.genome_builds and genome_build_name not in self.genome_builds:
@@ -85,6 +88,11 @@ class VEPColumnDef:
             if self.min_vep_version is not None and vep_version < self.min_vep_version:
                 return False
             if self.max_vep_version is not None and vep_version > self.max_vep_version:
+                return False
+        if cosmic_version is not None:
+            if self.min_cosmic_version is not None and cosmic_version < self.min_cosmic_version:
+                return False
+            if self.max_cosmic_version is not None and cosmic_version > self.max_cosmic_version:
                 return False
         if gnomad4_minor_version is not None and self.gnomad4_minor_version is not None \
                 and gnomad4_minor_version != self.gnomad4_minor_version:
@@ -834,8 +842,12 @@ VEP_COLUMNS: tuple[VEPColumnDef, ...] = (
         pipeline_types=STANDARD,
         formatter=fmt.format_pick_highest_float,
     ),
-    # COSMIC renamed the sample count INFO field from CNT to SAMPLE_COUNT when we moved from
-    # CosmicCodingMuts (v97) to Cosmic_GenomeScreensMutant (v99) in columns version 3
+    # COSMIC keeps renaming the INFO field carrying the sample count (#1673), so which one to read is a
+    # function of the installed release rather than our columns version: CNT in CosmicCodingMuts (<= v97),
+    # SAMPLE_COUNT in Cosmic_GenomeScreensMutant (v99), GENOME_SCREEN_SAMPLE_COUNT from v101. VEP silently
+    # emits an empty CSQ column for a --custom field the file doesn't have, so asking for the wrong name
+    # writes nulls rather than failing. The release comes off the configured filename
+    # (VEPConfig.cosmic_version) and is stored on the version as VariantAnnotationVersion.cosmic.
     VEPColumnDef(
         source_field='CNT',
         variant_grid_columns=('cosmic_count',),
@@ -843,7 +855,7 @@ VEP_COLUMNS: tuple[VEPColumnDef, ...] = (
         vep_custom=VEPCustom.COSMIC,
         source_field_has_custom_prefix=True,
         pipeline_types=STANDARD,
-        max_columns_version=2,
+        max_cosmic_version=98,
         formatter=fmt.format_pick_highest_int,
     ),
     VEPColumnDef(
@@ -853,7 +865,18 @@ VEP_COLUMNS: tuple[VEPColumnDef, ...] = (
         vep_custom=VEPCustom.COSMIC,
         source_field_has_custom_prefix=True,
         pipeline_types=STANDARD,
-        min_columns_version=3,
+        min_cosmic_version=99,
+        max_cosmic_version=100,
+        formatter=fmt.format_pick_highest_int,
+    ),
+    VEPColumnDef(
+        source_field='GENOME_SCREEN_SAMPLE_COUNT',
+        variant_grid_columns=('cosmic_count',),
+        category=ColumnAnnotationCategory.FREQUENCY_DATA,
+        vep_custom=VEPCustom.COSMIC,
+        source_field_has_custom_prefix=True,
+        pipeline_types=STANDARD,
+        min_cosmic_version=101,
         formatter=fmt.format_pick_highest_int,
     ),
     VEPColumnDef(
@@ -1243,6 +1266,7 @@ def filter_for(
     pipeline_type: Optional[VariantAnnotationPipelineType] = None,
     columns_version: Optional[int] = None,
     vep_version: Optional[int] = None,
+    cosmic_version: Optional[int] = None,
     gnomad4_minor_version: Optional[str] = None,
     vep_plugin: Optional[VEPPlugin] = None,
     vep_custom: Optional[VEPCustom] = None,
@@ -1256,6 +1280,8 @@ def filter_for(
             columns_version = vep_config.columns_version
         if vep_version is None:
             vep_version = vep_config.vep_version
+        if cosmic_version is None:
+            cosmic_version = vep_config.cosmic_version
         if gnomad4_minor_version is None:
             gnomad4_minor_version = vep_config.gnomad4_minor_version
 
@@ -1266,6 +1292,7 @@ def filter_for(
             pipeline_type=pipeline_type,
             columns_version=columns_version,
             vep_version=vep_version,
+            cosmic_version=cosmic_version,
             gnomad4_minor_version=gnomad4_minor_version,
         )
         and (vep_plugin is None or c.vep_plugin == vep_plugin)

--- a/annotation/vep_config.py
+++ b/annotation/vep_config.py
@@ -16,6 +16,16 @@ def parse_gnomad_version_from_filename(path: str) -> Optional[str]:
     return None
 
 
+def parse_cosmic_version_from_filename(path: str) -> Optional[int]:
+    """ COSMIC release from the distributed VCF name, e.g.
+        CosmicCodingMuts_v95_20211101_grch37.normal.vcf.gz -> 95
+        Cosmic_GenomeScreensMutant_Normal_v101_GRCh37.vcf.gz -> 101 """
+    basename = os.path.basename(path)
+    if m := re.match(r"^Cosmic.*_v(\d{2,})_.*.vcf.gz", basename):
+        return int(m.group(1))
+    return None
+
+
 # vep_config data files whose name carries no version - we pin the basename, so swapping the installed
 # file registers as a change, as does removing it (which drops that data's columns via has_data_files)
 _BASENAME_PIN_FIELDS = {
@@ -117,3 +127,14 @@ class VEPConfig:
         if version is None:
             return "4.0"
         return version
+
+    @property
+    def cosmic_version(self) -> Optional[int]:
+        """ COSMIC release of the configured VCF - gates which INFO field carries the sample count
+            (see the cosmic_count VEPColumnDefs). None where COSMIC isn't configured (T2T) or the
+            release can't be read off the filename, which leaves the count columns ungated. """
+        try:
+            cosmic_path = self["cosmic"]
+        except KeyError:
+            return None
+        return parse_cosmic_version_from_filename(cosmic_path)

--- a/annotation/views.py
+++ b/annotation/views.py
@@ -722,7 +722,9 @@ def view_annotation_descriptions(request, genome_build_name=None):
 
     def _first_for_build(vgc_id, build_name):
         for c in vep_columns.for_variant_grid_column(vgc_id, vep_config=vep_config):
-            if c.applies_to(genome_build_name=build_name):
+            # cosmic_version so cosmic_count describes the INFO field the installed COSMIC release
+            # actually carries the count in (#1673)
+            if c.applies_to(genome_build_name=build_name, cosmic_version=vep_config.cosmic_version):
                 return c
         return None
 

--- a/variantgrid/settings/components/annotation_settings.py
+++ b/variantgrid/settings/components/annotation_settings.py
@@ -145,7 +145,7 @@ ANNOTATION = {
         # The names correspond to VEPPlugin or VEPCustom entries (but lower case)
         "vep_config": {
             "sift": True,
-            "cosmic": "annotation_data/GRCh37/Cosmic_GenomeScreensMutant_v99_GRCh37.vcf.gz",
+            "cosmic": "annotation_data/GRCh37/Cosmic_GenomeScreensMutant_Normal_v101_GRCh37.vcf.gz",
             "dbnsfp": "annotation_data/GRCh37/dbNSFP5.3.1a.grch37.stripped.gz",
             "dbscsnv": "annotation_data/GRCh37/dbscSNV1.1_GRCh37.txt.gz",
             "denovo_db": "annotation_data/GRCh37/denovo-db.variants.v.1.6.1.GRCh37.vcf.gz",
@@ -197,7 +197,7 @@ ANNOTATION = {
         # The names correspond to VEPPlugin or VEPCustom entries (but lower case)
         "vep_config": {
             "sift": True,
-            "cosmic": "annotation_data/GRCh38/Cosmic_GenomeScreensMutant_v99_GRCh38.vcf.gz",
+            "cosmic": "annotation_data/GRCh38/Cosmic_GenomeScreensMutant_Normal_v101_GRCh38.vcf.gz",
             "dbnsfp": "annotation_data/GRCh38/dbNSFP5.3.1a.grch38.stripped.gz",
             "dbscsnv": "annotation_data/GRCh38/dbscSNV1.1_GRCh38.txt.gz",
             "denovo_db": "annotation_data/GRCh38/denovo-db.variants.v.1.6.1.GRCh38.vcf.gz",
@@ -295,6 +295,19 @@ def _disable_columns_version_5_plugins(annotation):
                 vep_config[plugin_key] = None
 
 
+def _use_cosmic_v99(annotation):
+    """Restore the COSMIC v99 VCFs the package default shipped before #1673.
+
+    The default now points at the v101 release, whose sample count arrives in a different INFO field
+    (see the cosmic_count VEPColumnDefs). Deployments pinned to an older columns_version haven't
+    downloaded v101, so put them back on the release they have.
+    """
+    annotation[BUILD_GRCH37]["vep_config"]["cosmic"] = \
+        "annotation_data/GRCh37/Cosmic_GenomeScreensMutant_v99_GRCh37.vcf.gz"
+    annotation[BUILD_GRCH38]["vep_config"]["cosmic"] = \
+        "annotation_data/GRCh38/Cosmic_GenomeScreensMutant_v99_GRCh38.vcf.gz"
+
+
 def pin_annotation_to_columns_version_4(annotation):
     """Restore the columns_version 4 annotation config (pre-#1638, no VEP 116 plugins).
 
@@ -307,6 +320,7 @@ def pin_annotation_to_columns_version_4(annotation):
     annotation[BUILD_GRCH37]["columns_version"] = 4
     annotation[BUILD_GRCH38]["columns_version"] = 4
     _disable_columns_version_5_plugins(annotation)
+    _use_cosmic_v99(annotation)
 
 
 def use_pre_vep112_fasta(annotation):
@@ -331,6 +345,7 @@ def pin_annotation_to_columns_version_3(annotation):
     Note the caller is also responsible for keeping ANNOTATION_VEP_VERSION on its historical value.
     """
     _disable_columns_version_5_plugins(annotation)
+    _use_cosmic_v99(annotation)
     annotation[BUILD_GRCH37]["columns_version"] = 3
     annotation[BUILD_GRCH37]["vep_config"].update({
         "denovo_db": None,


### PR DESCRIPTION
🤖 Written by Claude

The forward half of #1673: teach the pipeline where the COSMIC sample count lives so newly annotated variants get one.

## The bug

COSMIC renames the INFO field carrying the sample count with each release:

| Release | File | INFO field |
|---|---|---|
| ≤ v97 | `CosmicCodingMuts` | `CNT` |
| v99 | `Cosmic_GenomeScreensMutant` | `SAMPLE_COUNT` |
| v101 | `Cosmic_GenomeScreensMutant_Normal` | `GENOME_SCREEN_SAMPLE_COUNT` |

Confirmed against VEP 116 on vg-test: VEP names each `--custom` CSQ column `{short_name}_{field}` verbatim, and **asking for a field the custom VCF doesn't have is silent** — no warning, no non-zero exit, just an empty column on every record. Running v101 with `fields=CNT%GENOME_SCREEN_SAMPLE_COUNT%LEGACY_ID%SAMPLE_COUNT` emitted all four columns with only `COSMIC_GENOME_SCREEN_SAMPLE_COUNT` populated.

That's how the count went missing: annotation runs asked the v99 file for `CNT`, so `cosmic_count` landed null with nothing to show for it.

## The fix

Gate on the COSMIC release rather than our `columns_version` — the release is the thing that actually changed, and it's recorded per annotation version already.

- `VEPConfig.cosmic_version` reads the release off the configured VCF name (`parse_cosmic_version_from_filename`, sitting alongside the gnomAD one). `vep_dict_to_variant_annotation_version_kwargs` now shares that parser instead of its own inline regex.
- `VEPColumnDef` gains `min_cosmic_version` / `max_cosmic_version`, threaded through `applies_to()` and `filter_for()` exactly as `vep_version` is. `filter_for(vep_config=…)` fills it in, so `get_vep_command` and `BulkVEPVCFAnnotationInserter` can't drift apart.
- Three `cosmic_count` defs — `CNT` ≤98, `SAMPLE_COUNT` 99–100, `GENOME_SCREEN_SAMPLE_COUNT` ≥101.
- The old `max_columns_version=2` / `min_columns_version=3` gating goes: it was a proxy for the file swap and mis-fires on a deployment sitting on cv≥3 with an older COSMIC file (`env/runx1db2.py` is one).
- `VariantAnnotation.visible_columns` and the annotation descriptions page pass the release through, so a version describes itself off its own `VariantAnnotationVersion.cosmic`.

Default `vep_config["cosmic"]` now points at the v101 VCFs; `pin_annotation_to_columns_version_3/4` restore the v99 ones for deployments that haven't downloaded v101.

`annotation/fake_annotation.py` pins the COSMIC release per fixture `columns_version` (v95 for cv1/2, v99 for cv3+) the way it already pins gnomAD, matching the CSQ columns each fixture carries.

## Verification

On vg-test both builds now emit `fields=GENOME_SCREEN_SAMPLE_COUNT%LEGACY_ID`, and both v101 VCFs are tabix-indexed.

`python3 manage.py test --keepdb annotation` — 416 tests, OK. `analysis snpdb variantopedia` — 632, OK.

New tests cover the release→field mapping across all four releases, the filename parsing, and the settings-path→`--custom fields=` chain for v99 vs v101.

## Upgrading

Installing v101 changes the VEP version identity (`cosmic` 99 → 101), so `get_or_create_variant_annotation_version_from_current_vep` creates a **new VariantAnnotationVersion** — a full re-annotation for one integer column. A deployment that doesn't want to pay that keeps its env on v99 and fills the existing version in with the `annotation_backfill_columns` command from #1675.

Deployments below columns_version 5 need no action — the pin helpers hold them on v99, which now correctly resolves to `SAMPLE_COUNT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LTGmtYR5iG47p2ZZ92MK4