### PR TITLE
Analysis horizontal mode - grid docked along the bottom #38

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,11 @@ All major models use Django Guardian for object-level permissions. The mixin `Gu
 ### Frontend
 The project uses **Bootstrap 4**. Use `data-toggle` (not `data-bs-toggle`) and `data-target` (not `data-bs-target`) for collapse, modal, and other Bootstrap JS components.
 
+### Static files
+Source JS/CSS/images live in `variantgrid/static_files/<site>_static/` (`default_static` unless the
+change is site specific) — always edit there. `variantgrid/sitestatic/static/` is the collectstatic
+output: a temporary copy, gitignored, and overwritten by the next `manage.py collectstatic`.
+
 ### SCSS / CSS
 Files like `global.css` are compiled from their `.scss` sources (e.g. `global.scss`) by a PyCharm file watcher — do not run `sassc`/`sass` yourself, as its output formatting differs and creates huge diffs. When changing styles, edit the `.scss` file, then hand-apply the same minimal change to the generated `.css` (matching its existing formatting) so the change works before PyCharm next recompiles. Leave `.css.map` files alone.
 

--- a/analysis/forms/forms.py
+++ b/analysis/forms/forms.py
@@ -8,6 +8,7 @@ from crispy_forms.layout import Field, Layout
 from dal import forward
 from django import forms
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.forms import inlineformset_factory
 from django.forms.widgets import TextInput
 
@@ -227,7 +228,8 @@ class AnalysisForm(forms.ModelForm, ROFormMixin):
                   "name", "description", "analysis_type",
                   "custom_columns_collection", "default_sort_by_column", "canonical_transcript_collection",
                   "grid_sample_label_template", "variant_tag_stale_days",
-                  "show_igv_links", "annotation_version", "lock_input_sources", "node_queryset_filter_contigs")
+                  "show_igv_links", "analysis_horizontal_mode", "annotation_version", "lock_input_sources",
+                  "node_queryset_filter_contigs")
         read_only = ('user', 'genome_build')
         model = Analysis
         widgets = {'name': TextInput(),
@@ -283,7 +285,10 @@ class AnalysisForm(forms.ModelForm, ROFormMixin):
             instance.version += 1
 
         if commit:
-            instance.save()
+            with transaction.atomic():
+                instance.save()
+                if "analysis_horizontal_mode" in self.changed_data:
+                    instance.transpose_node_positions()
         return instance
 
 

--- a/analysis/models/models_analysis.py
+++ b/analysis/models/models_analysis.py
@@ -10,7 +10,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.db import models
-from django.db.models import Count, Max, Model, Q, QuerySet
+from django.db.models import Count, F, Max, Model, Q, QuerySet
 from django.db.models.deletion import CASCADE, PROTECT, SET_DEFAULT, SET_NULL, ProtectedError
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
@@ -223,6 +223,7 @@ class Analysis(GuardianPermissionsAutoInitialSaveMixin, TimeStampedModel, Previe
         self.default_sort_by_column = user_settings.default_sort_by_column
         self.grid_sample_label_template = user_settings.grid_sample_label_template
         self.variant_tag_stale_days = user_settings.variant_tag_stale_days
+        self.analysis_horizontal_mode = bool(user_settings.analysis_horizontal_mode)
         self.save()
 
         default_node_count_config = user_settings.get_node_count_settings_collection()
@@ -249,6 +250,12 @@ class Analysis(GuardianPermissionsAutoInitialSaveMixin, TimeStampedModel, Previe
         record_set = node_count_config.analysisnodecountconfigrecord_set
 
         AbstractNodeCountSettings.save_count_configs_from_array(record_set, node_counts_array)
+
+    def transpose_node_positions(self):
+        """ Node positions are laid out for an orientation (vertical DAGs are tall and narrow) so
+            switching analysis_horizontal_mode swaps them. Self-inverse - switching back restores the
+            original layout. Doesn't affect queries, so no version bump """
+        self.analysisnode_set.update(x=F("y"), y=F("x"))
 
     def get_samples(self) -> list[Sample]:
         samples = set()

--- a/analysis/models/nodes/filter_child.py
+++ b/analysis/models/nodes/filter_child.py
@@ -1,8 +1,6 @@
-import random
-
 from analysis.models.nodes.filters.filter_node import FilterNode, FilterNodeItem
 from analysis.models.nodes.filters.gene_list_node import GeneListNode
-from analysis.models.nodes.node_utils import update_analysis
+from analysis.models.nodes.node_utils import get_child_position, update_analysis
 from genes.custom_text_gene_list import create_custom_text_gene_list
 from genes.models import CustomTextGeneList, GeneListCategory
 from snpdb.models import VariantGridColumn
@@ -49,8 +47,7 @@ def create_filter_child_node(node, column_name, column_filter):
     else:
         child_node = create_filter_node(node.analysis, column_name, column_filter)
 
-    child_node.x = node.x + 50 + random.randrange(-10, 10)
-    child_node.y = node.y + 100 + random.randrange(-10, 10)
+    child_node.x, child_node.y = get_child_position(node)
     child_node.add_parent(node)
     child_node.ready = False
     child_node.save()

--- a/analysis/models/nodes/node_utils.py
+++ b/analysis/models/nodes/node_utils.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import time
 from collections import defaultdict
 from dataclasses import asdict
@@ -22,6 +23,17 @@ def get_nodes_by_id(nodes_qs):
     for node in nodes_qs:
         nodes_by_id[node.id] = node
     return nodes_by_id
+
+
+def get_child_position(parent):
+    """ Children go along the flow from their parent - to the right in horizontal mode, below in vertical """
+    if parent.analysis.analysis_horizontal_mode:
+        child_x_offset, child_y_offset = 100, 50
+    else:
+        child_x_offset, child_y_offset = 50, 100
+    x = parent.x + child_x_offset + random.randrange(-10, 10)
+    y = parent.y + child_y_offset + random.randrange(-10, 10)
+    return x, y
 
 
 def get_parent_value_dag_dictionary(nodes):

--- a/analysis/templates/analysis/analysis.html
+++ b/analysis/templates/analysis/analysis.html
@@ -56,7 +56,9 @@
 
     #analysis-toolbar {
         width: 100%;
-        z-index: 9999;
+        /* Over the canvas (nodes are 24) but under Bootstrap's tooltips, so a hover from the
+           toolbar or the editor drawer isn't drawn behind the bar */
+        z-index: 100;
         position: absolute;
         top: 0px;
         left: 0px;
@@ -349,6 +351,9 @@
                     <div class="drawer-resize-handle" title="Drag to resize"></div>
                     <div class="drawer-header">
                         <span class="drawer-title">Node editor</span>
+                        {# The node editor's own tabs are mirrored in here - see syncNodeEditorTabs() #}
+                        <span id="drawer-node-tabs" class="drawer-node-tabs"></span>
+                        <span id="drawer-variant-tabs" class="drawer-node-tabs"></span>
                         <a id="dock-editor-as-tab-button" class="toolbar-button" href="javascript:void(0)"
                            title="Dock the editor as a tab in the bottom panel"><i class="fa-solid fa-window-maximize"></i></a>
                         <a id="close-editor-drawer-button" class="toolbar-button" href="javascript:void(0)"

--- a/analysis/templates/analysis/analysis.html
+++ b/analysis/templates/analysis/analysis.html
@@ -137,6 +137,10 @@
     // noinspection JSAnnotator
     const ANALYSIS_ID = {{ analysis.pk }};
 
+    // Nodes flow left->right with the grid along the bottom - see analysis.js/analysis_nodes.js
+    // noinspection JSAnnotator
+    const ANALYSIS_HORIZONTAL_MODE = {{ analysis.analysis_horizontal_mode|jsonify }};
+
     // User-selected grid loading animations (menu ids; see showGridLoadingOverlay)
     // noinspection JSAnnotator
     const ANALYSIS_LOADING_ANIMATIONS = {{ loading_animations | jsonify }};
@@ -284,7 +288,7 @@
             <div class="clear"></div>
         </div>
     {% endif %}
-        <div id="analysis-and-toolbar-container" class="d-flex flex-row split-element">
+        <div id="analysis-and-toolbar-container" class="d-flex split-element {% if analysis.analysis_horizontal_mode %}flex-column analysis-horizontal{% else %}flex-row{% endif %}">
             <div id="left-panel" class="split-element noselect">
                 <div id="analysis-toolbar">
                 {% if has_write_permission %}
@@ -339,6 +343,20 @@
                     </div>
                 </div>
                 <div id='node-count-legend' title='Modify node counts in analysis settings (cog icon)'></div>
+            {% if analysis.analysis_horizontal_mode %}
+                {# The editor's other home - #node-editor-container is moved in here, see applyEditorHome() #}
+                <div id="node-editor-drawer" style="display: none">
+                    <div class="drawer-resize-handle" title="Drag to resize"></div>
+                    <div class="drawer-header">
+                        <span class="drawer-title">Node editor</span>
+                        <a id="dock-editor-as-tab-button" class="toolbar-button" href="javascript:void(0)"
+                           title="Dock the editor as a tab in the bottom panel"><i class="fa-solid fa-window-maximize"></i></a>
+                        <a id="close-editor-drawer-button" class="toolbar-button" href="javascript:void(0)"
+                           title="Close (Esc)"><i class="fa-solid fa-xmark"></i></a>
+                    </div>
+                    <div id="node-editor-drawer-body"></div>
+                </div>
+            {% endif %}
             </div>
             <div id="right-panel" class="split-element">
                 <div>&nbsp;</div>

--- a/analysis/templates/analysis/analysis_editor_and_grid.html
+++ b/analysis/templates/analysis/analysis_editor_and_grid.html
@@ -100,6 +100,15 @@
     justify-content: center;
 }
 </style>
+{% if analysis.analysis_horizontal_mode and not stand_alone %}
+{# Editor and grid share the bottom panel - the tabs only control which one is showing, see analysis.js #}
+<div id="bottom-pane-tabs" class="bottom-pane-tabs">
+	<a class="bottom-pane-tab" pane="editor" href="javascript:void(0)">Editor</a>
+	<a class="bottom-pane-tab active" pane="grid" href="javascript:void(0)">Grid</a>
+	<a id="undock-editor-button" class="bottom-pane-tab-action" href="javascript:void(0)"
+	   title="Undock the editor into a drawer over the canvas"><i class="fa-solid fa-up-right-from-square"></i> undock</a>
+</div>
+{% endif %}
 <div id="grid-and-editor-container">
 	<div id="node-editor-container">
 		<div style='display: none' class='cancel-node-loading'>

--- a/analysis/templates/analysis/analysis_editor_and_grid.html
+++ b/analysis/templates/analysis/analysis_editor_and_grid.html
@@ -103,8 +103,12 @@
 {% if analysis.analysis_horizontal_mode and not stand_alone %}
 {# Editor and grid share the bottom panel - the tabs only control which one is showing, see analysis.js #}
 <div id="bottom-pane-tabs" class="bottom-pane-tabs">
-	<a class="bottom-pane-tab" pane="editor" href="javascript:void(0)">Editor</a>
-	<a class="bottom-pane-tab active" pane="grid" href="javascript:void(0)">Grid</a>
+	<a class="bottom-pane-tab" pane="editor" editor-tab="0" href="javascript:void(0)">Editor</a>
+	<a class="bottom-pane-tab active" pane="grid" editor-tab="0" href="javascript:void(0)">Grid</a>
+	{# The node editor's own tabs (Summary, Doc, Graphs...) are mirrored in here - see syncBottomPaneNodeTabs() #}
+	<span id="bottom-pane-node-tabs" class="bottom-pane-node-tabs"></span>
+	{# Variant details open as their own closable tabs - see renderVariantDetailsTabs() #}
+	<span id="bottom-pane-variant-tabs" class="bottom-pane-node-tabs"></span>
 	<a id="undock-editor-button" class="bottom-pane-tab-action" href="javascript:void(0)"
 	   title="Undock the editor into a drawer over the canvas"><i class="fa-solid fa-up-right-from-square"></i> undock</a>
 </div>
@@ -118,6 +122,8 @@
 		<div class="node-editor" id="no-editor">
 		</div>
 	</div>
+	{# One pane per open variant details tab - moves between homes with the editor, see applyEditorHome() #}
+	<div id="variant-details-container" style="display: none"></div>
 	<div id="node-grid-container">
 		<div id="error-container">
 		</div>

--- a/analysis/templates/analysis/analysis_settings_details_tab.html
+++ b/analysis/templates/analysis/analysis_settings_details_tab.html
@@ -48,6 +48,11 @@
             checkAndMarkDirtyNodes();
         {% endif %}
 
+        {% if reload_page %}
+        if (IN_ANALYSIS) {
+            window.location.reload();  // horizontal mode changed - the page renders a different layout
+        }
+        {% endif %}
     });
 </script>
 

--- a/analysis/templates/analysis/node_data/node_data_grid.html
+++ b/analysis/templates/analysis/node_data/node_data_grid.html
@@ -73,6 +73,10 @@ function gridComplete() {
 
         // Clear the grid-only overlay we put up when the user clicked "Show grid" (no-op otherwise).
         hideGridLoadingOverlay();
+
+        if (typeof isHorizontalMode === "function" && isHorizontalMode()) {
+            resizeGrid();  // fill the full width bottom panel the grid landed in
+        }
     }
 }
 
@@ -99,22 +103,36 @@ $(document).ready(function() {
     const aWin = getAnalysisWindow();
     aWin.loadedGridVersions = aWin.loadedGridVersions || {};
     const alreadyLoaded = aWin.loadedGridVersions[{{ node_id }}] === {{ node_version }};
-    const autoLoad = {{ grid_auto_load|yesno:"true,false" }} || alreadyLoaded;
-    if (autoLoad) {
-        // We have retrieved it (or are about to) - show the grid, never the placeholder.
+    const wantsGrid = {{ grid_auto_load|yesno:"true,false" }} || alreadyLoaded;
+    // Nothing to show while the Editor tab is up, so don't pay for the rows - the tab-show handler
+    // in analysis.js fires the load we register below.
+    const deferredForHiddenTab = wantsGrid && typeof bottomPaneGridHidden === "function" && bottomPaneGridHidden();
+    const autoLoad = wantsGrid && !deferredForHiddenTab;
+
+    const showGrid = function() {
         $("#grid-placeholder-{{ node_id }}").hide();
         $("#node-data-grid", "#" + unique_code).show();
+    };
+
+    if (autoLoad) {
+        // We have retrieved it (or are about to) - show the grid, never the placeholder.
+        showGrid();
     }
     setupGrid(grid_url, {{ analysis_id }}, {{ node_id }}, {{ node_version }}, unique_code,
               gridComplete, gridLoadError, on_error_function, autoLoad);
-    if (!autoLoad) {
-        $("#load-variants-{{ node_id }}").click(function() {
-            $("#grid-placeholder-{{ node_id }}").hide();
-            $("#node-data-grid", "#" + unique_code).show();
-            // Double-helix over just the grid section (editor stays usable) while phase 2 runs.
-            showGridLoadingOverlay("#node-grid-container");
-            loadNodeGridData({{ node_id }}, unique_code);  // fires deferred phase 2
-        });
+
+    const loadDeferredGrid = function() {
+        showGrid();
+        // Double-helix over just the grid section (editor stays usable) while phase 2 runs.
+        showGridLoadingOverlay("#node-grid-container");
+        loadNodeGridData({{ node_id }}, unique_code);  // fires deferred phase 2
+    };
+
+    if (deferredForHiddenTab) {
+        registerDeferredGridLoad(loadDeferredGrid);
+    } else if (!autoLoad) {
+        // Over the row-count threshold - the placeholder gives the user the choice
+        $("#load-variants-{{ node_id }}").click(loadDeferredGrid);
     }
 });
 </script>

--- a/analysis/templates/analysis/node_editors/base_editor.html
+++ b/analysis/templates/analysis/node_editors/base_editor.html
@@ -101,6 +101,14 @@
 		$('.node-data', dataContainer).fadeOut().promise().done(fadeInFunc);
 	}
 
+	/* The summary/graph views render into the data container, which shares the bottom panel with the
+	   editor in horizontal mode - show the pane they land in */
+	function showNodeDataPane() {
+		if (typeof showBottomPaneTab === 'function') {
+			showBottomPaneTab(BOTTOM_PANE_GRID);
+		}
+	}
+
 	function load_column_summary() {
 		const column = $("select#id_column", "form#column-summary-form").val();
 		const base_url = "{% url 'node_column_summary' node.analysis_id node.analysis.version node.pk node.version extra_filters 'COLUMN' 3 %}";
@@ -108,6 +116,7 @@
 		const nodeDataSummary = $("#node-data-summary");
 
 		nodeDataSummary.load(url);
+		showNodeDataPane();
 	}
 
 
@@ -143,6 +152,7 @@
 		const nodeDataSummary = $("#node-data-summary");
 		nodeDataSummary.html("Loading...");
 		nodeDataSummary.load(url);
+		showNodeDataPane();
 	}
 
 	function load_node_graph() {
@@ -155,6 +165,7 @@
 		const nodeDataGraph = $("#node-data-graphs");
 		nodeDataGraph.html("Loading...");
 		nodeDataGraph.load(url);
+		showNodeDataPane();
 	}
 
 	$(document).ready(function() {
@@ -167,6 +178,9 @@
 			}
 		};
 		tab.tabs(params);
+		if (typeof syncNodeEditorTabs === 'function') {
+			syncNodeEditorTabs();  // horizontal mode shows these tabs in the bottom pane or drawer bar
+		}
 
 		params = {
 			activate: function (event, ui) {
@@ -202,7 +216,8 @@
 	<div id="node-editor-wrapper" node_id="{{ node.pk }}">
 		<div id="node-editor-tabs">
 			<ul>
-				<li><a id='tab-link-grid' href="#node-grid">Grid</a></li>
+				{# Horizontal mode mirrors these into the bottom pane strip, where this tab is the editor half #}
+				<li><a id='tab-link-grid' href="#node-grid">{% if node.analysis.analysis_horizontal_mode %}Editor{% else %}Grid{% endif %}</a></li>
 				{% block node_editor_tab_links_second %}{% endblock node_editor_tab_links_second %}
 
 				{% if node.visible %}

--- a/analysis/tests/test_horizontal_mode.py
+++ b/analysis/tests/test_horizontal_mode.py
@@ -1,0 +1,47 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from analysis.models import AllVariantsNode, Analysis
+from annotation.fake_annotation import get_fake_annotation_version
+from snpdb.models import GenomeBuild
+
+
+@override_settings(ANALYSIS_NODE_CACHE_Q=False)
+class HorizontalModeTestCase(TestCase):
+    """ The horizontal layout (full width canvas, grid docked along the bottom) is rendered into the
+        page, so both orientations need to keep rendering - see analysis.html """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = User.objects.create_superuser(f"test_user_{__file__}")
+        cls.grch37 = GenomeBuild.get_name_or_alias("GRCh37")
+        get_fake_annotation_version(cls.grch37)
+
+    def _get_analysis_page(self, horizontal_mode: bool) -> str:
+        analysis = Analysis(genome_build=self.grch37, name="horizontal mode test")
+        analysis.set_defaults_and_save(self.user)
+        analysis.analysis_horizontal_mode = horizontal_mode
+        analysis.save()
+        AllVariantsNode.objects.create(analysis=analysis, x=10, y=20)
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("analysis", kwargs={"analysis_id": analysis.pk}))
+        self.assertEqual(response.status_code, 200)
+
+        editor_and_grid = self.client.get(reverse("analysis_editor_and_grid", kwargs={"analysis_id": analysis.pk}))
+        self.assertEqual(editor_and_grid.status_code, 200)
+        return response.content.decode() + editor_and_grid.content.decode()
+
+    def test_horizontal_mode(self):
+        page = self._get_analysis_page(True)
+        self.assertIn("ANALYSIS_HORIZONTAL_MODE = true", page)
+        self.assertIn("node-editor-drawer", page)
+        self.assertIn("bottom-pane-tabs", page)
+
+    def test_vertical_mode(self):
+        page = self._get_analysis_page(False)
+        self.assertIn("ANALYSIS_HORIZONTAL_MODE = false", page)
+        self.assertNotIn("node-editor-drawer", page)
+        self.assertNotIn("bottom-pane-tabs", page)

--- a/analysis/tests/test_models.py
+++ b/analysis/tests/test_models.py
@@ -4,7 +4,16 @@ from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from analysis.models import Analysis, AnalysisLock, AnalysisTemplate, GeneListNode, SampleNode, ZygosityNode
+from analysis.forms.forms import AnalysisForm
+from analysis.models import (
+    AllVariantsNode,
+    Analysis,
+    AnalysisLock,
+    AnalysisTemplate,
+    GeneListNode,
+    SampleNode,
+    ZygosityNode,
+)
 from annotation.fake_annotation import get_fake_annotation_version
 from library.guardian_utils import assign_permission_to_user_and_groups
 from snpdb.models import (
@@ -54,6 +63,47 @@ class AnalysisModelTestCase(TestCase):
         analysis = Analysis(genome_build=self.grch37)
         analysis.set_defaults_and_save(self.owner_user)
         self.assertEqual(analysis.variant_tag_stale_days, 730)
+
+    def test_horizontal_mode_from_user_settings(self):
+        """ New analyses take the user's preferred orientation """
+        user_settings_override = UserSettingsOverride.objects.get_or_create(user=self.owner_user)[0]
+        user_settings_override.analysis_horizontal_mode = True
+        user_settings_override.save()
+
+        analysis = Analysis(genome_build=self.grch37)
+        analysis.set_defaults_and_save(self.owner_user)
+        self.assertTrue(analysis.analysis_horizontal_mode)
+
+    def test_transpose_node_positions(self):
+        """ Node positions are orientation specific - the swap has to be self-inverse so toggling
+            the mode back restores the original layout exactly """
+        analysis = Analysis(genome_build=self.grch37)
+        analysis.set_defaults_and_save(self.owner_user)
+        node = AllVariantsNode.objects.create(analysis=analysis, x=10, y=200)
+
+        analysis.transpose_node_positions()
+        node.refresh_from_db()
+        self.assertEqual((node.x, node.y), (200, 10))
+
+        analysis.transpose_node_positions()
+        node.refresh_from_db()
+        self.assertEqual((node.x, node.y), (10, 200))
+
+    def test_changing_horizontal_mode_transposes_nodes(self):
+        analysis = Analysis(genome_build=self.grch37, name="horizontal mode test")
+        analysis.set_defaults_and_save(self.owner_user)
+        assign_permission_to_user_and_groups(self.owner_user, analysis.custom_columns_collection)
+        node = AllVariantsNode.objects.create(analysis=analysis, x=10, y=200)
+
+        data = {k: v for k, v in AnalysisForm(instance=analysis, user=self.owner_user).initial.items()
+                if v is not None}
+        data["analysis_horizontal_mode"] = True
+        form = AnalysisForm(data, instance=analysis, user=self.owner_user)
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        node.refresh_from_db()
+        self.assertEqual((node.x, node.y), (200, 10))
 
     def test_invisible_analysis_hides_template_from_lists(self):
         """ Internal auto-analysis templates (eg cohort VCF export) are hidden from template lists

--- a/analysis/views/views.py
+++ b/analysis/views/views.py
@@ -963,12 +963,14 @@ def view_analysis_settings(request, analysis_id):
 def analysis_settings_details_tab(request, analysis_id):
     analysis = get_analysis_or_404(request.user, analysis_id)
     old_annotation_version = analysis.annotation_version
+    old_horizontal_mode = analysis.analysis_horizontal_mode
     form = forms.AnalysisForm(request.POST or None, user=request.user, instance=analysis)
     has_write_permission = analysis.can_write(request.user)
     if not has_write_permission:
         set_form_read_only(form)
 
     reload_analysis = False
+    reload_page = False
     if request.method == "POST":
         analysis.check_can_write(request.user)
         if form.has_changed:
@@ -978,6 +980,9 @@ def analysis_settings_details_tab(request, analysis_id):
                 analysis.save()
                 if reload_analysis := (old_annotation_version != analysis.annotation_version):
                     node_utils.reload_analysis_nodes(analysis.pk)
+                # The panel layout and node anchors are rendered per orientation, and the save
+                # transposed the node positions - the open page needs to come back as the other mode
+                reload_page = old_horizontal_mode != analysis.analysis_horizontal_mode
 
             add_save_message(request, valid, "Analysis Settings")
 
@@ -992,7 +997,8 @@ def analysis_settings_details_tab(request, analysis_id):
                "form": form,
                "new_analysis_settings": analysis_settings,
                "has_write_permission": has_write_permission,
-               "reload_analysis": reload_analysis}
+               "reload_analysis": reload_analysis,
+               "reload_page": reload_page}
     return render(request, 'analysis/analysis_settings_details_tab.html', context)
 
 

--- a/analysis/views/views_json.py
+++ b/analysis/views/views_json.py
@@ -120,8 +120,13 @@ def node_create(request, analysis_id, node_type):
     analysis = get_analysis_or_404(request.user, analysis_id, write=True)
 
     node_class = NODE_TYPES_HASH[node_type]
-    x = 10 + random.random() * 50
-    y = 50 + random.random() * 20
+    # New nodes go at the start of the flow - the top in vertical mode, the left edge in horizontal
+    if analysis.analysis_horizontal_mode:
+        x = 50 + random.random() * 20
+        y = 10 + random.random() * 50
+    else:
+        x = 10 + random.random() * 50
+        y = 50 + random.random() * 20
     node = node_class.objects.create(analysis=analysis, x=x, y=y)
     update_analysis(node.analysis_id)
     return JsonResponse(get_rendering_dict(node))
@@ -139,6 +144,9 @@ def nodes_copy(request, analysis_id):
     nodes_qs = analysis.analysisnode_set.filter(id__in=node_ids).select_subclasses()
     topo_sorted = get_toposorted_nodes(nodes_qs)
 
+    # Nudge the copy clear of the original - along the flow in horizontal mode, so it reads as the next node
+    copy_x_offset = 80 if analysis.analysis_horizontal_mode else 10
+
     old_new_map = {}
     for group in topo_sorted:
         for node in group:
@@ -149,7 +157,7 @@ def nodes_copy(request, analysis_id):
             parents = template_node.analysisnode_ptr.parents().filter(id__in=old_new_map).values_list('id', flat=True)
 
             clone_node = template_node.save_clone()
-            clone_node.x += 10
+            clone_node.x += copy_x_offset
             clone_node.y += 10
             clone_node.status = NodeStatus.DIRTY
             clone_node.save()

--- a/analysis/views/views_json.py
+++ b/analysis/views/views_json.py
@@ -29,6 +29,7 @@ from analysis.models.nodes.filters.selected_in_parent_node import NodeVariant, S
 from analysis.models.nodes.filters.venn_node import VennNode
 from analysis.models.nodes.node_types import get_node_types_hash_by_class_name
 from analysis.models.nodes.node_utils import (
+    get_child_position,
     get_rendering_dict,
     get_toposorted_nodes,
     reload_analysis_nodes,
@@ -304,8 +305,7 @@ def create_filter_child(request, analysis_id, node_id):
 @require_POST
 def create_extra_filter_child(request, analysis_id, node_id, extra_filters):
     node = get_node_subclass_or_404(request.user, node_id, write=True)
-    x = node.x + 50 + random.randrange(-10, 10)
-    y = node.y + 100 + random.randrange(-10, 10)
+    x, y = get_child_position(node)
     filter_node = BuiltInFilterNode.objects.create(analysis=node.analysis,
                                                    built_in_filter=extra_filters,
                                                    x=x,
@@ -322,8 +322,7 @@ def create_extra_filter_child(request, analysis_id, node_id, extra_filters):
 
 def create_selected_child(request, analysis_id, node_id):
     node = get_node_subclass_or_404(request.user, node_id)
-    x = node.x + 50 + random.randrange(-10, 10)
-    y = node.y + 100 + random.randrange(-10, 10)
+    x, y = get_child_position(node)
 
     selected_node = SelectedInParentNode.objects.create(analysis=node.analysis,
                                                         x=x,

--- a/annotation/models/models.py
+++ b/annotation/models/models.py
@@ -1669,6 +1669,21 @@ class AbstractVariantAnnotation(models.Model):
             hgvs_c = str(hgvs_variant)
         return hgvs_c
 
+    def get_short_label(self) -> str:
+        """ Shortest label that still tells a human which variant this is, eg "RUNX1:p.Ala547Val" -
+            for tabs and other places with no room for the transcript """
+        change = None
+        if self.hgvs_p:
+            change = self.hgvs_p.split(":", 1)[-1]
+        elif self.has_hgvs_c:
+            change = self.hgvs_c.split(":", 1)[-1]
+
+        if change is None:
+            return str(self.variant)
+        if self.symbol:
+            return f"{self.symbol}:{change}"
+        return change
+
 
 class VariantAnnotation(AbstractVariantAnnotation):
     """ This is the "representative transcript" chosen (1 per variant/annotation version) """

--- a/annotation/tests/test_annotation_disk_space.py
+++ b/annotation/tests/test_annotation_disk_space.py
@@ -49,6 +49,20 @@ from snpdb.tests.utils.vcf_testing_utils import slowly_create_test_variant
 STANDARD = VariantAnnotationPipelineType.STANDARD
 
 
+def past_vep_kwargs() -> dict:
+    """ Timestamps/counts a run carries once VEP has finished, ie ANNOTATION_COMPLETED - what the import
+        lane checks before it does anything. """
+    now = timezone.now()
+    return {
+        "count": 100,
+        "dump_start": now - timedelta(minutes=5),
+        "dump_end": now - timedelta(minutes=4),
+        "dump_count": 100,
+        "annotation_start": now - timedelta(minutes=4),
+        "annotation_end": now,
+    }
+
+
 @override_settings(**get_fake_annotation_settings_dict(columns_version=2))
 class AnnotationRunCleanupTestCase(TestCase):
     """ Each way into the cleanup module, and the one case that must not reach it. """
@@ -134,7 +148,8 @@ class AnnotationRunCleanupTestCase(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir, \
                 override_settings(ANNOTATION_VCF_DUMP_DIR=tmp_dir,
                                   ANNOTATION_DELETE_TEMP_FILES_ON_SUCCESS=True):
-            run, paths, _ = self._run_with_output(tmp_dir)
+            run, paths, _ = self._run_with_output(tmp_dir, **past_vep_kwargs())
+            self.assertEqual(run.status, AnnotationStatus.ANNOTATION_COMPLETED)
 
             with mock.patch.object(VEPRunner, "import_results",
                             side_effect=RuntimeError("import blew up")), \
@@ -204,12 +219,8 @@ class AnnotationDiskGateTestCase(TestCase):
         # count stamped as the count lane would have, so the run is ready for the run lanes
         run = AnnotationRun.objects.create(annotation_range_lock=lock, pipeline_type=STANDARD, count=100)
         if status == AnnotationStatus.ANNOTATION_COMPLETED:
-            now = timezone.now()  # past VEP, waiting on the import lane
-            run.dump_start = now - timedelta(minutes=5)
-            run.dump_end = now - timedelta(minutes=4)
-            run.dump_count = 100
-            run.annotation_start = now - timedelta(minutes=4)
-            run.annotation_end = now
+            for k, v in past_vep_kwargs().items():  # past VEP, waiting on the import lane
+                setattr(run, k, v)
             run.vcf_annotated_filename = "/does/not/need/to/exist.vcf.gz"
             run.save()
             self.assertEqual(run.status, AnnotationStatus.ANNOTATION_COMPLETED)

--- a/annotation/tests/test_models.py
+++ b/annotation/tests/test_models.py
@@ -15,3 +15,16 @@ class TestAnnotationModels(TestCase):
         for protein_position, expected in protein_position_and_expected_int:
             result = VariantAnnotation.protein_position_to_int(protein_position)
             self.assertEqual(expected, result, f"protein_position_to_int({protein_position})")
+
+    def test_get_short_label_prefers_protein_change(self):
+        va = VariantAnnotation(symbol="RUNX1", hgvs_c="NM_001754.5:c.1640C>T",
+                               hgvs_p="NP_001745.2:p.Ala547Val")
+        self.assertEqual("RUNX1:p.Ala547Val", va.get_short_label())
+
+    def test_get_short_label_falls_back_to_c_hgvs(self):
+        va = VariantAnnotation(symbol="RUNX1", hgvs_c="NM_001754.5:c.1640C>T")
+        self.assertEqual("RUNX1:c.1640C>T", va.get_short_label())
+
+    def test_get_short_label_without_symbol(self):
+        va = VariantAnnotation(hgvs_p="NP_001745.2:p.Ala547Val")
+        self.assertEqual("p.Ala547Val", va.get_short_label())

--- a/claude/design/analysis_grid_rework.html
+++ b/claude/design/analysis_grid_rework.html
@@ -1,0 +1,741 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Analysis Grid Rework</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap">
+<style>
+:root {
+    --ink: #1d242e;
+    --body-text: #3d4550;
+    --muted: #6b7583;
+    --ground: #f7f8fa;
+    --panel: #eef1f5;
+    --line: #d3d9e1;
+    --accent: #3455a4;      /* filter blue - from analysis_nodes.css */
+    --source: #0e7a4a;      /* source green - from analysis_nodes.css */
+    --good-bg: #e2f2ea;
+    --good-text: #0e6a41;
+    --warn-bg: #fdf3e0;
+    --warn-text: #8a5a10;
+    --card: #ffffff;
+    --mono: "IBM Plex Mono", ui-monospace, "SF Mono", Consolas, monospace;
+    --sans: "IBM Plex Sans", -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        --ink: #e8ebf0;
+        --body-text: #b8c0cc;
+        --muted: #8792a1;
+        --ground: #12161c;
+        --panel: #1b212a;
+        --line: #2e3743;
+        --accent: #7d9be0;
+        --good-bg: #12301f;
+        --good-text: #6fcf9b;
+        --warn-bg: #33270f;
+        --warn-text: #e0b568;
+        --card: #1b212a;
+    }
+}
+:root[data-theme="dark"] {
+    --ink: #e8ebf0;
+    --body-text: #b8c0cc;
+    --muted: #8792a1;
+    --ground: #12161c;
+    --panel: #1b212a;
+    --line: #2e3743;
+    --accent: #7d9be0;
+    --good-bg: #12301f;
+    --good-text: #6fcf9b;
+    --warn-bg: #33270f;
+    --warn-text: #e0b568;
+    --card: #1b212a;
+}
+
+* { box-sizing: border-box; }
+body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--body-text);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.6;
+}
+main { max-width: 960px; margin: 0 auto; padding: 48px 24px 96px; }
+
+h1, h2, h3 { color: var(--ink); text-wrap: balance; line-height: 1.25; }
+h1 { font-size: 30px; font-weight: 700; margin: 0 0 4px; }
+h2 { font-size: 21px; font-weight: 600; margin: 56px 0 8px; }
+h3 { font-size: 16px; font-weight: 600; margin: 24px 0 6px; }
+p { max-width: 68ch; margin: 10px 0; }
+ul { max-width: 70ch; padding-left: 22px; }
+li { margin: 5px 0; }
+strong { color: var(--ink); }
+
+.eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 2px;
+}
+.subtitle { color: var(--muted); margin-top: 0; }
+
+.verdict {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: .06em;
+    padding: 2px 10px;
+    border-radius: 99px;
+    vertical-align: 3px;
+    margin-left: 8px;
+}
+.verdict.recommended { background: var(--good-bg); color: var(--good-text); }
+.verdict.fallback { background: var(--warn-bg); color: var(--warn-text); }
+.verdict.parked { background: var(--panel); color: var(--muted); }
+
+.tldr {
+    background: var(--panel);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 8px 8px 0;
+    padding: 16px 20px;
+    margin: 28px 0;
+}
+.tldr p { margin: 6px 0; }
+
+.pros-cons { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 28px; margin: 14px 0; }
+.pros-cons h4 {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .1em;
+    text-transform: uppercase; margin: 0 0 4px;
+}
+.pros-cons .pro h4 { color: var(--good-text); }
+.pros-cons .con h4 { color: var(--warn-text); }
+.pros-cons ul { margin: 0; padding-left: 18px; font-size: 14px; }
+@media (max-width: 640px) { .pros-cons { grid-template-columns: 1fr; } }
+
+.seq { counter-reset: step; margin: 20px 0; padding: 0; list-style: none; max-width: 74ch; }
+.seq > li {
+    position: relative;
+    padding: 0 0 18px 44px;
+    border-left: 2px solid var(--line);
+    margin-left: 13px;
+}
+.seq > li:last-child { border-left-color: transparent; }
+.seq > li::before {
+    counter-increment: step;
+    content: counter(step);
+    position: absolute;
+    left: -15px; top: -2px;
+    width: 28px; height: 28px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: var(--ground);
+    font-family: var(--mono);
+    font-weight: 500;
+    display: flex; align-items: center; justify-content: center;
+}
+.seq h3 { margin: 0 0 4px; }
+.seq p { margin: 4px 0; font-size: 14px; }
+
+/* ============ mockup frames ============ */
+/* The mock screens depict the real (light) app, so they stay light in both page themes,
+   like a screenshot. The bezel separates them from a dark ground. */
+.mock {
+    margin: 22px 0 8px;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 2px 10px rgba(0,0,0,.08);
+    background: #fff;
+}
+.mock-chrome {
+    display: flex; align-items: center; gap: 6px;
+    background: #e6e9ee;
+    border-bottom: 1px solid #d0d5dc;
+    padding: 6px 10px;
+}
+.mock-chrome .dot { width: 9px; height: 9px; border-radius: 50%; background: #c3c9d2; }
+.mock-chrome .url {
+    flex: 1; margin-left: 8px;
+    background: #fff; border-radius: 5px;
+    font-family: var(--mono); font-size: 10px; color: #6b7583;
+    padding: 2px 10px;
+}
+.mock-body { display: flex; flex-direction: column; height: 420px; background: #fff; color: #3d4550; }
+.mock-body.short { height: 360px; }
+
+.mock-toolbar {
+    flex: 0 0 30px;
+    display: flex; align-items: center; gap: 10px;
+    padding: 0 10px;
+    border-bottom: 2px solid #1d242e;
+    font-size: 11px;
+    background: #fff;
+    z-index: 5;
+}
+.mock-toolbar .tool { color: #5a6472; font-size: 12px; cursor: default; }
+.mock-toolbar .select {
+    border: 1px solid #c6cdd6; border-radius: 4px;
+    padding: 1px 8px; color: #5a6472; font-size: 10px; background: #fff;
+}
+.mock-toolbar .build { margin-left: auto; font-weight: 700; color: #1d242e; font-size: 10px; }
+
+.pane-row { display: flex; flex-direction: row; flex: 1; min-height: 0; }
+.pane-col { display: flex; flex-direction: column; flex: 1; min-width: 0; }
+
+.canvas {
+    position: relative;
+    overflow: hidden;
+    background: #fdfdfe;
+    background-image: radial-gradient(#e3e7ec 1px, transparent 1px);
+    background-size: 16px 16px;
+}
+.canvas svg.edges { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+.canvas svg.edges path { fill: none; stroke: #9aa4b0; stroke-width: 1.5; }
+.canvas svg.edges circle { fill: #7c8794; }
+
+.pane-label {
+    position: absolute; right: 8px; top: 6px;
+    font-family: var(--mono); font-size: 9px; letter-spacing: .1em;
+    text-transform: uppercase; color: #9aa4b0;
+    pointer-events: none;
+    z-index: 4;
+}
+
+/* gutters (split.js) */
+.gut-v {
+    flex: 0 0 7px; cursor: col-resize;
+    background: #eef1f5 repeating-linear-gradient(180deg, transparent 0 3px, #b9c1cc 3px 5px);
+    background-size: 2px 22px; background-repeat: no-repeat; background-position: center;
+    border-left: 1px solid #dfe3e9; border-right: 1px solid #dfe3e9;
+}
+.gut-h {
+    flex: 0 0 7px; cursor: row-resize;
+    background: #eef1f5 repeating-linear-gradient(90deg, transparent 0 3px, #b9c1cc 3px 5px);
+    background-size: 22px 2px; background-repeat: no-repeat; background-position: center;
+    border-top: 1px solid #dfe3e9; border-bottom: 1px solid #dfe3e9;
+}
+.gut-v:hover, .gut-h:hover { background-color: #dce3ec; }
+
+/* mini Design-A node cards */
+.mnode {
+    position: absolute;
+    width: 76px;
+    background: #fff;
+    border: 1px solid #808080;
+    border-radius: 8px;
+    box-shadow: 2px 2px 8px rgba(0,0,0,.25);
+    font-size: 9px;
+    cursor: pointer;
+    z-index: 3;
+    user-select: none;
+}
+.mnode.active { border-color: #e6a817; box-shadow: 0 0 0 2px #e6a817, 2px 2px 8px rgba(0,0,0,.25); }
+.mnode .mbadge {
+    position: absolute; top: -8px; left: -8px;
+    width: 18px; height: 18px; border-radius: 50%;
+    color: #fff; font-size: 9px;
+    display: flex; align-items: center; justify-content: center;
+    box-shadow: 0 1px 3px rgba(0,0,0,.35);
+}
+.mnode .mklass {
+    font-size: 7px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+    color: #fff; padding: 2px 4px 1px 13px;
+    border-radius: 7px 7px 0 0; white-space: nowrap; overflow: hidden;
+}
+.mnode.source .mklass, .mnode.source .mbadge { background: #0e7a4a; }
+.mnode.filter .mklass, .mnode.filter .mbadge { background: #3455a4; }
+.mnode .mname { padding: 3px 5px; font-weight: 600; color: #24292f; min-height: 2em; }
+.mnode .mcount {
+    border-top: 1px solid #eceff3; color: #6b7583;
+    font-family: var(--mono); font-size: 8px; text-align: right; padding: 1px 5px;
+}
+
+/* node editor pane (fake form) */
+.editor { background: #fff; overflow: auto; position: relative; }
+.ed-head {
+    display: flex; align-items: center; gap: 7px;
+    padding: 8px 10px; border-bottom: 1px solid #e3e7ec;
+}
+.ed-head .mbadge {
+    position: static;
+    width: 20px; height: 20px; border-radius: 50%; flex: 0 0 20px;
+    background: #3455a4; color: #fff; font-size: 10px;
+    display: flex; align-items: center; justify-content: center;
+}
+.ed-head .ed-title { font-weight: 600; font-size: 12px; color: #1d242e; }
+.ed-head .ed-close { margin-left: auto; color: #9aa4b0; font-size: 14px; cursor: pointer; }
+.ed-tabs { display: flex; gap: 2px; padding: 6px 10px 0; border-bottom: 1px solid #e3e7ec; font-size: 10px; }
+.ed-tabs span { padding: 3px 10px; border: 1px solid #e3e7ec; border-bottom: none; border-radius: 5px 5px 0 0; color: #6b7583; }
+.ed-tabs span.on { background: #eef1f5; color: #1d242e; font-weight: 600; }
+.ed-form { padding: 10px 12px; display: grid; grid-template-columns: 74px 1fr; gap: 7px 10px; font-size: 10px; align-items: center; }
+.ed-form label { color: #6b7583; text-align: right; }
+.ed-form .field { border: 1px solid #c6cdd6; border-radius: 4px; min-height: 17px; padding: 1px 6px; color: #3d4550; background: #fbfcfd; }
+.ed-apply {
+    margin: 2px 12px 12px; justify-self: start;
+    background: #3455a4; color: #fff; font-size: 10px; font-weight: 600;
+    border-radius: 4px; padding: 3px 14px; width: max-content;
+}
+
+/* variant grid (fake) */
+.vgrid { background: #fff; overflow: auto; position: relative; }
+.vgrid table { border-collapse: collapse; font-size: 9px; white-space: nowrap; min-width: 100%; }
+.vgrid th {
+    position: sticky; top: 0;
+    background: #eef1f5; color: #3d4550;
+    border: 1px solid #dfe3e9; border-top: none;
+    padding: 3px 7px; font-weight: 600; text-align: left;
+}
+.vgrid td { border: 1px solid #eef1f3; padding: 2px 7px; color: #4a5361; font-family: var(--mono); font-size: 8.5px; }
+.vgrid tr:nth-child(even) td { background: #f8fafb; }
+
+/* drawer (design: Drawer) */
+.drawer {
+    position: absolute; top: 0; right: 0; bottom: 0;
+    width: 300px; max-width: 65%;
+    background: #fff;
+    border-left: 1px solid #c6cdd6;
+    box-shadow: -6px 0 18px rgba(0,0,0,.15);
+    transform: translateX(103%);
+    transition: transform .25s ease;
+    z-index: 6;
+    overflow: auto;
+}
+.drawer.open { transform: translateX(0); }
+@media (prefers-reduced-motion: reduce) { .drawer { transition: none; } }
+
+/* tabbed bottom pane (design: Swap) */
+.tabbar {
+    flex: 0 0 26px;
+    display: flex; align-items: flex-end; gap: 2px;
+    background: #eef1f5;
+    border-bottom: 1px solid #c6cdd6;
+    padding: 4px 10px 0;
+    font-size: 10px;
+    z-index: 5;
+}
+.tabbar .tab {
+    padding: 3px 14px;
+    border: 1px solid #c6cdd6; border-bottom: none;
+    border-radius: 6px 6px 0 0;
+    background: #e2e6ec; color: #6b7583;
+    cursor: pointer; user-select: none;
+}
+.tabbar .tab.on {
+    background: #fff; color: #1d242e; font-weight: 600;
+    position: relative; top: 1px;
+}
+.tabbar .tab-count { font-family: var(--mono); font-size: 8.5px; color: #6b7583; margin-left: 5px; }
+.tabbar .tab.on .tab-count { color: #3455a4; }
+.tab-pane { display: none; flex: 1; min-height: 0; }
+.tab-pane.on { display: flex; flex-direction: column; }
+.tab-pane .editor, .tab-pane .vgrid { flex: 1; }
+.editor.wide .ed-form { max-width: 560px; }
+
+/* floating editor (design: Float) */
+.floated {
+    position: absolute;
+    width: 280px;
+    background: #fff;
+    border: 1px solid #b9c1cc;
+    border-radius: 8px;
+    box-shadow: 0 8px 26px rgba(0,0,0,.25);
+    z-index: 7;
+    display: none;
+    overflow: hidden;
+}
+.floated.open { display: block; }
+.floated .ed-head { cursor: grab; background: #f4f6f8; }
+
+.hint {
+    font-family: var(--mono); font-size: 10.5px; color: var(--muted);
+    margin: 6px 0 0;
+}
+figcaption { font-size: 13.5px; color: var(--muted); margin: 8px 2px 0; max-width: 74ch; }
+figure { margin: 0 0 26px; }
+
+table.plain { border-collapse: collapse; font-size: 13.5px; margin: 14px 0; }
+table.plain th, table.plain td { border: 1px solid var(--line); padding: 5px 12px; text-align: left; vertical-align: top; }
+table.plain th { background: var(--panel); color: var(--ink); font-weight: 600; }
+
+code {
+    font-family: var(--mono); font-size: .85em;
+    background: var(--panel); border-radius: 4px; padding: 1px 5px;
+}
+hr { border: none; border-top: 1px solid var(--line); margin: 48px 0; }
+</style>
+</head>
+<body>
+<main>
+
+<p class="eyebrow">VariantGrid &middot; Analysis page &middot; design exploration</p>
+<h1>Analysis Grid Rework</h1>
+<p class="subtitle">Bottom-docked variant grid, horizontal node flow, and where the node editor goes &mdash; plus sequencing against the jsPlumb and DataTables migrations.</p>
+
+<div class="tldr">
+    <p><strong>Recommendation.</strong> Bottom-docked full-width grid + horizontal node flow is the right move, and the schema is already reserved for it (<code>analysis_horizontal_mode</code> on both <code>UserSettings</code> and <code>Analysis</code>). For the editor, build <strong>Swap</strong> (tabbed bottom pane) first: it reuses the existing editor+grid container almost untouched, and since saving a node kicks off a 3&ndash;10&nbsp;s re-compute before the grid refreshes anyway, there is no tight editor-beside-grid feedback loop to preserve, and a hidden Grid tab defers the expensive grid query until it's actually wanted. <strong>Decision: build Swap and Drawer together</strong> &mdash; one editor, two homes (bottom tab, or undocked over the canvas), with a live toggle so both get real use before picking a default. <strong>Dock</strong> is parked. Implementation plan: <code>claude/plans/analysis_layout_rework_plan.md</code>.</p>
+    <p><strong>Sequencing.</strong> jsPlumb upgrade first (like-for-like), layout rework second, jqGrid&rarr;DataTables last &mdash; each on its own branch. Reasoning at the bottom.</p>
+</div>
+
+<h2>Current layout <span class="verdict parked">reference</span></h2>
+<p>Vertical node flow on the left; the right panel is split editor-over-grid. The grid inherits whatever width is left over &mdash; typically less than half the screen for a table that wants 15+ columns. Drag the splitters below; note the grid scrollbar.</p>
+
+<figure>
+    <div class="mock">
+        <div class="mock-chrome"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="url">variantgrid/analysis/1234</span></div>
+        <div class="mock-body short">
+            <div class="mock-toolbar"><span class="select">Add node&hellip; &#9662;</span><span class="tool">&#10133;</span><span class="tool">&#10064;</span><span class="tool">&#128465;</span><span class="tool">&#9881;</span><span class="tool">&#127991;</span><span class="build">GRCh38</span></div>
+            <div class="pane-row">
+                <div class="canvas" id="canvas-current" style="flex:0 0 34%"><span class="pane-label">node canvas</span></div>
+                <div class="gut-v" data-gutter="v"></div>
+                <div class="pane-col">
+                    <div class="editor" id="editor-current" style="flex:0 0 46%"><span class="pane-label">node editor</span></div>
+                    <div class="gut-h" data-gutter="h"></div>
+                    <div class="vgrid" id="grid-current"><span class="pane-label">variant grid</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <figcaption>The grid is boxed into the bottom-right quadrant. Vertical node flow means the canvas wants height, the editor wants width, and the grid loses both fights.</figcaption>
+</figure>
+
+<h2>Dock <span class="verdict parked">parked</span></h2>
+<p>Horizontal node flow across the top, grid docked along the bottom at full width. The editor keeps a docked pane beside the canvas. Both splitters drag &mdash; pull the horizontal one up and the grid gets as tall as you like.</p>
+
+<figure>
+    <div class="mock">
+        <div class="mock-chrome"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="url">variantgrid/analysis/1234</span></div>
+        <div class="mock-body">
+            <div class="mock-toolbar"><span class="select">Add node&hellip; &#9662;</span><span class="tool">&#10133;</span><span class="tool">&#10064;</span><span class="tool">&#128465;</span><span class="tool">&#9881;</span><span class="tool">&#127991;</span><span class="build">GRCh38</span></div>
+            <div class="pane-row" style="flex:0 0 55%">
+                <div class="canvas" id="canvas-dock" style="flex:1"><span class="pane-label">node canvas &mdash; horizontal flow</span></div>
+                <div class="gut-v" data-gutter="v"></div>
+                <div class="editor" id="editor-dock" style="flex:0 0 280px"><span class="pane-label">node editor</span></div>
+            </div>
+            <div class="gut-h" data-gutter="h"></div>
+            <div class="vgrid" id="grid-dock"><span class="pane-label">variant grid &mdash; full width</span></div>
+        </div>
+    </div>
+    <figcaption>Same 15 columns as above &mdash; now they fit without a horizontal scrollbar. Horizontal node flow spreads the DAG the same way the page now spreads, so canvas and grid stop competing for the same axis.</figcaption>
+</figure>
+
+<div class="pros-cons">
+    <div class="pro"><h4>For</h4><ul>
+        <li>Lowest risk: same three components, same Split.js machinery, rearranged.</li>
+        <li>Editor always visible &mdash; no interaction model to learn.</li>
+        <li>Node editors are real forms (tabs, sub-grids); a docked pane gives them honest width.</li>
+    </ul></div>
+    <div class="con"><h4>Against</h4><ul>
+        <li>Editor pane taxes canvas width &mdash; the axis horizontal flow needs most.</li>
+        <li>Always-visible buys less than it looks: saving triggers a 3&ndash;10&nbsp;s node re-compute before the grid updates, so editor and grid were never a live feedback pair.</li>
+        <li>Wide analyses will still pan; acceptable, canvas already scrolls.</li>
+    </ul></div>
+</div>
+
+<h2>Drawer <span class="verdict recommended">building &mdash; toggles with Swap</span></h2>
+<p>Same bottom-docked grid, but the canvas takes the full top row. Selecting a node slides the editor in over the canvas from the right; close it (or press <kbd>Esc</kbd>) and the whole width returns to the graph. <strong>Click a node below.</strong></p>
+
+<figure>
+    <div class="mock">
+        <div class="mock-chrome"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="url">variantgrid/analysis/1234</span></div>
+        <div class="mock-body">
+            <div class="mock-toolbar"><span class="select">Add node&hellip; &#9662;</span><span class="tool">&#10133;</span><span class="tool">&#10064;</span><span class="tool">&#128465;</span><span class="tool">&#9881;</span><span class="tool">&#127991;</span><span class="build">GRCh38</span></div>
+            <div class="pane-row" style="flex:0 0 55%; position:relative">
+                <div class="canvas" id="canvas-drawer" style="flex:1"><span class="pane-label">node canvas &mdash; full width</span></div>
+                <div class="drawer" id="drawer-el"></div>
+            </div>
+            <div class="gut-h" data-gutter="h"></div>
+            <div class="vgrid" id="grid-drawer"><span class="pane-label">variant grid &mdash; full width</span></div>
+        </div>
+    </div>
+    <figcaption>The drawer is the Dock's editor pane made collapsible &mdash; docked when open, gone when closed. A pin control could hold it open (which is exactly the Dock layout), so this ships as an enhancement, not an alternative.</figcaption>
+</figure>
+
+<div class="pros-cons">
+    <div class="pro"><h4>For</h4><ul>
+        <li>Full canvas width while browsing the graph; editor appears only when needed.</li>
+        <li>Familiar pattern (n8n, Node-RED, Retool all edit nodes in a side panel).</li>
+        <li>Resizable width; can cover complex editors comfortably.</li>
+    </ul></div>
+    <div class="con"><h4>Against</h4><ul>
+        <li>Overlays the right of the graph while open &mdash; needs a pin/dock toggle for compare-while-editing workflows.</li>
+        <li>Slightly more state to persist (open/pinned/width) per analysis.</li>
+    </ul></div>
+</div>
+
+<h2>Swap <span class="verdict recommended">building &mdash; toggles with Drawer</span></h2>
+<p>Canvas gets the whole top, and the bottom pane is shared: it <em>tabs</em> between editor and grid, each at full width and full pane height. Selecting a node flips to the editor; <strong>Save</strong> flips back to the grid so you see the result. <strong>Click a node, then click Save.</strong></p>
+
+<figure>
+    <div class="mock">
+        <div class="mock-chrome"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="url">variantgrid/analysis/1234</span></div>
+        <div class="mock-body">
+            <div class="mock-toolbar"><span class="select">Add node&hellip; &#9662;</span><span class="tool">&#10133;</span><span class="tool">&#10064;</span><span class="tool">&#128465;</span><span class="tool">&#9881;</span><span class="tool">&#127991;</span><span class="build">GRCh38</span></div>
+            <div class="pane-row" style="flex:0 0 48%">
+                <div class="canvas" id="canvas-swap" style="flex:1"><span class="pane-label">node canvas &mdash; full width</span></div>
+            </div>
+            <div class="gut-h" data-gutter="h"></div>
+            <div class="tabbar">
+                <span class="tab" id="tab-editor" data-pane="pane-editor">Editor</span>
+                <span class="tab on" id="tab-grid" data-pane="pane-grid">Grid<span class="tab-count">1,204</span></span>
+            </div>
+            <div class="tab-pane" id="pane-editor">
+                <div class="editor wide" id="editor-swap"><span class="pane-label">node editor &mdash; full width</span></div>
+            </div>
+            <div class="tab-pane on" id="pane-grid">
+                <div class="vgrid" id="grid-swap"><span class="pane-label">variant grid &mdash; full width</span></div>
+            </div>
+        </div>
+    </div>
+    <figcaption>This is the current <code>#grid-and-editor-container</code> (editor stacked on grid) moved to the bottom and given tabs instead of a stack &mdash; the editor/grid loading plumbing barely changes, so it's by far the least work of the four. The auto-flip on select/save is what makes it livable.</figcaption>
+</figure>
+
+<div class="pros-cons">
+    <div class="pro"><h4>For</h4><ul>
+        <li>Cheapest to build: the existing editor+grid container and its paired-loading logic move wholesale; the only new UI is the tab strip.</li>
+        <li>Lazy by construction: a hidden Grid tab defers the expensive grid query (via the existing <code>grid_auto_load</code>/deferred machinery) &mdash; editing a chain of nodes issues no grid fetches until you flip to Grid.</li>
+        <li>Editor, grid <em>and</em> canvas each get full width &mdash; nothing shares an axis with anything.</li>
+        <li>Matches real usage: analysts mostly browse node results (grid tab stays put as you click around the graph); editing is the occasional detour.</li>
+    </ul></div>
+    <div class="con"><h4>Against</h4><ul>
+        <li>Editor and grid are never visible together &mdash; but saving already triggers a 3&ndash;10&nbsp;s node re-compute before the grid refreshes, so there was never a live pair to lose. The residual cost is a tab flip when comparing settings against results.</li>
+        <li>Full width is wasted on most editors (they're narrow forms), which is the axis the grid actually needed.</li>
+        <li>Hidden-tab grids need care: a jqGrid sized while hidden gets zero width (DataTables has the same quirk) &mdash; resize on tab-show.</li>
+    </ul></div>
+</div>
+
+<h2>Float <span class="verdict fallback">not as the only mode</span></h2>
+<p>The editor as a floating panel that pops up beside the selected node (draggable by its title bar). <strong>Click a node below</strong>, then drag the panel around.</p>
+
+<figure>
+    <div class="mock">
+        <div class="mock-chrome"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="url">variantgrid/analysis/1234</span></div>
+        <div class="mock-body">
+            <div class="mock-toolbar"><span class="select">Add node&hellip; &#9662;</span><span class="tool">&#10133;</span><span class="tool">&#10064;</span><span class="tool">&#128465;</span><span class="tool">&#9881;</span><span class="tool">&#127991;</span><span class="build">GRCh38</span></div>
+            <div class="pane-row" style="flex:0 0 55%; position:relative">
+                <div class="canvas" id="canvas-float" style="flex:1"><span class="pane-label">node canvas &mdash; full width</span></div>
+                <div class="floated" id="float-el"></div>
+            </div>
+            <div class="gut-h" data-gutter="h"></div>
+            <div class="vgrid" id="grid-float"><span class="pane-label">variant grid &mdash; full width</span></div>
+        </div>
+    </div>
+    <figcaption>Feels great for quick tweaks, but it sits on top of the thing you're navigating, fights node dragging for mouse territory, and the bigger editors (FilterNode's column builder, GeneListNode) outgrow a popover. Worth having later as a "quick edit"; not the primary editor surface.</figcaption>
+</figure>
+
+<p>A fourth idea &mdash; the editor sliding out from behind the node card itself <span class="verdict parked">parked</span> &mdash; looks delightful but doesn't survive contact with the content: cards are 64px wide and editors need ten times that, so the "slide out" immediately becomes a detached panel anyway (i.e. Float), while adding z-order and repaint fights with jsPlumb during drag.</p>
+
+<hr>
+
+<h2>Settings &amp; behaviour notes</h2>
+<ul>
+    <li><strong>Already reserved:</strong> <code>UserSettings.analysis_horizontal_mode</code> (default for new analyses) and <code>Analysis.analysis_horizontal_mode</code> (what the page actually renders). Per-analysis is right for a deeper reason than taste: <strong>saved node positions are authored for an orientation</strong>. A vertical DAG is tall and narrow; flipping it to horizontal without touching positions gives a mess.</li>
+    <li><strong>Mode switch on an existing analysis:</strong> transpose node positions (swap x/y) as the first pass &mdash; a topologically-sorted DAG transposes surprisingly well. Offer "auto-arrange" as the escape hatch.</li>
+    <li><strong>Anchors:</strong> vertical mode wires <code>BottomCenter &rarr; TopCenter</code>; horizontal becomes <code>RightMiddle &rarr; LeftMiddle</code> (and the dual-parent Top&nbsp;Left/Right endpoints for Trio-style nodes become upper/lower on the left edge).</li>
+    <li><strong>Splitter persistence:</strong> <code>analysis_panel_fraction</code> can keep meaning "fraction of the primary split" in both modes (canvas/editor today, canvas-row/grid in horizontal mode); the Dock's editor width is one more float.</li>
+    <li><strong>Dual-screen mode</strong> composes fine: it already ships editor+grid to a second window, which is the ultimate "grid gets the full width" &mdash; horizontal mode just makes single-screen life better.</li>
+</ul>
+
+<h2>Sequencing the three jobs</h2>
+<p>The rule that decides the order: <strong>never bundle a library migration with a UX change</strong>. A migration is verifiable exactly because current behaviour is the baseline; redesign at the same time and every bug becomes unattributable.</p>
+
+<ol class="seq">
+    <li>
+        <h3>jsPlumb 1.4.1 &rarr; Community Edition 5/6 (<code>@jsplumb/browser-ui</code>) &mdash; like-for-like</h3>
+        <p>1.4.1 is from 2013 and the API it exposes no longer exists: the new library is instance-based (<code>newInstance({container})</code>), jQuery-free, and does its own dragging &mdash; which absorbs the jquery-ui draggable + <code>multidraggable.js</code> stack (5+ has native drag-selection for multi-node drag). Do this <em>before</em> the layout work so the horizontal anchor/orientation code is written once, against an API that's alive, instead of written for 1.4.1 and immediately ported.</p>
+    </li>
+    <li>
+        <h3>Layout rework &mdash; Swap, with Dock/Drawer as optional evolutions</h3>
+        <p>Mostly templates, CSS and Split.js reconfiguration plus wiring the reserved settings; the existing editor+grid container moves to the bottom pane and gains tabs. jqGrid survives the move: the existing resize plumbing (<code>setGridWidth</code> on splitter drag) keeps working, so the layout doesn't wait on the grid migration. This is the step users actually see &mdash; land it second.</p>
+    </li>
+    <li>
+        <h3>jqGrid &rarr; DataTables &mdash; the big one, in its final home</h3>
+        <p>The analysis grid is the deepest jqGrid usage in the codebase: custom column collections, server-side sort persistence, exports, tag rendering, variant links. Doing it after the layout means the DataTable is designed once for where it will live &mdash; full-width, arbitrary height, Scroller/fixed-header &mdash; rather than tuned for the narrow right panel and re-tuned after. The <code>DatatableConfig</code>/<code>RichColumn</code> infrastructure is already the house pattern.</p>
+        <p><em>Swap 2&nbsp;&amp;&nbsp;3 only if</em> jqGrid's resize behaviour proves too janky in a freely-draggable pane &mdash; that's the one scenario where the grid migration blocks the layout instead of following it.</p>
+    </li>
+</ol>
+
+<script>
+// ---------- fake data ----------
+const COLS = ["Variant","Gene","HGVS c.","HGVS p.","dbSNP","gnomAD AF","CADD","GERP","ClinVar","Consequence","SIFT","PolyPhen","Zyg.","Depth","Tags"];
+const ROWS = [
+    ["3:178936091 G>A","PIK3CA","c.1633G>A","p.Glu545Lys","rs104886003","0.00001","32","5.1","Pathogenic","missense","del","prob_dam","HET","142",""],
+    ["17:41245466 C>T","BRCA1","c.181T>G","p.Cys61Gly","rs28897672","0.00002","28","4.9","Pathogenic","missense","del","prob_dam","HET","98","&#9873;"],
+    ["7:117199644 AT>A","CFTR","c.1521_1523del","p.Phe508del","rs113993960","0.0071","&mdash;","&mdash;","Pathogenic","inframe_del","&mdash;","&mdash;","HOM","87",""],
+    ["13:32914438 T>C","BRCA2","c.5946T>C","p.=","rs206075","0.4312","3","-1.2","Benign","synonymous","tol","benign","HET","110",""],
+    ["2:47641560 G>T","MSH2","c.942+3A>T","&mdash;","rs193922376","0.00004","24","5.4","Likely path.","splice_region","&mdash;","&mdash;","HET","76","&#9873;"],
+    ["12:25398284 C>T","KRAS","c.35G>A","p.Gly12Asp","rs121913529","&mdash;","29","5.6","Pathogenic","missense","del","prob_dam","HET","203",""],
+    ["1:11856378 G>A","MTHFR","c.665C>T","p.Ala222Val","rs1801133","0.3121","12","2.3","Benign","missense","tol","benign","HOM","54",""],
+    ["19:11224301 C>T","LDLR","c.1060+1G>A","&mdash;","rs879254797","0.00001","27","5.2","Pathogenic","splice_donor","&mdash;","&mdash;","HET","91",""],
+    ["X:153296777 G>C","MECP2","c.397C>G","p.Arg133Gly","rs61748421","&mdash;","25","4.7","VUS","missense","del","poss_dam","HET","66",""],
+];
+function makeGrid(id) {
+    const el = document.getElementById(id);
+    const t = ["<table><thead><tr>", ...COLS.map(c => `<th>${c}</th>`), "</tr></thead><tbody>"];
+    for (const r of ROWS) { t.push("<tr>", ...r.map(c => `<td>${c}</td>`), "</tr>"); }
+    t.push("</tbody></table>");
+    el.insertAdjacentHTML("beforeend", t.join(""));
+}
+["grid-current","grid-dock","grid-drawer","grid-float","grid-swap"].forEach(makeGrid);
+
+// ---------- mini node canvases ----------
+const NW = 76, NH = 40; // approximate card size for anchor maths
+function drawCanvas(id, nodes, edges, mode, onClick) {
+    const canvas = document.getElementById(id);
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("class", "edges");
+    canvas.appendChild(svg);
+    const byId = {};
+    for (const n of nodes) {
+        const el = document.createElement("div");
+        el.className = `mnode ${n.cls}` + (n.active ? " active" : "");
+        el.style.left = n.x + "px";
+        el.style.top = n.y + "px";
+        el.innerHTML = `<span class="mbadge">${n.cls === "source" ? "&#9654;" : "&#9661;"}</span>` +
+            `<div class="mklass">${n.klass}</div><div class="mname">${n.name}</div><div class="mcount">${n.count}</div>`;
+        canvas.appendChild(el);
+        byId[n.id] = n;
+        el.addEventListener("click", () => {
+            canvas.querySelectorAll(".mnode").forEach(m => m.classList.remove("active"));
+            el.classList.add("active");
+            if (onClick) onClick(n, el);
+        });
+    }
+    for (const [a, b] of edges) {
+        const na = byId[a], nb = byId[b];
+        let x1, y1, x2, y2, c;
+        if (mode === "v") {
+            x1 = na.x + NW / 2; y1 = na.y + NH + 14; x2 = nb.x + NW / 2; y2 = nb.y - 1;
+            c = `M${x1},${y1} C${x1},${y1 + 28} ${x2},${y2 - 28} ${x2},${y2}`;
+        } else {
+            x1 = na.x + NW + 1; y1 = na.y + NH / 2 + 4; x2 = nb.x - 1; y2 = nb.y + NH / 2 + 4;
+            c = `M${x1},${y1} C${x1 + 30},${y1} ${x2 - 30},${y2} ${x2},${y2}`;
+        }
+        const p = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        p.setAttribute("d", c);
+        svg.appendChild(p);
+        for (const [cx, cy] of [[x1, y1], [x2, y2]]) {
+            const dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+            dot.setAttribute("cx", cx); dot.setAttribute("cy", cy); dot.setAttribute("r", 2.5);
+            svg.appendChild(dot);
+        }
+    }
+}
+
+const V_NODES = [
+    {id:"s", cls:"source", klass:"Sample", name:"HG002 proband", count:"4,412,067", x:70, y:22},
+    {id:"z", cls:"filter", klass:"Zygosity", name:"Het / Hom alt", count:"1,982,410", x:18, y:110, active:true},
+    {id:"p", cls:"filter", klass:"Population", name:"gnomAD &lt; 1%", count:"84,217", x:126, y:110},
+    {id:"g", cls:"filter", klass:"Gene list", name:"Incidentalome", count:"1,204", x:70, y:198},
+];
+const V_EDGES = [["s","z"],["s","p"],["z","g"],["p","g"]];
+
+const H_NODES = [
+    {id:"s", cls:"source", klass:"Sample", name:"HG002 proband", count:"4,412,067", x:26, y:80},
+    {id:"z", cls:"filter", klass:"Zygosity", name:"Het / Hom alt", count:"1,982,410", x:170, y:26},
+    {id:"p", cls:"filter", klass:"Population", name:"gnomAD &lt; 1%", count:"84,217", x:170, y:134},
+    {id:"g", cls:"filter", klass:"Gene list", name:"Incidentalome", count:"1,204", x:314, y:80, active:true},
+    {id:"e", cls:"filter", klass:"Effect", name:"HIGH / MODERATE impact", count:"312", x:458, y:80},
+];
+const H_EDGES = [["s","z"],["s","p"],["z","g"],["p","g"],["g","e"]];
+
+function editorHTML(n, closable) {
+    return `<div class="ed-head"><span class="mbadge" style="background:${n.cls === "source" ? "#0e7a4a" : "#3455a4"}">${n.cls === "source" ? "&#9654;" : "&#9661;"}</span>` +
+        `<span class="ed-title">${n.name}</span>${closable ? '<span class="ed-close" title="Close">&#10005;</span>' : ""}</div>` +
+        `<div class="ed-tabs"><span class="on">Editor</span><span>Doc</span><span>Audit</span></div>` +
+        `<div class="ed-form">` +
+        `<label>Name</label><div class="field">${n.name}</div>` +
+        `<label>${n.klass}</label><div class="field">&hellip;</div>` +
+        `<label>Min count</label><div class="field">1</div>` +
+        `<label>Options</label><div class="field" style="min-height:34px"></div>` +
+        `</div><div class="ed-apply">Save</div>`;
+}
+
+drawCanvas("canvas-current", V_NODES, V_EDGES, "v",
+    n => { document.getElementById("editor-current").innerHTML = '<span class="pane-label">node editor</span>' + editorHTML(n, false); });
+document.getElementById("editor-current").insertAdjacentHTML("beforeend", editorHTML(V_NODES[1], false));
+
+drawCanvas("canvas-dock", H_NODES, H_EDGES, "h",
+    n => { document.getElementById("editor-dock").innerHTML = '<span class="pane-label">node editor</span>' + editorHTML(n, false); });
+document.getElementById("editor-dock").insertAdjacentHTML("beforeend", editorHTML(H_NODES[3], false));
+
+const drawer = document.getElementById("drawer-el");
+drawCanvas("canvas-drawer", H_NODES.map(n => ({...n, active:false})), H_EDGES, "h", n => {
+    drawer.innerHTML = editorHTML(n, true);
+    drawer.classList.add("open");
+    drawer.querySelector(".ed-close").addEventListener("click", closeDrawer);
+});
+function closeDrawer() {
+    drawer.classList.remove("open");
+    document.querySelectorAll("#canvas-drawer .mnode").forEach(m => m.classList.remove("active"));
+}
+document.addEventListener("keydown", e => { if (e.key === "Escape") { closeDrawer(); floatEl.classList.remove("open"); } });
+
+// Swap: tabbed bottom pane. Node select -> editor tab; Save -> grid tab.
+function swapShowTab(paneId) {
+    document.querySelectorAll(".tabbar .tab").forEach(t => t.classList.toggle("on", t.dataset.pane === paneId));
+    ["pane-editor", "pane-grid"].forEach(id =>
+        document.getElementById(id).classList.toggle("on", id === paneId));
+}
+document.querySelectorAll(".tabbar .tab").forEach(t =>
+    t.addEventListener("click", () => swapShowTab(t.dataset.pane)));
+drawCanvas("canvas-swap", H_NODES.map(n => ({...n, active:false})), H_EDGES, "h", n => {
+    const ed = document.getElementById("editor-swap");
+    ed.innerHTML = '<span class="pane-label">node editor &mdash; full width</span>' + editorHTML(n, false);
+    swapShowTab("pane-editor");
+    ed.querySelector(".ed-apply").addEventListener("click", () => swapShowTab("pane-grid"));
+});
+
+const floatEl = document.getElementById("float-el");
+drawCanvas("canvas-float", H_NODES.map(n => ({...n, active:false})), H_EDGES, "h", (n, el) => {
+    floatEl.innerHTML = editorHTML(n, true);
+    const parent = floatEl.parentElement.getBoundingClientRect();
+    const rect = el.getBoundingClientRect();
+    floatEl.style.left = Math.min(rect.right - parent.left + 14, parent.width - 292) + "px";
+    floatEl.style.top = Math.max(8, Math.min(rect.top - parent.top - 10, 130)) + "px";
+    floatEl.classList.add("open");
+    floatEl.querySelector(".ed-close").addEventListener("click", () => {
+        floatEl.classList.remove("open");
+        document.querySelectorAll("#canvas-float .mnode").forEach(m => m.classList.remove("active"));
+    });
+    makeDraggable(floatEl, floatEl.querySelector(".ed-head"));
+});
+function makeDraggable(panel, handle) {
+    handle.onpointerdown = e => {
+        if (e.target.classList.contains("ed-close")) return;
+        const startX = e.clientX - panel.offsetLeft, startY = e.clientY - panel.offsetTop;
+        handle.setPointerCapture(e.pointerId);
+        handle.onpointermove = ev => {
+            panel.style.left = (ev.clientX - startX) + "px";
+            panel.style.top = (ev.clientY - startY) + "px";
+        };
+        handle.onpointerup = () => { handle.onpointermove = null; };
+    };
+}
+
+// ---------- draggable gutters ----------
+document.querySelectorAll("[data-gutter]").forEach(g => {
+    const horiz = g.dataset.gutter === "v"; // v gutter moves along x
+    g.addEventListener("pointerdown", e => {
+        e.preventDefault();
+        const prev = g.previousElementSibling;
+        const start = horiz ? e.clientX : e.clientY;
+        const base = horiz ? prev.getBoundingClientRect().width : prev.getBoundingClientRect().height;
+        g.setPointerCapture(e.pointerId);
+        const move = ev => {
+            const d = (horiz ? ev.clientX : ev.clientY) - start;
+            prev.style.flex = `0 0 ${Math.max(60, base + d)}px`;
+        };
+        g.addEventListener("pointermove", move);
+        g.addEventListener("pointerup", () => g.removeEventListener("pointermove", move), {once:true});
+    });
+});
+</script>
+</main>
+</body>
+</html>

--- a/claude/plans/analysis_layout_rework_plan.md
+++ b/claude/plans/analysis_layout_rework_plan.md
@@ -1,0 +1,108 @@
+# Analysis layout rework: horizontal mode with Swap + Drawer editors
+
+**Goal:** a per-analysis "horizontal mode": nodes flow left→right on a full-width canvas, the
+variant grid docks along the bottom at full width, and the node editor is available two ways —
+docked as a bottom-pane tab beside the grid ("Swap") or sliding in over the canvas ("Drawer") —
+with a live toggle between them so both can be used and compared. Mockups and rationale:
+`claude/design/analysis_grid_rework.html`.
+
+The variant grid stays jqGrid throughout — the DataTables conversion is a separate plan.
+The existing vertical layout keeps working unchanged and remains the default; everything new is
+gated on `analysis.analysis_horizontal_mode`.
+
+**Prerequisite:** `claude/plans/jsplumb_upgrade_plan.md` has landed (anchor work below is written
+once, against the new API).
+
+## 1. Settings wiring (fields already exist)
+
+- `Analysis.analysis_horizontal_mode` (`analysis/models/models_analysis.py:65`): add to
+  `AnalysisForm.Meta.fields` (`analysis/forms/forms.py`) so it appears in analysis settings.
+- `UserSettings.analysis_horizontal_mode` (`snpdb/models/models_user_settings.py:216`): expose the
+  form field by making `get_settings_form_features().analysis_horizontal_mode` return
+  `self.analysis_enabled` (`snpdb/forms.py:483` — currently hard-coded off) and pointing the
+  `_hide_unused_fields` entry (`snpdb/forms.py:606`) at that feature flag.
+- New analyses inherit the user setting in `set_defaults_and_save`
+  (`analysis/models/models_analysis.py:~222`, alongside `custom_columns_collection` etc.).
+  Analyses created from a template take the **template's** mode — node positions copy from the
+  template, and positions are orientation-specific.
+- **Mode switch transposes positions:** when `AnalysisForm` save changes the mode, swap x/y on all
+  the analysis's nodes in the same transaction. Swap is self-inverse, so toggling back restores the
+  original layout exactly. No version bump — positions don't affect queries.
+
+## 2. Page layout (templates + Split.js)
+
+- `view_analysis` (`analysis/views/views.py:198`) passes the mode; `analysis.html` renders the
+  horizontal structure when set: toolbar, then `#canvas-row` (full width), then a horizontal
+  gutter, then `#bottom-panel` (full width) holding `analysis_editor_and_grid.html`.
+- `layoutAnalysisPanels` (`analysis.js:88`) grows a horizontal variant:
+  `Split(['#canvas-row', '#bottom-panel'], {direction: 'vertical', ...})`.
+  `analysis_panel_fraction` keeps its meaning as "fraction taken by the node-canvas side" in both
+  modes, and `analysis_set_panel_size` (`analysis/views/views_json.py:431`) is reused as-is.
+- `resizeGrid` (`analysis.js:32`) sizes to the bottom panel (full window width) and also sets the
+  grid height to fill the pane; call it on splitter drag-end and on grid-tab show (a jqGrid sized
+  while hidden measures zero width).
+- The template/analysis-variables top bar and its vertical split stay exactly as they are.
+
+## 3. Swap: tabbed bottom pane
+
+`analysis_editor_and_grid.html` gains a tab strip — **Editor | Grid** — over the existing
+`#node-editor-container` and `#node-grid-container`. Container ids and the
+`registerComponent(EDITOR/GRID)` pairing stay untouched; the tabs only control visibility.
+
+- **Tab behaviour:** the active tab is sticky while browsing — clicking nodes with the Grid tab up
+  loads each node's grid (results-browsing mode); clicking nodes with the Editor tab up shows each
+  node's editor. Saving an editor switches to the Grid tab, which shows the existing async-wait /
+  loading states until the node re-computes.
+- **Toolbar-driven editor content** (`analysisSettings()`, `inputSamples()`, `viewTags()` via
+  `replaceEditorWindow`) switches to the Editor tab when it loads.
+- **Lazy grid:** while the Grid tab is hidden, defer the grid data fetch until the tab is first
+  shown — integrate with the existing deferred machinery in
+  `analysis/templates/analysis/node_data/node_data_grid.html` (`grid_auto_load` placeholder,
+  `loadedGridVersions` page-cache, and the `datatype:'local'` empty init that lets the editor's
+  `everythingLoaded` proceed without a row fetch). Editing a chain of nodes with the Editor tab up
+  therefore issues zero grid queries; the `grid_auto_load_max_variants` placeholder then applies as
+  normal when the tab is shown.
+
+## 4. Drawer: the same editor, undocked
+
+- A drawer element on the right edge of `#canvas-row`, hidden by default, ~450px wide, resizable by
+  dragging its left edge, closable via a button and Escape.
+- **One editor, two homes:** toggling reparents the existing `#node-editor-container` between the
+  Editor tab pane and the drawer body — all load logic targets that id and keeps working. In drawer
+  mode the bottom panel is grid-only (tab strip hidden) and node selection opens the drawer; the
+  grid stays visible below, so after a save the re-computed results appear without any tab flip.
+- **Toggle placement:** an "undock" button on the Editor tab strip, and a "dock as tab" button in
+  the drawer header. Persist the choice in `localStorage` for the comparison period; once a winner
+  (or a lasting preference) emerges, promote it to a `UserSettings` field in a follow-up change.
+
+## 5. Node canvas: horizontal flow
+
+- Centralise orientation in one config object consumed by `setupConnections` and the instance
+  defaults in `analysis_nodes.js` — vertical: input `TopCenter` (Venn: `[0.25,0]`/`[0.75,0]`),
+  output `BottomCenter`; horizontal: input `LeftMiddle` (Venn: left edge at 0.25/0.75 height),
+  output `RightMiddle`. Everything else about endpoints (uuids, styles, MergeNode multi-input,
+  invalid-target highlighting) is orientation-independent and stays shared.
+- New-node placement: horizontal mode places an added/copied node to the right of the active node
+  (vertical mode keeps placing below).
+- Node cards, chips, badges and the counts strip are unchanged — the card design works in both
+  orientations.
+
+## 6. Interactions to keep working in both modes
+
+Dual-screen mode, Delete-key node deletion, marquee multi-select + multi-drag, node count
+click-through (`extra_filters`), grid export CSV/VCF (including from the placeholder), the
+tags view, and read-only analyses (no editing, no dragging, editor read-only).
+
+## Verification (manual, `python3 manage.py runserver`)
+
+1. A vertical analysis renders and behaves exactly as before (regression pass).
+2. Toggle an analysis to horizontal in analysis settings: nodes transpose sensibly; toggle back
+   restores the original layout exactly.
+3. New analysis inherits the user setting; analysis-from-template inherits the template's mode.
+4. Swap: sticky tabs while clicking around the graph; save flips to Grid with the loading state;
+   with the Editor tab up, no grid queries fire (check the network tab); Grid tab first-show loads
+   or shows the auto-load placeholder per the row-count threshold.
+5. Drawer: undock/redock round-trips, preference survives reload, Escape closes, drawer-edited
+   save shows refreshed grid below.
+6. Splitter drag persists `analysis_panel_fraction`; grid resizes on drag-end and tab show.
+7. Items in §6 all pass in horizontal mode.

--- a/snpdb/forms.py
+++ b/snpdb/forms.py
@@ -481,8 +481,7 @@ class SettingsFormFeatures:
 
     @cached_property
     def analysis_horizontal_mode(self) -> bool:
-        implemented_analysis_horizontal_mode = False  # Not yet
-        return self.analysis_enabled and implemented_analysis_horizontal_mode
+        return self.analysis_enabled
 
     @cached_property
     def upload_enabled(self) -> bool:
@@ -528,6 +527,7 @@ class SettingsOverrideForm(BaseModelForm):
             "variant_link_in_analysis_opens_new_tab": BlankNullBooleanSelect(),
             "tool_tips": BlankNullBooleanSelect(),
             "node_debug_tab": BlankNullBooleanSelect(),
+            "analysis_horizontal_mode": BlankNullBooleanSelect(),
             "import_messages": BlankNullBooleanSelect(),
             'default_sort_by_column': ModelSelect2(url='custom_column_autocomplete',
                                                   forward=['columns'],
@@ -544,6 +544,7 @@ class SettingsOverrideForm(BaseModelForm):
             "tool_tips": "Tooltips",
             "tag_colors": "Tag Colours",
             "node_debug_tab": "Node Debug Tab",
+            "analysis_horizontal_mode": "Analysis Horizontal Mode",
             "import_messages": "Import Messages",
             "default_sort_by_column": "Default Sort by Column",
             "igv_port": "IGV Port",
@@ -603,7 +604,7 @@ class SettingsOverrideForm(BaseModelForm):
             "variant_link_in_analysis_opens_new_tab": settings_config.analysis_enabled,
             "tool_tips": settings_config.analysis_enabled,
             "node_debug_tab": settings_config.analysis_enabled,
-            "analysis_horizontal_mode": False,
+            "analysis_horizontal_mode": settings_config.analysis_horizontal_mode,
             "tag_colors": settings_config.analysis_enabled,
             "import_messages": settings_config.upload_enabled,
             "igv_port": settings_config.igv_links_enabled,

--- a/variantgrid/static_files/default_static/css/analysis_nodes.css
+++ b/variantgrid/static_files/default_static/css/analysis_nodes.css
@@ -771,3 +771,110 @@ span.node-counts {
 	pointer-events: none;
 	transition: opacity 300ms ease-out;
 }
+
+/*
+	Horizontal mode (analysis.analysis_horizontal_mode) - nodes flow left to right on a full width
+	canvas, with the editor/grid panel docked along the bottom. See analysis.js
+*/
+
+/* The toolbar and the editor drawer are pinned to this pane, so the canvas does its own scrolling */
+.analysis-horizontal #left-panel {
+	overflow: hidden;
+}
+
+.analysis-horizontal #analysis-container {
+	overflow: auto;
+}
+
+.analysis-horizontal #right-panel {
+	overflow: auto;
+}
+
+/* The grid is sized to fill the bottom panel, so it doesn't need the top bar sized margin */
+.analysis-horizontal #node-grid-container {
+	margin-bottom: 0;
+}
+
+/* Bottom panel tab strip - Editor | Grid ("Swap") */
+.bottom-pane-tabs {
+	display: flex;
+	align-items: stretch;
+	gap: 2px;
+	background-color: #eee;
+	border-bottom: 1px solid #ccc;
+	padding: 0 4px;
+}
+
+.bottom-pane-tab {
+	padding: 4px 16px;
+	border: 1px solid transparent;
+	border-bottom: none;
+	border-radius: 4px 4px 0 0;
+	color: #333;
+	text-decoration: none;
+	font-weight: 600;
+}
+
+.bottom-pane-tab:hover {
+	text-decoration: none;
+	background-color: #f6f6f6;
+}
+
+.bottom-pane-tab.active {
+	background-color: white;
+	border-color: #ccc;
+	margin-bottom: -1px;
+}
+
+.bottom-pane-tab-action {
+	margin-left: auto;
+	align-self: center;
+	padding: 2px 8px;
+	color: #555;
+	text-decoration: none;
+	font-size: 0.9em;
+}
+
+/* The editor's other home - slides in over the right of the canvas ("Drawer") */
+#node-editor-drawer {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: 450px;
+	z-index: 9998; /* over the nodes, under #analysis-toolbar */
+	display: flex;
+	flex-direction: column;
+	background-color: white;
+	border-left: 1px solid #ccc;
+	box-shadow: -2px 0 8px rgba(0, 0, 0, .2);
+}
+
+.drawer-resize-handle {
+	position: absolute;
+	left: -3px;
+	top: 0;
+	bottom: 0;
+	width: 6px;
+	cursor: col-resize;
+}
+
+.drawer-header {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 6px 4px 12px;
+	border-bottom: 1px solid #ddd;
+	background-color: #eee;
+}
+
+.drawer-title {
+	flex: 1;
+	font-weight: bold;
+}
+
+#node-editor-drawer-body {
+	flex: 1;
+	overflow: auto;
+	padding: 6px;
+}

--- a/variantgrid/static_files/default_static/css/analysis_nodes.css
+++ b/variantgrid/static_files/default_static/css/analysis_nodes.css
@@ -826,6 +826,26 @@ span.node-counts {
 	margin-bottom: -1px;
 }
 
+/* Variant details tabs - one pane each, closed with the x on the tab. See openVariantDetailsTab() */
+.variant-tab {
+	display: inline-flex;
+	align-items: center;
+}
+
+.close-variant-tab {
+	margin-left: 6px;
+	font-size: 0.85em;
+	opacity: 0.5;
+}
+
+.close-variant-tab:hover {
+	opacity: 1;
+}
+
+.variant-details-pane {
+	padding: 5px;
+}
+
 .bottom-pane-tab-action {
 	margin-left: auto;
 	align-self: center;
@@ -835,6 +855,60 @@ span.node-counts {
 	font-size: 0.9em;
 }
 
+.bottom-pane-node-tabs {
+	display: flex;
+	align-items: stretch;
+	gap: 2px;
+}
+
+/* One row of tabs - the node editor's own strip is mirrored into the bar of whichever home it's in */
+.analysis-horizontal #node-editor-tabs > ul.ui-tabs-nav {
+	display: none;
+}
+
+/* Node counts legend - moved into the toolbar (see layoutAnalysisPanels), so it reads as a single row */
+.analysis-horizontal #node-count-legend {
+	position: static;
+	float: none;  /* #analysis-toolbar floats its divs - this one sits inline after the genome build */
+	display: inline-flex;
+	align-items: center;
+	vertical-align: middle;
+	gap: 12px;
+	margin-left: 15px;
+	height: auto;
+}
+
+.analysis-horizontal #node-count-legend .legend-row {
+	display: flex;
+	align-items: center;
+	min-height: 0;
+	margin: 0;
+}
+
+.analysis-horizontal #node-count-legend .legend-color-box {
+	float: none;
+	width: 14px;
+	height: 14px;
+	margin-right: 4px;
+}
+
+.analysis-horizontal #node-count-legend .legend-label {
+	float: none;
+	white-space: nowrap;
+}
+
+/* The Venn rings and the Merge glyph turn with the flow, so they line up with their input endpoints */
+.analysis-horizontal .design-a-node .node-venn {
+	align-items: center;
+	height: 56px;
+}
+
+.analysis-horizontal .design-a-node .node-venn svg,
+.analysis-horizontal .design-a-node .node-graphic svg {
+	flex-shrink: 0;
+	transform: rotate(-90deg);
+}
+
 /* The editor's other home - slides in over the right of the canvas ("Drawer") */
 #node-editor-drawer {
 	position: absolute;
@@ -842,7 +916,7 @@ span.node-counts {
 	right: 0;
 	bottom: 0;
 	width: 450px;
-	z-index: 9998; /* over the nodes, under #analysis-toolbar */
+	z-index: 200; /* over #analysis-toolbar, so header tooltips aren't drawn behind it */
 	display: flex;
 	flex-direction: column;
 	background-color: white;
@@ -869,8 +943,44 @@ span.node-counts {
 }
 
 .drawer-title {
-	flex: 1;
 	font-weight: bold;
+	margin-right: 4px;
+}
+
+#node-editor-drawer.has-node-tabs .drawer-title {
+	display: none;
+}
+
+.drawer-header .toolbar-button:first-of-type {
+	margin-left: auto;
+}
+
+/* The editor's tabs, mirrored into the drawer header - see syncNodeEditorTabs() */
+.drawer-node-tabs {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	overflow: hidden;
+}
+
+.drawer-tab {
+	padding: 2px 8px;
+	border: 1px solid transparent;
+	border-radius: 4px;
+	color: #333;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.drawer-tab:hover {
+	text-decoration: none;
+	background-color: #f6f6f6;
+}
+
+.drawer-tab.active {
+	background-color: white;
+	border-color: #ccc;
+	font-weight: 600;
 }
 
 #node-editor-drawer-body {

--- a/variantgrid/static_files/default_static/js/analysis.js
+++ b/variantgrid/static_files/default_static/js/analysis.js
@@ -100,12 +100,18 @@ function resizePanel() {
    localStorage while both are being compared. */
 const BOTTOM_PANE_EDITOR = "editor";
 const BOTTOM_PANE_GRID = "grid";
+const BOTTOM_PANE_VARIANT = "variant";
 const EDITOR_HOME_TAB = "tab";
 const EDITOR_HOME_DRAWER = "drawer";
 const EDITOR_HOME_STORAGE_KEY = "analysisEditorHome";
 const DRAWER_MIN_WIDTH = 300;
 
 let activeBottomPaneTab = BOTTOM_PANE_GRID;
+// Which of the node editor's own tabs the strip is pointing at - 0 is the editor/grid pair
+const NODE_EDITOR_TAB_EDITOR = 0;
+let activeNodeEditorTab = NODE_EDITOR_TAB_EDITOR;
+let activeVariantTab = null;  // variant id of the details tab that's up, if any
+let paneBeforeVariantTab = BOTTOM_PANE_GRID;  // what to go back to when we leave the variant tabs
 
 function getEditorHome() {
     if (!isHorizontalMode()) {
@@ -130,25 +136,215 @@ function registerDeferredGridLoad(loadFunc) {
     deferredGridLoad = loadFunc;
 }
 
+// Editor tabs share a pane, so they're told apart by which node editor tab they point at
+function updateMirroredTabHighlight() {
+    const variantShowing = activeBottomPaneTab === BOTTOM_PANE_VARIANT;
+    $(".bottom-pane-tab, .drawer-tab").each(function() {
+        const tab = $(this);
+        const pane = tab.attr("pane");
+        let active;
+        if (pane === BOTTOM_PANE_GRID) {
+            active = activeBottomPaneTab === BOTTOM_PANE_GRID;
+        } else if (pane === BOTTOM_PANE_VARIANT) {
+            active = variantShowing && parseInt(tab.attr("variant_id")) === activeVariantTab;
+        } else {
+            // The drawer only ever shows the editor or a variant, so there's no pane to take into account
+            const editorShowing = !variantShowing &&
+                (!bottomPaneTabsEnabled() || activeBottomPaneTab === BOTTOM_PANE_EDITOR);
+            active = editorShowing && parseInt(tab.attr("editor-tab")) === activeNodeEditorTab;
+        }
+        tab.toggleClass("active", active);
+    });
+}
+
+/* The node editor's own tab strip is mirrored into whichever bar is always on screen, so horizontal
+   mode only ever has one row of tabs: the bottom pane strip while docked (Editor | Grid | Summary...),
+   or the drawer header while undocked. Rebuilt by each editor load - see base_editor.html */
+function syncNodeEditorTabs() {
+    const docked = getEditorHome() === EDITOR_HOME_TAB;
+    $("#bottom-pane-node-tabs, #drawer-node-tabs").empty();
+    const mirror = docked ? $("#bottom-pane-node-tabs") : $("#drawer-node-tabs");
+    if (!mirror.length) {
+        return;
+    }
+    activeNodeEditorTab = NODE_EDITOR_TAB_EDITOR;
+    // Docked, the strip's own Editor and Grid tabs already cover the editor's first tab
+    const firstTab = docked ? NODE_EDITOR_TAB_EDITOR + 1 : NODE_EDITOR_TAB_EDITOR;
+    $("#node-editor-tabs > ul > li > a").slice(firstTab).each(function(i) {
+        const editorTab = firstTab + i;
+        $("<a>", {
+            "class": docked ? "bottom-pane-tab" : "drawer-tab",
+            "pane": BOTTOM_PANE_EDITOR,
+            "editor-tab": editorTab,
+            href: "javascript:void(0)",
+            text: $(this).text(),
+        }).appendTo(mirror).click(function() {
+            showNodeEditorTab(editorTab);
+        });
+    });
+    // The tabs name what's showing, so the drawer's own title gives up its space to them
+    $("#node-editor-drawer").toggleClass("has-node-tabs", !docked && mirror.children().length > 0);
+    updateMirroredTabHighlight();
+}
+
+/* Variant details from the grid open as their own closable tab rather than taking over the editor,
+   so you can keep a few variants beside the node you're working on. They only ever come from the grid
+   that's showing, and go when it does - see closeAllVariantDetailsTabs(). The details page uses page level
+   ids, so only the tab being read is in the DOM - the others are remembered by url and re-loaded when
+   picked, which is all a first open does anyway. Tabs are named by the page itself once it loads,
+   see setVariantDetailsTabLabel() */
+let openVariantTabs = [];  // {variantId, url, label}
+
+function findVariantTab(variantId) {
+    return openVariantTabs.find(function(tab) { return tab.variantId === variantId; });
+}
+
+function openVariantDetailsTab(variantId, url) {
+    if (!isHorizontalMode()) {
+        return false;
+    }
+    if (!findVariantTab(variantId)) {
+        openVariantTabs.push({variantId: variantId, url: url, label: null});
+    }
+    showVariantDetailsTab(variantId);
+    return true;
+}
+
+function loadVariantDetailsPane(tab) {
+    const pane = $("<div>", {"class": "variant-details-pane"})
+        .html('<div class="editor-loading"><i class="fa fa-spinner"></i> Loading variant details...</div>');
+    $("#variant-details-container").empty().append(pane);
+    pane.load(tab.url);
+}
+
+function showVariantDetailsTab(variantId) {
+    const tab = findVariantTab(variantId);
+    if (!tab) {
+        return;
+    }
+    if (activeBottomPaneTab !== BOTTOM_PANE_VARIANT) {
+        paneBeforeVariantTab = activeBottomPaneTab;
+    }
+    // The pane is also gone if the whole panel was reloaded under us (dual screen close)
+    if (activeVariantTab !== variantId || !$(".variant-details-pane", "#variant-details-container").length) {
+        activeVariantTab = variantId;
+        loadVariantDetailsPane(tab);
+    }
+    renderVariantDetailsTabs();
+    showBottomPaneTab(BOTTOM_PANE_VARIANT);
+    openNodeEditorDrawer();
+}
+
+function closeVariantDetailsTab(variantId) {
+    openVariantTabs = openVariantTabs.filter(function(tab) { return tab.variantId !== variantId; });
+    if (activeVariantTab !== variantId) {
+        renderVariantDetailsTabs();
+        return;
+    }
+
+    activeVariantTab = null;
+    $("#variant-details-container").empty();
+    const nextTab = openVariantTabs[openVariantTabs.length - 1];
+    if (nextTab) {
+        showVariantDetailsTab(nextTab.variantId);
+    } else {
+        renderVariantDetailsTabs();
+        showBottomPaneTab(paneBeforeVariantTab);
+    }
+}
+
+/* The tabs belong to the grid they were opened from - anything that replaces it (selecting a node,
+   a save, or toolbar content taking over the editor) takes its variant tabs with it */
+function closeAllVariantDetailsTabs() {
+    openVariantTabs = [];
+    activeVariantTab = null;
+    $("#variant-details-container").empty();
+    renderVariantDetailsTabs();
+    if (activeBottomPaneTab === BOTTOM_PANE_VARIANT) {
+        showBottomPaneTab(paneBeforeVariantTab);
+    }
+}
+
+// Called by the variant details page as it loads - until then the tab shows a placeholder
+function setVariantDetailsTabLabel(variantId, label) {
+    const tab = findVariantTab(variantId);
+    if (tab) {
+        tab.label = label;
+        renderVariantDetailsTabs();
+    }
+}
+
+function renderVariantDetailsTabs() {
+    const docked = getEditorHome() === EDITOR_HOME_TAB;
+    $("#bottom-pane-variant-tabs, #drawer-variant-tabs").empty();
+    const strip = docked ? $("#bottom-pane-variant-tabs") : $("#drawer-variant-tabs");
+    if (!strip.length) {
+        return;
+    }
+    openVariantTabs.forEach(function(variantTab) {
+        const tab = $("<a>", {
+            "class": (docked ? "bottom-pane-tab" : "drawer-tab") + " variant-tab",
+            "pane": BOTTOM_PANE_VARIANT,
+            "variant_id": variantTab.variantId,
+            href: "javascript:void(0)",
+            text: variantTab.label || "Variant",
+        }).appendTo(strip).click(function() {
+            showVariantDetailsTab(variantTab.variantId);
+        });
+        $("<i>", {"class": "fa-solid fa-xmark close-variant-tab", title: "Close"}).appendTo(tab).click(function(event) {
+            event.stopPropagation();
+            closeVariantDetailsTab(variantTab.variantId);
+        });
+    });
+    updateMirroredTabHighlight();
+}
+
+// Point the node editor (and so the data container, see switch_node_data) at one of its own tabs
+function setNodeEditorTab(editorTab) {
+    activeNodeEditorTab = editorTab;
+    // ui-tabs-nav is added by the widget - the editor is only tabbed once it's finished loading
+    const tabs = $("#node-editor-tabs:has(> ul.ui-tabs-nav)");
+    if (tabs.length && tabs.tabs("option", "active") !== editorTab) {
+        tabs.tabs("option", "active", editorTab);
+    }
+}
+
+function showNodeEditorTab(editorTab) {
+    setNodeEditorTab(editorTab);
+    showBottomPaneTab(BOTTOM_PANE_EDITOR);
+}
+
+/* Which of the panes sharing the bottom panel is on screen. Docked, the panel shows exactly one of
+   editor / variant details / grid; undocked the grid keeps the whole panel and the drawer body holds
+   the editor or a variant details pane. */
+function updatePaneVisibility() {
+    const docked = bottomPaneTabsEnabled();
+    const showVariant = activeBottomPaneTab === BOTTOM_PANE_VARIANT;
+    const showEditor = docked ? activeBottomPaneTab === BOTTOM_PANE_EDITOR : !showVariant;
+
+    $("#node-editor-container").toggle(showEditor);
+    $("#variant-details-container").toggle(showVariant);
+    $("#node-grid-container").toggle(!docked || activeBottomPaneTab === BOTTOM_PANE_GRID);
+}
+
+function gridPaneShown() {
+    if (deferredGridLoad) {
+        const loadFunc = deferredGridLoad;
+        deferredGridLoad = null;
+        loadFunc();
+    }
+    resizeGrid();  // a jqGrid sized while hidden measures zero width
+}
+
 function showBottomPaneTab(name) {
-    if (!bottomPaneTabsEnabled()) {
+    if (!isHorizontalMode()) {
         return;
     }
     activeBottomPaneTab = name;
-    $(".bottom-pane-tab", "#bottom-pane-tabs").each(function() {
-        $(this).toggleClass("active", $(this).attr("pane") === name);
-    });
-    const showEditor = name === BOTTOM_PANE_EDITOR;
-    $("#node-editor-container").toggle(showEditor);
-    $("#node-grid-container").toggle(!showEditor);
-
-    if (!showEditor) {
-        if (deferredGridLoad) {
-            const loadFunc = deferredGridLoad;
-            deferredGridLoad = null;
-            loadFunc();
-        }
-        resizeGrid();  // a jqGrid sized while hidden measures zero width
+    updatePaneVisibility();
+    updateMirroredTabHighlight();
+    if ($("#node-grid-container").is(":visible")) {
+        gridPaneShown();
     }
 }
 
@@ -171,22 +367,28 @@ function applyEditorHome() {
         return;
     }
     const editorContainer = $("#node-editor-container");
+    const variantContainer = $("#variant-details-container");
     const drawerBody = $("#node-editor-drawer-body");
     const tabs = $("#bottom-pane-tabs");
 
     if (getEditorHome() === EDITOR_HOME_DRAWER) {
         tabs.hide();
-        drawerBody.children().not(editorContainer).remove();
-        editorContainer.show().appendTo(drawerBody);
-        $("#node-grid-container").show();
-        activeBottomPaneTab = BOTTOM_PANE_GRID;
+        drawerBody.children().not(editorContainer).not(variantContainer).remove();
+        editorContainer.appendTo(drawerBody);
+        variantContainer.appendTo(drawerBody);
     } else {
         closeNodeEditorDrawer();
         editorContainer.prependTo($("#grid-and-editor-container"));
+        variantContainer.insertAfter(editorContainer);
         tabs.show();
-        showBottomPaneTab(activeBottomPaneTab);
     }
-    resizeGrid();
+    updatePaneVisibility();
+    // The editor's tabs and any open variant details mirror into whichever bar its new home has
+    syncNodeEditorTabs();
+    renderVariantDetailsTabs();
+    if ($("#node-grid-container").is(":visible")) {
+        gridPaneShown();
+    }
 }
 
 function setEditorHome(home) {
@@ -239,7 +441,13 @@ function setupBottomPaneTabs() {
         return;
     }
     $(".bottom-pane-tab", tabs).click(function() {
-        showBottomPaneTab($(this).attr("pane"));
+        const pane = $(this).attr("pane");
+        if (pane === BOTTOM_PANE_EDITOR) {
+            showNodeEditorTab(NODE_EDITOR_TAB_EDITOR);
+        } else {
+            setNodeEditorTab(NODE_EDITOR_TAB_EDITOR);  // clicking Grid asks for the variant grid
+            showBottomPaneTab(pane);
+        }
     });
     $("#undock-editor-button", tabs).click(function() {
         setEditorHome(EDITOR_HOME_DRAWER);
@@ -263,12 +471,20 @@ function replaceEditorWindow(url) {
     unselectActive();
     if (url) {
         // Toolbar content (analysis settings, input samples) is editor-only - put it where it can be seen
-        showBottomPaneTab(BOTTOM_PANE_EDITOR);
-        openNodeEditorDrawer();
+        revealNodeEditor();
         nodeEditorContainer.load(url);
     } else {
         closeNodeEditorDrawer();
     }
+}
+
+/* Content that only has an editor half (analysis settings, input samples, variant details) - bring
+   the editor up in whichever home it's in */
+function revealNodeEditor() {
+    closeAllVariantDetailsTabs();
+    syncNodeEditorTabs();  // what's loading has no tabs of its own
+    showBottomPaneTab(BOTTOM_PANE_EDITOR);
+    openNodeEditorDrawer();
 }
 
 function analysisSettings() {
@@ -304,6 +520,8 @@ function layoutAnalysisPanels(showAnalysisVariables, initialAnalysisPanelFractio
     if (isHorizontalMode()) {
         // Canvas on top, editor/grid along the bottom - both full window width
         splitParams.direction = 'vertical';
+        // The canvas is full width now, so the counts legend goes in the toolbar beside the genome build
+        $("#node-count-legend").insertAfter($("#analysis-genome-build"));
     }
     Split(['#left-panel', '#right-panel'], splitParams);
 
@@ -688,6 +906,7 @@ function loadGridAndEditorForNode(nodeId, extra_filters, fromSelectNode) {
         removeGridLoadingOverlay();  // tear down any in-progress grid overlay from the previous node
         deferredGridLoad = null;  // the pending load belonged to the node we're leaving
         $("#node-editor-container").empty();
+        closeAllVariantDetailsTabs();  // they belonged to the grid we're replacing
         openNodeEditorDrawer();  // selecting a node is what opens the drawer
         showLoadingOverlay();
         dataContainer.load(load_node_url, function() {
@@ -696,6 +915,7 @@ function loadGridAndEditorForNode(nodeId, extra_filters, fromSelectNode) {
     } else {
         removeGridLoadingOverlay();
         closeNodeEditorDrawer();
+        closeAllVariantDetailsTabs();
         $("#node-editor-container").html("Please select a node");
         dataContainer.empty();
     }

--- a/variantgrid/static_files/default_static/js/analysis.js
+++ b/variantgrid/static_files/default_static/js/analysis.js
@@ -3,6 +3,7 @@ function startDualScreenMode() {
     if (!secondWindow) {
         saveSettingsOnResize = false;
         secondWindow = window.open(STAND_ALONE_URL, '_blank', 'toolbar=0,location=0,menubar=0');
+        closeNodeEditorDrawer();  // the editor lives in the other window now
         $("#right-panel").empty();
         $('div#analysis-outer-container').removePane("east");
         $("#dual-screen-button").hide();
@@ -29,20 +30,56 @@ function loadNodeData(nodeId, extra_filters, fromSelectNode) {
     win.loadGridAndEditorForNode(nodeId, extra_filters, fromSelectNode);
 }
 
-function resizeGrid() {
-    const panelSize = $("#right-panel").innerWidth;
-    const grid = $('.ui-jqgrid-btable:visible');
-    if(grid.length) {
-        grid.each(function(index) {
-            const gridId = $(this).attr('id');
-            $('#' + gridId).setGridWidth(panelSize - 2);
-        });
+function isHorizontalMode() {
+    return typeof ANALYSIS_HORIZONTAL_MODE !== "undefined" && ANALYSIS_HORIZONTAL_MODE;
+}
+
+// The height available to the grid inside the bottom panel - what's left under whatever sits above it
+function gridPaneAvailableHeight() {
+    const panel = $("#right-panel");
+    const gridContainer = $("#node-grid-container");
+    if (!panel.length || !gridContainer.length) {
+        return 0;
     }
+    const offsetInPanel = gridContainer.offset().top - panel.offset().top + panel.scrollTop();
+    return panel.innerHeight() - offsetInPanel;
+}
+
+const MIN_GRID_HEIGHT = 100;
+const GRID_BOTTOM_MARGIN = 10;
+
+function resizeGrid() {
+    const panelWidth = $("#right-panel").innerWidth();
+    const grid = $('.ui-jqgrid-btable:visible');
+    if (!grid.length) {
+        return;
+    }
+    // The grid pane is the full window width in horizontal mode, so give the rows the pane height too -
+    // otherwise jqGrid's default keeps them in a short scrolling box with the panel empty underneath
+    const available = isHorizontalMode() ? gridPaneAvailableHeight() : null;
+
+    grid.each(function() {
+        const gridSelector = $('#' + $(this).attr('id'));
+        gridSelector.setGridWidth(panelWidth - 2);
+        if (available) {
+            const view = gridSelector.closest(".ui-jqgrid");
+            // Everything but the rows - caption, column headers and pager
+            const chrome = view.outerHeight(true) - $(".ui-jqgrid-bdiv", view).height();
+            gridSelector.setGridHeight(Math.max(available - chrome - GRID_BOTTOM_MARGIN, MIN_GRID_HEIGHT));
+        }
+    });
 }
 
 function savePanelWidthSettings() {
     if (saveSettingsOnResize) {
-        const analysis_panel_fraction = $("#left-panel").outerWidth() / window.innerWidth;
+        // analysis_panel_fraction is the fraction taken by the node canvas in both modes
+        const canvasPanel = $("#left-panel");
+        let analysis_panel_fraction;
+        if (isHorizontalMode()) {
+            analysis_panel_fraction = canvasPanel.outerHeight() / $("#analysis-and-toolbar-container").height();
+        } else {
+            analysis_panel_fraction = canvasPanel.outerWidth() / window.innerWidth;
+        }
         const data = 'analysis_panel_fraction=' + analysis_panel_fraction;
         $.ajax({
             type: "POST",
@@ -55,6 +92,159 @@ function savePanelWidthSettings() {
 function resizePanel() {
     clearTimeout(panelResizeTimeout);
     panelResizeTimeout = setTimeout(savePanelWidthSettings, panelResizeUpdateDelay);
+}
+
+/* Horizontal mode gives the node editor two homes: docked as a tab in the bottom panel beside the
+   grid ("Swap"), or slid in over the canvas ("Drawer"). It's one editor either way - #node-editor-container
+   is reparented between them, so everything that loads into it by id keeps working. The choice lives in
+   localStorage while both are being compared. */
+const BOTTOM_PANE_EDITOR = "editor";
+const BOTTOM_PANE_GRID = "grid";
+const EDITOR_HOME_TAB = "tab";
+const EDITOR_HOME_DRAWER = "drawer";
+const EDITOR_HOME_STORAGE_KEY = "analysisEditorHome";
+const DRAWER_MIN_WIDTH = 300;
+
+let activeBottomPaneTab = BOTTOM_PANE_GRID;
+
+function getEditorHome() {
+    if (!isHorizontalMode()) {
+        return EDITOR_HOME_TAB;
+    }
+    return localStorage.getItem(EDITOR_HOME_STORAGE_KEY) === EDITOR_HOME_DRAWER ? EDITOR_HOME_DRAWER : EDITOR_HOME_TAB;
+}
+
+function bottomPaneTabsEnabled() {
+    return isHorizontalMode() && getEditorHome() === EDITOR_HOME_TAB && $("#bottom-pane-tabs").length > 0;
+}
+
+// The grid tab defers its data fetch while hidden - editing a chain of nodes then costs no grid queries
+function bottomPaneGridHidden() {
+    return bottomPaneTabsEnabled() && activeBottomPaneTab !== BOTTOM_PANE_GRID;
+}
+
+// Set by node_data_grid.html when it built a grid whose rows we skipped because the Grid tab was hidden
+let deferredGridLoad = null;
+
+function registerDeferredGridLoad(loadFunc) {
+    deferredGridLoad = loadFunc;
+}
+
+function showBottomPaneTab(name) {
+    if (!bottomPaneTabsEnabled()) {
+        return;
+    }
+    activeBottomPaneTab = name;
+    $(".bottom-pane-tab", "#bottom-pane-tabs").each(function() {
+        $(this).toggleClass("active", $(this).attr("pane") === name);
+    });
+    const showEditor = name === BOTTOM_PANE_EDITOR;
+    $("#node-editor-container").toggle(showEditor);
+    $("#node-grid-container").toggle(!showEditor);
+
+    if (!showEditor) {
+        if (deferredGridLoad) {
+            const loadFunc = deferredGridLoad;
+            deferredGridLoad = null;
+            loadFunc();
+        }
+        resizeGrid();  // a jqGrid sized while hidden measures zero width
+    }
+}
+
+function openNodeEditorDrawer() {
+    if (getEditorHome() === EDITOR_HOME_DRAWER) {
+        const drawer = $("#node-editor-drawer");
+        drawer.css("top", $("#analysis-toolbar").outerHeight() + "px");  // start below the toolbar
+        drawer.show();
+    }
+}
+
+function closeNodeEditorDrawer() {
+    $("#node-editor-drawer").hide();
+}
+
+/* Moves the editor into its current home and shows/hides the tab strip and drawer to match.
+   Runs on every editor+grid load, so it also re-homes a container replaced by a panel reload. */
+function applyEditorHome() {
+    if (!isHorizontalMode()) {
+        return;
+    }
+    const editorContainer = $("#node-editor-container");
+    const drawerBody = $("#node-editor-drawer-body");
+    const tabs = $("#bottom-pane-tabs");
+
+    if (getEditorHome() === EDITOR_HOME_DRAWER) {
+        tabs.hide();
+        drawerBody.children().not(editorContainer).remove();
+        editorContainer.show().appendTo(drawerBody);
+        $("#node-grid-container").show();
+        activeBottomPaneTab = BOTTOM_PANE_GRID;
+    } else {
+        closeNodeEditorDrawer();
+        editorContainer.prependTo($("#grid-and-editor-container"));
+        tabs.show();
+        showBottomPaneTab(activeBottomPaneTab);
+    }
+    resizeGrid();
+}
+
+function setEditorHome(home) {
+    localStorage.setItem(EDITOR_HOME_STORAGE_KEY, home);
+    applyEditorHome();
+    if (home === EDITOR_HOME_DRAWER && $(".node-editor, #node-editor-wrapper", "#node-editor-container").length) {
+        openNodeEditorDrawer();  // keep whatever the user was looking at on screen
+    }
+}
+
+function setupNodeEditorDrawer() {
+    const drawer = $("#node-editor-drawer");
+    if (!drawer.length) {
+        return;
+    }
+
+    $("#dock-editor-as-tab-button", drawer).click(function() {
+        setEditorHome(EDITOR_HOME_TAB);
+        showBottomPaneTab(BOTTOM_PANE_EDITOR);
+    });
+    $("#close-editor-drawer-button", drawer).click(closeNodeEditorDrawer);
+
+    $(document).on("keydown", function(event) {
+        const ESCAPE_KEY = 27;
+        if (event.keyCode === ESCAPE_KEY && drawer.is(":visible")) {
+            closeNodeEditorDrawer();
+        }
+    });
+
+    // Drag the left edge to resize
+    $(".drawer-resize-handle", drawer).on("mousedown", function(event) {
+        event.preventDefault();
+        const startX = event.pageX;
+        const startWidth = drawer.outerWidth();
+
+        const onMove = function(moveEvent) {
+            const width = Math.max(startWidth + startX - moveEvent.pageX, DRAWER_MIN_WIDTH);
+            drawer.css("width", width + "px");
+        };
+        const onUp = function() {
+            $(document).off("mousemove", onMove).off("mouseup", onUp);
+        };
+        $(document).on("mousemove", onMove).on("mouseup", onUp);
+    });
+}
+
+function setupBottomPaneTabs() {
+    const tabs = $("#bottom-pane-tabs");
+    if (!tabs.length) {
+        return;
+    }
+    $(".bottom-pane-tab", tabs).click(function() {
+        showBottomPaneTab($(this).attr("pane"));
+    });
+    $("#undock-editor-button", tabs).click(function() {
+        setEditorHome(EDITOR_HOME_DRAWER);
+        openNodeEditorDrawer();
+    });
 }
 
 function viewTags() {
@@ -72,7 +262,12 @@ function replaceEditorWindow(url) {
     nodeDataContainer.removeAttr("node_id");
     unselectActive();
     if (url) {
+        // Toolbar content (analysis settings, input samples) is editor-only - put it where it can be seen
+        showBottomPaneTab(BOTTOM_PANE_EDITOR);
+        openNodeEditorDrawer();
         nodeEditorContainer.load(url);
+    } else {
+        closeNodeEditorDrawer();
     }
 }
 
@@ -106,7 +301,13 @@ function layoutAnalysisPanels(showAnalysisVariables, initialAnalysisPanelFractio
         expandToMin: true,
         onDragEnd: onDragEnd,
     };
+    if (isHorizontalMode()) {
+        // Canvas on top, editor/grid along the bottom - both full window width
+        splitParams.direction = 'vertical';
+    }
     Split(['#left-panel', '#right-panel'], splitParams);
+
+    setupNodeEditorDrawer();
 
     // Make clicking the background send a "click event" but not if you click on the .window
     // This is so we can make the editor switch out and then add nodes etc....
@@ -485,14 +686,17 @@ function loadGridAndEditorForNode(nodeId, extra_filters, fromSelectNode) {
 
         dataContainer.attr("node_url", load_node_url);
         removeGridLoadingOverlay();  // tear down any in-progress grid overlay from the previous node
-        $("#node-editor-container", gridAndEditorContainer).empty();
+        deferredGridLoad = null;  // the pending load belonged to the node we're leaving
+        $("#node-editor-container").empty();
+        openNodeEditorDrawer();  // selecting a node is what opens the drawer
         showLoadingOverlay();
         dataContainer.load(load_node_url, function() {
             $(this).attr('node_id', nodeId);
         });
     } else {
         removeGridLoadingOverlay();
-        $("#node-editor-container", gridAndEditorContainer).html("Please select a node");
+        closeNodeEditorDrawer();
+        $("#node-editor-container").html("Please select a node");
         dataContainer.empty();
     }
 }
@@ -504,6 +708,9 @@ function layout_analysis_editor_and_grid() {
         //console.log("resizePanel = null");
         resizePanel = null;
     }
+
+    setupBottomPaneTabs();
+    applyEditorHome();
 }
 
 
@@ -576,7 +783,7 @@ function showGridLoadingOverlay(container) {
     const overlay = $("<div>", {id: "grid-loading-overlay"});
     // Pin the overlay to the visible grid area (panel height minus the editor above it). A fixed
     // height keeps the centred helix from jumping down as rows load and the container grows.
-    const available = $("#right-panel").height() - $("#node-editor-container").outerHeight(true);
+    const available = gridPaneAvailableHeight();
     if (available > 200) {
         overlay.css("height", available + "px");
     }

--- a/variantgrid/static_files/default_static/js/analysis.js
+++ b/variantgrid/static_files/default_static/js/analysis.js
@@ -907,6 +907,7 @@ function loadGridAndEditorForNode(nodeId, extra_filters, fromSelectNode) {
         deferredGridLoad = null;  // the pending load belonged to the node we're leaving
         $("#node-editor-container").empty();
         closeAllVariantDetailsTabs();  // they belonged to the grid we're replacing
+        showNodeEditorTab(NODE_EDITOR_TAB_EDITOR);  // a node comes up on its editor, so its grid stays deferred
         openNodeEditorDrawer();  // selecting a node is what opens the drawer
         showLoadingOverlay();
         dataContainer.load(load_node_url, function() {

--- a/variantgrid/static_files/default_static/js/analysis_nodes.js
+++ b/variantgrid/static_files/default_static/js/analysis_nodes.js
@@ -11,6 +11,29 @@ const CONNECTOR_SPEC = {type: "Bezier", options: {curviness: 63}};
 const ENDPOINT_STYLE = {fill: endpointColor};
 const DOT_ENDPOINT = {type: "Dot", options: {radius: 11}};
 
+// Which way the graph flows. Everything else about the endpoints (uuids, styles, MergeNode multi-input,
+// invalid-target highlighting) is orientation-independent - see setupConnections
+const NODE_ORIENTATIONS = {
+	vertical: {
+		instanceAnchors: ["Bottom", "Top"],
+		input: "Top",
+		output: "Bottom",
+		// Venn takes 2 inputs, spread along the input edge
+		vennInputs: [[0.25, 0, 0, -1], [0.75, 0, 0, -1]],
+	},
+	horizontal: {
+		instanceAnchors: ["Right", "Left"],
+		input: "Left",
+		output: "Right",
+		vennInputs: [[0, 0.25, -1, 0], [0, 0.75, -1, 0]],
+	},
+};
+
+function getNodeOrientation() {
+	const horizontal = typeof ANALYSIS_HORIZONTAL_MODE !== "undefined" && ANALYSIS_HORIZONTAL_MODE;
+	return NODE_ORIENTATIONS[horizontal ? "horizontal" : "vertical"];
+}
+
 // @jsplumb/browser-ui instance, created in variantgridPipeline.init once #analysis is in the DOM
 let jsPlumbInstance = null;
 
@@ -677,6 +700,8 @@ function setupConnections(nodes_selector, readOnly) {
 		maxConnections: -1,
 	};
 
+	const orientation = getNodeOrientation();
+
 	nodes_selector.each(function() {
 		// Nodes without endpoints still need to be managed, so they can be dragged
 		jsPlumbInstance.manage(this);
@@ -686,19 +711,19 @@ function setupConnections(nodes_selector, readOnly) {
 
 		if ($(this).attr("input_endpoint") == "true") {
 			if ($(this).hasClass("VennNode")) {
-				const topLeft = uuid + "-left";
-				const topRight = uuid + "-right";
-				jsPlumbInstance.addEndpoint(this, { anchor: [0.25, 0, 0, -1], uuid: topLeft}, inputEndpoint);
-				jsPlumbInstance.addEndpoint(this, { anchor: [0.75, 0, 0, -1], uuid: topRight}, inputEndpoint);
+				const inputLeft = uuid + "-left";
+				const inputRight = uuid + "-right";
+				jsPlumbInstance.addEndpoint(this, { anchor: orientation.vennInputs[0], uuid: inputLeft}, inputEndpoint);
+				jsPlumbInstance.addEndpoint(this, { anchor: orientation.vennInputs[1], uuid: inputRight}, inputEndpoint);
             } else if ($(this).hasClass("MergeNode")) {
 				const commonInputEndpoint = $.extend({}, inputEndpoint);
 				commonInputEndpoint["endpoint"] = {type: "Dot", options: {radius: 18}};
                 commonInputEndpoint["maxConnections"] = -1;
-                jsPlumbInstance.addEndpoint(this, { anchor: "Top", uuid: uuid}, commonInputEndpoint);
+                jsPlumbInstance.addEndpoint(this, { anchor: orientation.input, uuid: uuid}, commonInputEndpoint);
 			} else {
-			    // Keep existing, so we don't 
+			    // Keep existing, so we don't
 			    if (!existingEndpoint) {
-				    jsPlumbInstance.addEndpoint(this, { anchor: "Top", uuid: uuid}, inputEndpoint);
+				    jsPlumbInstance.addEndpoint(this, { anchor: orientation.input, uuid: uuid}, inputEndpoint);
 				}
 			}
 		} else {
@@ -706,9 +731,9 @@ function setupConnections(nodes_selector, readOnly) {
                 jsPlumbInstance.deleteEndpoint(uuid);
             }
 		}
-		
+
 		if ($(this).attr("output_endpoint") == "true") {
-			const e = jsPlumbInstance.addEndpoint(this, {anchor: "Bottom"}, outputEndpoint);
+			const e = jsPlumbInstance.addEndpoint(this, {anchor: orientation.output}, outputEndpoint);
 			if (!readOnly) {
 				add_click_overlay(e);
 			}
@@ -855,7 +880,7 @@ window.variantgridPipeline = {init : function(readOnly) {
 		endpointStyle: ENDPOINT_STYLE,
 		connector: CONNECTOR_SPEC,
 		paintStyle: CONNECTOR_STYLE,
-		anchors: ["Bottom", "Top"],
+		anchors: getNodeOrientation().instanceAnchors,
 		dragOptions: {cursor: 'pointer', zIndex: 2000, beforeStart: syncDragSelection},
 	});
 
@@ -1046,4 +1071,8 @@ function reloadNodeAndData(node_id) {
 	const aWin = getAnalysisWindow();
 	checkAndMarkDirtyNodes(aWin);
     aWin.loadNodeData(node_id);
+    // An editor save is the one time we want to leave the editor - show the results being re-computed
+    if (typeof showBottomPaneTab === "function") {
+        showBottomPaneTab(BOTTOM_PANE_GRID);
+    }
 }

--- a/variantgrid/static_files/default_static/js/analysis_nodes.js
+++ b/variantgrid/static_files/default_static/js/analysis_nodes.js
@@ -25,13 +25,18 @@ const NODE_ORIENTATIONS = {
 		instanceAnchors: ["Right", "Left"],
 		input: "Left",
 		output: "Right",
-		vennInputs: [[0, 0.25, -1, 0], [0, 0.75, -1, 0]],
+		// The card's rings are rotated anti-clockwise (see analysis_nodes.css), which puts the left
+		// ring at the bottom - so the left input takes the lower endpoint
+		vennInputs: [[0, 0.75, -1, 0], [0, 0.25, -1, 0]],
 	},
 };
 
+function isHorizontalNodeFlow() {
+	return typeof ANALYSIS_HORIZONTAL_MODE !== "undefined" && ANALYSIS_HORIZONTAL_MODE;
+}
+
 function getNodeOrientation() {
-	const horizontal = typeof ANALYSIS_HORIZONTAL_MODE !== "undefined" && ANALYSIS_HORIZONTAL_MODE;
-	return NODE_ORIENTATIONS[horizontal ? "horizontal" : "vertical"];
+	return NODE_ORIENTATIONS[isHorizontalNodeFlow() ? "horizontal" : "vertical"];
 }
 
 // @jsplumb/browser-ui instance, created in variantgridPipeline.init once #analysis is in the DOM
@@ -924,10 +929,12 @@ function drawCountLegend(nodeCountTypes) {
         }
     }
 
-    // Absolute positioning can sometimes get thrown off after resizing contents
-    const rowHeight = 31;
-    const numRows = 1 + nodeCountTypes.length;
-    legend.height(rowHeight * numRows);
+    if (!isHorizontalNodeFlow()) {
+        // Absolute positioning can sometimes get thrown off after resizing contents
+        const rowHeight = 31;
+        const numRows = 1 + nodeCountTypes.length;
+        legend.height(rowHeight * numRows);
+    }
 }
 
 

--- a/variantgrid/static_files/default_static/js/grid.js
+++ b/variantgrid/static_files/default_static/js/grid.js
@@ -69,6 +69,10 @@ function load_variant_details(variant_id) {
             }
         }
     }
+    // Horizontal mode gives each variant its own closable tab, leaving the node editor where it was
+    if (typeof openVariantDetailsTab === "function" && openVariantDetailsTab(variant_id, variant_details_url)) {
+        return;
+    }
     const editorContainer = $("#node-editor-container");
     editorContainer.html('<div class="editor-loading"><i class="fa fa-spinner"></i> Loading variant details...</div>');
     editorContainer.load(variant_details_url);

--- a/variantgrid/static_files/default_static/js/variant_sample_information.js
+++ b/variantgrid/static_files/default_static/js/variant_sample_information.js
@@ -8,7 +8,8 @@
  * The allele may be created (and linked to the other builds' variants) by the variant details page while
  * this is loading, so we also listen for ALLELE_VARIANTS_EVENT and pick up any variants that turned up.
  */
-const VariantSampleInformation = (function () {
+// var not const - the analysis' variant details tabs load this script again for each variant
+var VariantSampleInformation = (function () {
     // Ordered as the zygosity filter checkboxes are drawn
     const ZYGOSITIES = [
         {code: 'R', label: 'REF'},
@@ -42,6 +43,8 @@ const VariantSampleInformation = (function () {
     ];
     const GRAPH_HEIGHT = 384;
     const ALLELE_VARIANTS_EVENT = "allele-variants-loaded";
+    // Namespaced so re-loading the section (another variant details tab) replaces its document handlers
+    const EVENT_NAMESPACE = ".variantSampleInformation";
 
     let config = null;
     let dataTable = null;
@@ -666,11 +669,14 @@ const VariantSampleInformation = (function () {
         config = cfg;
         createDataTable();
 
+        $(document).off(EVENT_NAMESPACE);
+
         // getOntologyTermLinks makes these as the grid renders, so delegate from the document
-        $(document).on('click', '.ontology-terms-container .collapsed-term', expandCollapsedOntologyTerm);
+        $(document).on('click' + EVENT_NAMESPACE, '.ontology-terms-container .collapsed-term',
+                       expandCollapsedOntologyTerm);
 
         // The allele can be created (linking the other builds' variants) while this section is loading
-        $(document).on(ALLELE_VARIANTS_EVENT, (event, variantIds) => requestVariants(variantIds));
+        $(document).on(ALLELE_VARIANTS_EVENT + EVENT_NAMESPACE, (event, variantIds) => requestVariants(variantIds));
 
         requestVariants(config.variantIds);
         requestVariants(window.alleleVariantIds);  // Allele resolved before we got here, so we missed the event

--- a/variantgrid/templates/default_templates/changelog.html
+++ b/variantgrid/templates/default_templates/changelog.html
@@ -251,6 +251,7 @@
                 </ul>
                 <h4>Analysis</h4>
                 <ul>
+                    <li>#38 - Horizontal mode - nodes flow left to right, variant grid docked full width along the bottom</li>
                     <li>#24 - Analysis nodes redesigned - cards with icons and info chips, clearer source/filter colours</li>
                     <li>#1775 - Somatic classifications - node germline/somatic toggle + tier pills, grid germline/somatic boxes, Tier I/II node count</li>
                     <li>#26, #235 - Node counts record their data sources - exact vs advisory when data may have changed</li>

--- a/variantopedia/templates/variantopedia/variant_details.html
+++ b/variantopedia/templates/variantopedia/variant_details.html
@@ -35,7 +35,13 @@ function analysisLinkRenderer(data, type, row) {
 }
 
 // User's variant_tag_stale_days setting (null = staleness off)
-const VARIANT_TAG_STALE_DAYS = {{ variant_tag_stale_days|jsonify }};
+// var not const - the analysis editor loads this page's scripts into the same document each time
+var VARIANT_TAG_STALE_DAYS = {{ variant_tag_stale_days|jsonify }};
+
+// Opened from an analysis grid - name the tab now we know what the variant is called
+if (typeof setVariantDetailsTabLabel === "function") {
+    setVariantDetailsTabLabel({{ variant.pk }}, {{ variant_short_label|jsonify }});
+}
 
 function tagRenderer(data, type, row) {
     let tagLabel = row.tag;

--- a/variantopedia/views.py
+++ b/variantopedia/views.py
@@ -816,6 +816,8 @@ def variant_details_annotation_version(request, variant_id, annotation_version_i
         "variant": variant,
         "variant_allele": variant_allele_data,
         "variant_annotation": variant_annotation,
+        # Names the analysis' variant details tab, which has no room for a transcript
+        "variant_short_label": variant_annotation.get_short_label() if variant_annotation else str(variant),
         "variant_tag_stale_days": user_settings.variant_tag_stale_days,
         "visible_fields": variant_annotation.visible_columns if variant_annotation else frozenset(),
         "vts": vts,


### PR DESCRIPTION
🤖 Written by Claude

Implements `claude/plans/analysis_layout_rework_plan.md` (design + rationale: `claude/design/analysis_grid_rework.html`) for #38.

A per-analysis **horizontal mode**: nodes flow left→right on a full-width canvas, and the editor/grid panel docks along the bottom at full width. The variant grid stays jqGrid — the DataTables conversion is a separate plan. Vertical remains the default and is unchanged.

## What's in it

**Settings wiring** — `analysis_horizontal_mode` added to `AnalysisForm` (analysis settings) and un-hidden on the user settings form (`get_settings_form_features()` now returns `analysis_enabled`). New analyses inherit the user setting in `set_defaults_and_save`; analyses from a template inherit the template's mode via the existing `analysis.clone()`.

**Mode switch transposes the layout** — changing the mode swaps x/y on every node in the same transaction (`Analysis.transpose_node_positions()`). Swap is self-inverse, so toggling back restores the original layout exactly. No version bump — positions don't affect queries. The settings tab reloads the open analysis page afterwards, since the layout is rendered into the page.

**Page layout** — `analysis.html` renders the same two Split.js panes with `direction: 'vertical'` in horizontal mode, so `analysis_panel_fraction` and `analysis_set_panel_size` are reused as-is. `resizeGrid` now sizes the grid to the panel width (it was passing `NaN` — `innerWidth` without the call) and, in horizontal mode, sets the grid height to fill the pane. It runs on splitter drag-end, grid-tab show and grid load.

**Swap (tabbed bottom pane)** — an `Editor | Grid` strip over the existing `#node-editor-container` / `#node-grid-container`. Container ids and the `registerComponent(EDITOR/GRID)` pairing are untouched; the tabs only control visibility.
- The active tab is sticky while clicking around the graph.
- Saving an editor flips to Grid (hooked into `reloadNodeAndData`), which shows the usual loading states while the node re-computes.
- Toolbar editor content (`analysisSettings()`, `inputSamples()` via `replaceEditorWindow`) flips to Editor.
- **Lazy grid:** while the Grid tab is hidden the row fetch is deferred, reusing the existing `grid_auto_load` machinery (`datatype:'local'` init so `everythingLoaded` still proceeds). Editing a chain of nodes with the Editor tab up issues zero grid queries; the `grid_auto_load_max_variants` placeholder still applies as normal when the tab is shown.

**Drawer (the same editor, undocked)** — `#node-editor-container` is reparented into a ~450px drawer on the right of the canvas, resizable by its left edge, closable by button or Escape. In drawer mode the tab strip is hidden and the grid keeps the whole bottom panel, so a save shows refreshed results with no tab flip. Toggled by an "undock" button on the tab strip and a "dock as tab" button in the drawer header; the choice is persisted in `localStorage` for the comparison period.

**Node canvas** — orientation centralised in one `NODE_ORIENTATIONS` config consumed by `setupConnections` and the jsPlumb instance defaults (vertical `Top`/`Bottom`, horizontal `Left`/`Right`, with the Venn pair spread along the input edge). New/copied nodes are placed at the start of the flow for the orientation.

## Notes / deviations from the plan

- **Element ids:** the two Split panes keep their existing `#left-panel` / `#right-panel` ids in both modes rather than being renamed to `#canvas-row` / `#bottom-panel`. Those ids are referenced from the dual-screen, loading-overlay and panel-persistence code; keeping them meant the structure changes without touching any of that. Horizontal mode is marked by an `.analysis-horizontal` class on `#analysis-and-toolbar-container`.
- **`viewTags()`** keeps the sticky tab rather than forcing the Editor tab — the tags a user asked for are in the grid, not the tag node's editor. Easy to change if you'd rather it match the other two toolbar actions.
- **`analysis_panel_fraction` on a mode switch** is left alone, as the plan specifies it keeps meaning "fraction taken by the node canvas" in both modes. That means an analysis at the 0.25 default gets a 25%-tall canvas the first time it's switched to horizontal, until the splitter is dragged (which persists). Worth a look during the manual pass — flipping it to `1 - fraction` on switch would be self-inverse in the same way the position swap is, and would land near the ~50/50 the mockup shows.
- In horizontal mode the canvas pane scrolls on `#analysis-container` rather than `#left-panel`, so the toolbar and drawer stay pinned while the graph pans.

## Testing

- `python3 manage.py test --keepdb analysis snpdb` — 602 tests pass.
- New: `analysis/tests/test_horizontal_mode.py` (both layouts render; the drawer and tab strip are gated on the flag) and, in `test_models.py`, coverage for the self-inverse position transpose, the form triggering it on a mode change, and new analyses inheriting the user setting.
- Not yet run through the browser — the manual verification pass in §"Verification" of the plan (regression on a vertical analysis, mode toggle round-trip, sticky tabs / zero grid queries with the Editor tab up, drawer undock/redock and Escape, splitter persistence) still needs doing.

## Update: feedback from trying both editors

**One row of tabs.** The node editor had its own tab strip inside the editor, which meant two levels of tabs in Swap mode and a strip that disappeared with the editor. Its tabs are now mirrored into whichever bar is always on screen — the bottom pane strip while docked (`Editor | Grid | Summary | Doc | …`), or the drawer header beside undock/X while undocked (`Editor | Summary | Doc | …`, no Grid tab needed since the grid keeps the panel). The editor's first tab, which shows the node's own form, is labelled "Editor" rather than "Grid" in horizontal mode. Clicking *view* on a Summary or Graph flips to the pane its output lands in. The drawer's "Node editor" title steps aside once the tabs are in its bar.

**Variant details open as closable tabs.** Clicking a variant used to load the details page over the node editor, with no way back. It now opens its own tab with an `×`, after the node tabs in whichever bar is in use. The details page uses page-level ids (`#allele`, `#variant_coordinate`, `#variant-tags-datatable`…) and fills them from its own `$(document).ready`, so two copies in the DOM would fight over them — instead the tabs remember `{variantId, url, label}` and only the tab being read is in the DOM, re-loading when picked (which is all a first open does anyway). Tabs belong to the grid that opened them: selecting a node, saving, or a toolbar action taking over the editor clears them.

Tabs are named by `AbstractVariantAnnotation.get_short_label()` — `RUNX1:p.Ala547Val`, falling back to the c.HGVS, then the change alone, then the variant coordinate. The view passes it to the details page, which names its tab as it loads.

**Variant details could only be loaded once per page.** `VARIANT_TAG_STALE_DAYS` (inline) and `VariantSampleInformation` (in `variant_sample_information.js`) were `const` at script top level, and jQuery re-evaluates a fragment's scripts on every load — the second variant click died with `Identifier … has already been declared`. Both are `var` now, and the samples section's two `$(document)` handlers are namespaced so a re-load replaces them instead of stacking up.

**Node counts legend** moves into the toolbar beside the genome build in horizontal mode, laid out as a single row — the canvas is full width now, so the bottom-left corner it used to sit in is where the flow goes.

**Venn and Merge cards** turn with the flow: the rings stack and the merge glyph points right. The Venn's left input takes the lower endpoint to match the rotation, so clicking a ring still filters the parent it's drawn for.

**Drawer tooltips** were drawn behind the toolbar, which sat at `z-index: 9999` — above Bootstrap's tooltips at `1070`. The toolbar is now `100` and the drawer `200`, both still well clear of the canvas (node cards are 24).

**CLAUDE.md** gains a note that `variantgrid/sitestatic/static/` is collectstatic output and edits belong in `variantgrid/static_files/<site>_static/`.

Tests: `python3 manage.py test --keepdb analysis variantopedia annotation` — 906 pass, including three new cases for `get_short_label()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rcwKA3g1DWVnwZCUP8K1a
