### PR TITLE
Classification grouping - clean up groupings when classifications are deleted #1776

### DIFF
--- a/classification/signals/classification_hooks_grouping.py
+++ b/classification/signals/classification_hooks_grouping.py
@@ -66,10 +66,13 @@ def condition_set(sender, classification: Classification, **kwargs):
 @receiver(pre_delete, sender=Classification)
 def deleting_classification(sender, instance: Classification, **kwargs):  # pylint: disable=unused-argument
     # CLASSIFICATION DELETED
-    # when a classification is deleted, it will delete the corresponding ClassificationGroupingEntry
-    # so we need to mark the Allele Origin grouping (which dirty up does)
+    # delete the ClassificationGroupingEntry now (rather than waiting for the cascade) so the
+    # recalculation below doesn't count the classification being deleted - otherwise the grouping
+    # would be re-saved as clean while still including it, leaving a stale grouping behind
     if entry := ClassificationGroupingEntry.objects.filter(classification=instance).first():
-        entry.dirty_up()
+        grouping = entry.grouping
+        entry.delete()
+        grouping.dirty_up()
         _instant_undirty_check()
 
 


### PR DESCRIPTION
🤖 Written by Claude

Issue #1776

The `pre_delete` handler for `Classification` recalculated the grouping while the `ClassificationGroupingEntry` still existed (it is only removed by CASCADE when the classification row is deleted), so `ClassificationGrouping.update()` still counted the doomed classification, re-saved the grouping with `dirty=False`, and the "no classifications → delete grouping" branch never ran. Deleting classifications left stale, empty groupings behind that nothing ever revisited.

The handler now deletes the entry explicitly before dirtying the grouping and running the instant recalculation — mirroring what `assign_grouping_for_classification` already does in its no-allele branch — so the recount excludes the deleted classification and empty groupings clean themselves up.

Existing orphaned groupings on deployments can be cleaned up with `python3 manage.py classification_groupings --refresh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
