### PR TITLE
Remove duplicate implementations in the analysis app #1799

### DIFF
--- a/analysis/models/nodes/filters/classifications_node.py
+++ b/analysis/models/nodes/filters/classifications_node.py
@@ -7,13 +7,14 @@ from django.db.models import CASCADE, Q
 from analysis.models.enums import NodeMatchInput
 from analysis.models.nodes.analysis_node import AnalysisNode
 from analysis.models.nodes.node_display import NodeChip, NodeIcon, significance_chips
+from analysis.models.nodes.significance_filter_mixin import SignificanceFilterNodeMixin
 from classification.enums import ClinicalSignificance, SomaticClinicalSignificance
 from classification.models.classification import Classification, ClassificationModification
 from snpdb.models import Lab
 from snpdb.models.models_enums import AlleleOriginFilterDefault
 
 
-class ClassificationsNode(AnalysisNode):
+class ClassificationsNode(SignificanceFilterNodeMixin, AnalysisNode):
     node_input = models.CharField(max_length=1, choices=NodeMatchInput.choices,
                                   default=NodeMatchInput.PARENT_MATCHING)
     # Default is to show all
@@ -46,31 +47,6 @@ class ClassificationsNode(AnalysisNode):
         'tier_3': SomaticClinicalSignificance.TIER_3,
         'tier_4': SomaticClinicalSignificance.TIER_4,
     }
-
-    @property
-    def min_inputs(self):
-        return self.max_inputs
-
-    @property
-    def max_inputs(self):
-        if self.node_input == NodeMatchInput.MATCHING_VARIANTS:
-            return 0
-        return 1
-
-    @property
-    def allele_origin_filter(self) -> AlleleOriginFilterDefault:
-        return AlleleOriginFilterDefault(self.allele_origin)
-
-    @property
-    def germline_enabled(self) -> bool:
-        return self.allele_origin_filter != AlleleOriginFilterDefault.SOMATIC
-
-    @property
-    def somatic_enabled(self) -> bool:
-        return self.allele_origin_filter != AlleleOriginFilterDefault.GERMLINE
-
-    def _selected_values(self, field_values: dict[str, str]) -> list[str]:
-        return [value for field, value in field_values.items() if getattr(self, field)]
 
     def _germline_q(self) -> Q:
         q = Q(classification__allele_origin_bucket__in=AlleleOriginFilterDefault.GERMLINE.buckets)

--- a/analysis/models/nodes/filters/clinvar_node.py
+++ b/analysis/models/nodes/filters/clinvar_node.py
@@ -9,6 +9,7 @@ from django.db.models import Q
 from analysis.models.enums import NodeMatchInput
 from analysis.models.nodes.analysis_node import AnalysisNode
 from analysis.models.nodes.node_display import NodeChip, NodeIcon, significance_chips
+from analysis.models.nodes.significance_filter_mixin import SignificanceFilterNodeMixin
 from annotation.models.models_enums import ClinVarOncogenicity, ClinVarPathogenicity, ClinVarReviewStatus
 from classification.enums import SomaticClinicalSignificance
 from snpdb.models.models_enums import AlleleOriginFilterDefault
@@ -73,7 +74,7 @@ SOMATIC_TIER_LABELS = SomaticClinicalSignificance.LABELS | {NO_SOMATIC_TIER: "No
 SOMATIC_TIER_SHORT_LABELS = SomaticClinicalSignificance.SHORT_LABELS | {NO_SOMATIC_TIER: "None"}
 
 
-class ClinVarNode(AnalysisNode):
+class ClinVarNode(SignificanceFilterNodeMixin, AnalysisNode):
     """ What ClinVar says about a variant - every pill on means "has a ClinVar record" """
     node_input = models.CharField(max_length=1, choices=NodeMatchInput.choices,
                                   default=NodeMatchInput.PARENT_MATCHING)
@@ -130,31 +131,6 @@ class ClinVarNode(AnalysisNode):
         'oncogenicity_benign': ClinVarOncogenicity.BENIGN,
         'oncogenicity_none': NO_CLINVAR_CALL,
     }
-
-    @property
-    def min_inputs(self):
-        return self.max_inputs
-
-    @property
-    def max_inputs(self):
-        if self.node_input == NodeMatchInput.MATCHING_VARIANTS:
-            return 0
-        return 1
-
-    @property
-    def allele_origin_filter(self) -> AlleleOriginFilterDefault:
-        return AlleleOriginFilterDefault(self.allele_origin)
-
-    @property
-    def germline_enabled(self) -> bool:
-        return self.allele_origin_filter != AlleleOriginFilterDefault.SOMATIC
-
-    @property
-    def somatic_enabled(self) -> bool:
-        return self.allele_origin_filter != AlleleOriginFilterDefault.GERMLINE
-
-    def _selected_values(self, field_values: dict) -> list:
-        return [value for field, value in field_values.items() if getattr(self, field)]
 
     def _filtering_values(self, field_values: dict) -> list:
         """ A row with every pill on is 'everything ClinVar has', so it applies no filter """

--- a/analysis/models/nodes/significance_filter_mixin.py
+++ b/analysis/models/nodes/significance_filter_mixin.py
@@ -1,0 +1,32 @@
+from analysis.models.enums import NodeMatchInput
+from snpdb.models.models_enums import AlleleOriginFilterDefault
+
+
+class SignificanceFilterNodeMixin:
+    """ Nodes that filter on clinical significance pills, split by allele origin, over either a parent's
+        variants or everything matching. Expects `node_input` and `allele_origin` fields. """
+
+    @property
+    def min_inputs(self):
+        return self.max_inputs
+
+    @property
+    def max_inputs(self):
+        if self.node_input == NodeMatchInput.MATCHING_VARIANTS:
+            return 0
+        return 1
+
+    @property
+    def allele_origin_filter(self) -> AlleleOriginFilterDefault:
+        return AlleleOriginFilterDefault(self.allele_origin)
+
+    @property
+    def germline_enabled(self) -> bool:
+        return self.allele_origin_filter != AlleleOriginFilterDefault.SOMATIC
+
+    @property
+    def somatic_enabled(self) -> bool:
+        return self.allele_origin_filter != AlleleOriginFilterDefault.GERMLINE
+
+    def _selected_values(self, field_values: dict[str, str]) -> list[str]:
+        return [value for field, value in field_values.items() if getattr(self, field)]

--- a/analysis/models/nodes/sources/_family_inheritance.py
+++ b/analysis/models/nodes/sources/_family_inheritance.py
@@ -1,0 +1,153 @@
+"""
+Inheritance filtering shared by TrioNode and QuadNode - everything that doesn't care how many family
+members there are. The per-family bits (which zygosity each member needs) stay in trio_node/quad_node.
+"""
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from cache_memoize import cache_memoize
+from django.db.models import Count
+from django.db.models.query_utils import Q
+
+from annotation.models.models import VariantTranscriptAnnotation
+from library.constants import DAY_SECS
+from patients.models_enums import Sex, Zygosity
+from snpdb.models import Contig
+
+
+def _build_family_zyg_q(cohort_genotype_collection, sample_zyg_require: list[tuple]) -> Q:
+    """Build a zygosity Q for any number of family members.
+
+    Args:
+        cohort_genotype_collection: The CGC to build the Q for.
+        sample_zyg_require: List of (sample, zygosity_set, require_zygosity).
+            Entries with an empty zygosity_set are silently skipped
+            (used for father in X-linked recessive).
+    """
+    sample_zygosities_dict = {}
+    sample_require_zygosity_dict = {}
+    for sample, zyg_set, require in sample_zyg_require:
+        if zyg_set:
+            sample_zygosities_dict[sample] = zyg_set
+            sample_require_zygosity_dict[sample] = require
+    return cohort_genotype_collection.get_zygosity_q(
+        sample_zygosities_dict, sample_require_zygosity_dict
+    )
+
+
+def _dominant_requires_affected_parent_error(mother_affected: bool, father_affected: bool):
+    if not (mother_affected or father_affected):
+        return "Dominant inheritance requires an affected parent"
+    return None
+
+
+def _xlinked_recessive_errors(proband_sample, mother_affected: bool) -> list[str]:
+    errors = []
+    proband_is_female = proband_sample.patient and proband_sample.patient.sex == Sex.FEMALE
+    if proband_is_female:
+        errors.append("X-linked recessive inheritance doesn't currently work with female proband")
+    elif mother_affected:
+        errors.append("X-linked recessive inheritance requires an unaffected mother")
+    return errors
+
+
+class AbstractFamilyInheritance(ABC):
+    """ Do inheritance filtering in subclasses to keep filters/methods consistent """
+    NO_VARIANT = {Zygosity.MISSING, Zygosity.HOM_REF}  # 2 different het would be "missing" (as has no ref)
+    HAS_VARIANT = {Zygosity.HET, Zygosity.HOM_ALT}
+    UNAFFECTED_AND_AFFECTED_ZYGOSITIES = [NO_VARIANT, HAS_VARIANT]
+
+    def __init__(self, node):
+        self.node = node
+
+    @staticmethod
+    def _zygosity_options(zyg: set, allow_unknown=False):
+        if allow_unknown:
+            # Make a new set so as to not alter passed in value
+            zyg = zyg | {Zygosity.UNKNOWN_ZYGOSITY}
+        zyg = zyg - {Zygosity.MISSING}  # Implementation detail - don't show to user
+        return ", ".join(sorted([Zygosity.display(z) for z in zyg]))
+
+    @abstractmethod
+    def get_arg_q_dict(self) -> dict[Optional[str], dict[str, Q]]:
+        pass
+
+    @abstractmethod
+    def get_method(self) -> str:
+        pass
+
+    def get_contigs(self) -> Optional[set[Contig]]:
+        """ None means we don't know """
+        return None
+
+    def get_other_filters_description(self) -> str:
+        """Variant-level filters applied in addition to per-member zygosity.
+
+        Shown in every member row of the "Other Filters" column on the
+        zygosity table. Empty string means no extra filters.
+        """
+        return ""
+
+
+class AbstractCompHetInheritance(AbstractFamilyInheritance):
+    """ Two hits in the same gene, one inherited from each parent. Subclasses supply the per-member
+        zygosities for each side via _mum_but_not_dad/_dad_but_not_mum, and _get_zyg_q from whichever
+        family base they are mixed in with """
+
+    @abstractmethod
+    def _mum_but_not_dad(self) -> tuple[set, ...]:
+        pass
+
+    @abstractmethod
+    def _dad_but_not_mum(self) -> tuple[set, ...]:
+        pass
+
+    @cache_memoize(DAY_SECS, args_rewrite=lambda s: (s.node.pk, s.node.version))
+    def _get_comp_het_q_and_two_hit_genes(self):
+        cgc = self.node._get_cohort().cohort_genotype_collection
+
+        parent = self.node.get_single_parent()
+        mum_but_not_dad = self._get_zyg_q(cgc, self._mum_but_not_dad())
+        dad_but_not_mum = self._get_zyg_q(cgc, self._dad_but_not_mum())
+        comp_het_q = mum_but_not_dad | dad_but_not_mum
+
+        # Need to pass in kwargs in case we have parent (eg Venn node) that doesn't have same cohort annotation kwargs
+        annotation_kwargs = self.node.get_annotation_kwargs()
+
+        # Gene overlaps (not transcript annotation) - a long SV is skipped by VEP so its only
+        # record of the genes it crosses is VariantGeneOverlap @see issue #940
+        def get_parent_genes(q):
+            qs = parent.get_queryset(q, extra_annotation_kwargs=annotation_kwargs)
+            return qs.values_list("variantgeneoverlap__gene", flat=True).distinct()
+
+        # This ends up doing 3 queries (where we call set() - to work out what Q we need to return)
+        common_genes = set(get_parent_genes(mum_but_not_dad)) & set(get_parent_genes(dad_but_not_mum))
+        vav = self.node.analysis.annotation_version.variant_annotation_version
+        q_in_genes = VariantTranscriptAnnotation.get_overlapping_genes_q(vav, common_genes)
+        parent_genes_qs = parent.get_queryset(q_in_genes, extra_annotation_kwargs=annotation_kwargs)
+        parent_genes_qs = parent_genes_qs.values_list("variantgeneoverlap__gene")
+        two_hits = parent_genes_qs.annotate(gene_count=Count("pk")).filter(gene_count__gte=2)
+        two_hit_genes = set(two_hits.values_list("variantgeneoverlap__gene", flat=True).distinct())
+        return comp_het_q, two_hit_genes
+
+    def get_arg_q_dict(self) -> dict[Optional[str], dict[str, Q]]:
+        comp_het_q, two_hit_genes = self._get_comp_het_q_and_two_hit_genes()
+        vav = self.node.analysis.annotation_version.variant_annotation_version
+        comp_het_genes = VariantTranscriptAnnotation.get_overlapping_genes_q(vav, two_hit_genes)
+        cgc = self.node._get_cohort().cohort_genotype_collection
+        q_hash = str(comp_het_q)
+        return {
+            cgc.cohortgenotype_alias: {q_hash: comp_het_q},
+            None: {q_hash: comp_het_genes},
+        }
+
+    def get_contigs(self) -> Optional[set[Contig]]:
+        _, two_hit_genes = self._get_comp_het_q_and_two_hit_genes()
+        contig_qs = Contig.objects.filter(
+            transcriptversion__genome_build=self.node._get_cohort().genome_build,
+            transcriptversion__gene_version__gene__in=two_hit_genes
+        )
+        return set(contig_qs.distinct())
+
+    def get_other_filters_description(self) -> str:
+        return "≥2 hits in same gene, one from mother and one from father"

--- a/analysis/models/nodes/sources/cohort_node.py
+++ b/analysis/models/nodes/sources/cohort_node.py
@@ -49,6 +49,29 @@ class AbstractCohortBasedNode(CohortMixin, AnalysisNode):
             in count_for_zygosity. """
         return [True, True, True, True]
 
+    def _get_cached_label_count(self, label):
+        cohort = self._get_cohort()
+        if cohort is None:
+            return None
+        if self._has_filters_that_affect_label_counts():
+            return None
+        filter_code = self.get_filter_code()
+        if filter_code not in (0, 1):
+            return None
+        handler = get_handler_for_node(self)
+        filter_key = handler.filter_key_for_node(self)
+        if filter_key is UNCACHEABLE:
+            return None
+        return get_cached_label_count_for_cohort(
+            cohort=cohort,
+            sample=None,  # aggregate row
+            filter_key=filter_key,
+            annotation_version=self.analysis.annotation_version,
+            passing_filter=bool(filter_code),
+            zygosities=self._cached_label_count_zygosities(),
+            label=label,
+        )
+
     def _get_q_and_list(self) -> list[Q]:
         q_and = super()._get_q_and_list()
 
@@ -103,28 +126,6 @@ class CohortNode(AbstractCohortBasedNode, AbstractZygosityCountNode):
         if self.accordion_panel != self.COUNT:
             return True
         return False
-
-    def _get_cached_label_count(self, label):
-        if self.cohort is None:
-            return None
-        if self._has_filters_that_affect_label_counts():
-            return None
-        filter_code = self.get_filter_code()
-        if filter_code not in (0, 1):
-            return None
-        handler = get_handler_for_node(self)
-        filter_key = handler.filter_key_for_node(self)
-        if filter_key is UNCACHEABLE:
-            return None
-        return get_cached_label_count_for_cohort(
-            cohort=self.cohort,
-            sample=None,  # aggregate row
-            filter_key=filter_key,
-            annotation_version=self.analysis.annotation_version,
-            passing_filter=bool(filter_code),
-            zygosities=self._cached_label_count_zygosities(),
-            label=label,
-        )
 
     def _get_cohort(self):
         return self.cohort

--- a/analysis/models/nodes/sources/pedigree_node.py
+++ b/analysis/models/nodes/sources/pedigree_node.py
@@ -6,11 +6,6 @@ from django.db.models import Q
 from django.db.models.deletion import SET_NULL
 
 from analysis.models.nodes.sources import AbstractCohortBasedNode
-from analysis.models.nodes.sources._stats_cache import (
-    UNCACHEABLE,
-    get_cached_label_count_for_cohort,
-    get_handler_for_node,
-)
 from analysis.models.nodes.node_display import NodeIcon
 from patients.models_enums import Zygosity
 from pedigree.models import CohortSamplePedFileRecord, Pedigree, PedigreeInheritance
@@ -36,28 +31,6 @@ class PedigreeNode(AbstractCohortBasedNode):
         if super()._has_filters_that_affect_label_counts():
             return True
         return bool(self.inheritance_model)
-
-    def _get_cached_label_count(self, label):
-        if self.pedigree is None:
-            return None
-        if self._has_filters_that_affect_label_counts():
-            return None
-        filter_code = self.get_filter_code()
-        if filter_code not in (0, 1):
-            return None
-        handler = get_handler_for_node(self)
-        filter_key = handler.filter_key_for_node(self)
-        if filter_key is UNCACHEABLE:
-            return None
-        return get_cached_label_count_for_cohort(
-            cohort=self.pedigree.cohort,
-            sample=None,
-            filter_key=filter_key,
-            annotation_version=self.analysis.annotation_version,
-            passing_filter=bool(filter_code),
-            zygosities=self._cached_label_count_zygosities(),
-            label=label,
-        )
 
     def _get_node_arg_q_dict(self) -> dict[Optional[str], dict[str, Q]]:
         cohort, arg_q_dict = self.get_cohort_and_arg_q_dict()

--- a/analysis/models/nodes/sources/quad_node.py
+++ b/analysis/models/nodes/sources/quad_node.py
@@ -1,38 +1,28 @@
 import operator
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from functools import reduce
 from typing import Optional
 
 from auditlog.registry import auditlog
-from cache_memoize import cache_memoize
 from django.db import models
-from django.db.models import Count
 from django.db.models.deletion import SET_NULL
 from django.db.models.query_utils import Q
 
 from analysis.models.enums import AnalysisTemplateType, NodeErrorSource, QuadInheritance
 from analysis.models.nodes.sources import AbstractCohortBasedNode
-from analysis.models.nodes.sources.trio_node import (
-    AbstractTrioInheritance,
+from analysis.models.nodes.sources._family_inheritance import (
+    AbstractCompHetInheritance,
+    AbstractFamilyInheritance,
     _build_family_zyg_q,
     _dominant_requires_affected_parent_error,
     _xlinked_recessive_errors,
 )
 from analysis.models.nodes.node_display import NodeIcon
-from annotation.models.models import VariantTranscriptAnnotation
-from library.constants import DAY_SECS
 from patients.models_enums import Zygosity
 from snpdb.models import Contig, Quad, Sample
 
 
-class AbstractQuadInheritance(ABC):
-    NO_VARIANT = {Zygosity.MISSING, Zygosity.HOM_REF}
-    HAS_VARIANT = {Zygosity.HET, Zygosity.HOM_ALT}
-    UNAFFECTED_AND_AFFECTED_ZYGOSITIES = [NO_VARIANT, HAS_VARIANT]
-
-    def __init__(self, node: 'QuadNode'):
-        self.node = node
-
+class AbstractQuadInheritance(AbstractFamilyInheritance):
     def _get_zyg_q(self, cgc, quad_zyg_data) -> Q:
         """quad_zyg_data = (mum_zyg, dad_zyg, proband_zyg, sibling_zyg)"""
         quad = self.node.quad
@@ -42,25 +32,6 @@ class AbstractQuadInheritance(ABC):
             (quad.proband.sample, quad_zyg_data[2], True),  # 947 - Always require zygosity for Proband
             (quad.sibling.sample, quad_zyg_data[3], self.node.require_sibling_zygosity),
         ])
-
-    @abstractmethod
-    def get_arg_q_dict(self) -> dict[Optional[str], dict[str, Q]]:
-        pass
-
-    @abstractmethod
-    def get_method(self) -> str:
-        pass
-
-    def get_contigs(self) -> Optional[set[Contig]]:
-        return None
-
-    def get_other_filters_description(self) -> str:
-        """Variant-level filters applied in addition to per-member zygosity.
-
-        Shown in every member row of the "Other Filters" column on the
-        zygosity table. Empty string means no extra filters.
-        """
-        return ""
 
 
 class SimpleQuadInheritance(AbstractQuadInheritance):
@@ -159,8 +130,8 @@ class QuadAllRecessive(AbstractQuadInheritance):
         return "XLR branch: Chr X only"
 
 
-class QuadCompHet(AbstractQuadInheritance):
-    """Compound Het for Quad. Same two-pass gene logic as TrioCompHet.
+class QuadCompHet(AbstractCompHetInheritance, AbstractQuadInheritance):
+    """Compound Het for Quad. Same two-pass gene logic as the Trio's CompHet.
 
     TODO: An unaffected sibling having BOTH comp-het hits (one from mum AND one from dad)
     in the same gene is strong evidence against pathogenicity and should be excluded.
@@ -174,55 +145,8 @@ class QuadCompHet(AbstractQuadInheritance):
     def _dad_but_not_mum(self):
         return self.NO_VARIANT, {Zygosity.HET}, {Zygosity.HET}, {Zygosity.HET}
 
-    @cache_memoize(DAY_SECS, args_rewrite=lambda s: (s.node.pk, s.node.version))
-    def _get_comp_het_q_and_two_hit_genes(self):
-        cgc = self.node.quad.cohort.cohort_genotype_collection
-        parent = self.node.get_single_parent()
-        mum_but_not_dad = self._get_zyg_q(cgc, self._mum_but_not_dad())
-        dad_but_not_mum = self._get_zyg_q(cgc, self._dad_but_not_mum())
-        comp_het_q = mum_but_not_dad | dad_but_not_mum
-
-        annotation_kwargs = self.node.get_annotation_kwargs()
-
-        # Gene overlaps (not transcript annotation) - a long SV is skipped by VEP so its only
-        # record of the genes it crosses is VariantGeneOverlap @see issue #940
-        def get_parent_genes(q):
-            qs = parent.get_queryset(q, extra_annotation_kwargs=annotation_kwargs)
-            return qs.values_list("variantgeneoverlap__gene", flat=True).distinct()
-
-        common_genes = set(get_parent_genes(mum_but_not_dad)) & set(get_parent_genes(dad_but_not_mum))
-        vav = self.node.analysis.annotation_version.variant_annotation_version
-        q_in_genes = VariantTranscriptAnnotation.get_overlapping_genes_q(vav, common_genes)
-        parent_genes_qs = parent.get_queryset(q_in_genes, extra_annotation_kwargs=annotation_kwargs)
-        parent_genes_qs = parent_genes_qs.values_list("variantgeneoverlap__gene")
-        two_hits = parent_genes_qs.annotate(gene_count=Count("pk")).filter(gene_count__gte=2)
-        two_hit_genes = set(two_hits.values_list("variantgeneoverlap__gene", flat=True).distinct())
-        return comp_het_q, two_hit_genes
-
-    def get_arg_q_dict(self) -> dict[Optional[str], dict[str, Q]]:
-        comp_het_q, two_hit_genes = self._get_comp_het_q_and_two_hit_genes()
-        vav = self.node.analysis.annotation_version.variant_annotation_version
-        comp_het_genes = VariantTranscriptAnnotation.get_overlapping_genes_q(vav, two_hit_genes)
-        cgc = self.node.quad.cohort.cohort_genotype_collection
-        q_hash = str(comp_het_q)
-        return {
-            cgc.cohortgenotype_alias: {q_hash: comp_het_q},
-            None: {q_hash: comp_het_genes},
-        }
-
     def get_method(self) -> str:
         return "Proband: HET, >=2 hits in gene from (mum OR dad), sibling HET for each hit"
-
-    def get_contigs(self) -> Optional[set[Contig]]:
-        _, two_hit_genes = self._get_comp_het_q_and_two_hit_genes()
-        contig_qs = Contig.objects.filter(
-            transcriptversion__genome_build=self.node.quad.genome_build,
-            transcriptversion__gene_version__gene__in=two_hit_genes
-        )
-        return set(contig_qs.distinct())
-
-    def get_other_filters_description(self) -> str:
-        return "≥2 hits in same gene, one from mother and one from father"
 
 
 class QuadAnyAffected(AbstractQuadInheritance):
@@ -375,7 +299,7 @@ class QuadNode(AbstractCohortBasedNode):
         For modes where affected status matters, includes both affected/unaffected variants.
         """
         from types import SimpleNamespace
-        fmt = AbstractTrioInheritance._zygosity_options
+        fmt = AbstractFamilyInheritance._zygosity_options
         members = ['mother', 'father', 'proband', 'sibling']
         stub_node = SimpleNamespace(quad=SimpleNamespace())
 

--- a/analysis/models/nodes/sources/trio_node.py
+++ b/analysis/models/nodes/sources/trio_node.py
@@ -1,74 +1,28 @@
 import operator
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from functools import reduce
 from typing import Optional
 
 from auditlog.registry import auditlog
-from cache_memoize import cache_memoize
 from django.db import models
-from django.db.models import Count
 from django.db.models.deletion import SET_NULL
 from django.db.models.query_utils import Q
 
 from analysis.models.enums import AnalysisTemplateType, NodeErrorSource, TrioInheritance
 from analysis.models.nodes.sources import AbstractCohortBasedNode
-from analysis.models.nodes.sources._stats_cache import (
-    UNCACHEABLE,
-    get_cached_label_count_for_cohort,
-    get_handler_for_node,
+from analysis.models.nodes.sources._family_inheritance import (
+    AbstractCompHetInheritance,
+    AbstractFamilyInheritance,
+    _build_family_zyg_q,
+    _dominant_requires_affected_parent_error,
+    _xlinked_recessive_errors,
 )
 from analysis.models.nodes.node_display import NodeIcon
-from annotation.models.models import VariantTranscriptAnnotation
-from library.constants import DAY_SECS
-from patients.models_enums import Sex, Zygosity
+from patients.models_enums import Zygosity
 from snpdb.models import Contig, Sample, Trio
 
 
-def _build_family_zyg_q(cohort_genotype_collection, sample_zyg_require: list[tuple]) -> Q:
-    """Build a zygosity Q for any number of family members.
-
-    Args:
-        cohort_genotype_collection: The CGC to build the Q for.
-        sample_zyg_require: List of (sample, zygosity_set, require_zygosity).
-            Entries with an empty zygosity_set are silently skipped
-            (used for father in X-linked recessive).
-    """
-    sample_zygosities_dict = {}
-    sample_require_zygosity_dict = {}
-    for sample, zyg_set, require in sample_zyg_require:
-        if zyg_set:
-            sample_zygosities_dict[sample] = zyg_set
-            sample_require_zygosity_dict[sample] = require
-    return cohort_genotype_collection.get_zygosity_q(
-        sample_zygosities_dict, sample_require_zygosity_dict
-    )
-
-
-def _dominant_requires_affected_parent_error(mother_affected: bool, father_affected: bool):
-    if not (mother_affected or father_affected):
-        return "Dominant inheritance requires an affected parent"
-    return None
-
-
-def _xlinked_recessive_errors(proband_sample, mother_affected: bool) -> list[str]:
-    errors = []
-    proband_is_female = proband_sample.patient and proband_sample.patient.sex == Sex.FEMALE
-    if proband_is_female:
-        errors.append("X-linked recessive inheritance doesn't currently work with female proband")
-    elif mother_affected:
-        errors.append("X-linked recessive inheritance requires an unaffected mother")
-    return errors
-
-
-class AbstractTrioInheritance(ABC):
-    """ Do inheritance filtering in subclasses to keep filters/methods consistent """
-    NO_VARIANT = {Zygosity.MISSING, Zygosity.HOM_REF}  # 2 different het would be "missing" (as has no ref)
-    HAS_VARIANT = {Zygosity.HET, Zygosity.HOM_ALT}
-    UNAFFECTED_AND_AFFECTED_ZYGOSITIES = [NO_VARIANT, HAS_VARIANT]
-
-    def __init__(self, node: 'TrioNode'):
-        self.node = node
-
+class AbstractTrioInheritance(AbstractFamilyInheritance):
     def _get_zyg_q(self, cohort_genotype_collection, trio_zyg_data) -> Q:
         """ trio_zyg_data = tuple of mum_zyg_set, dad_zyg_set, proband_zyg_set """
         trio = self.node.trio
@@ -78,40 +32,12 @@ class AbstractTrioInheritance(ABC):
             (trio.proband.sample, trio_zyg_data[2], True),  # 947 - Always require zygosity for Proband
         ])
 
-    @staticmethod
-    def _zygosity_options(zyg: set, allow_unknown=False):
-        if allow_unknown:
-            # Make a new set so as to not alter passed in value
-            zyg = zyg | {Zygosity.UNKNOWN_ZYGOSITY}
-        zyg = zyg - {Zygosity.MISSING}  # Implementation detail - don't show to user
-        return ", ".join(sorted([Zygosity.display(z) for z in zyg]))
-
     def get_zygosities_method(self, mum_z: set, dad_z: set, proband_z: set):
         proband = self._zygosity_options(proband_z)
         mum = self._zygosity_options(mum_z, not self.node.require_zygosity)
         dad = self._zygosity_options(dad_z, not self.node.require_zygosity)
         filters = {"Proband": proband, "Mother": mum, "Father": dad}
         return ", ".join([f"{k}: {v}" for k, v in filters.items() if v])
-
-    @abstractmethod
-    def get_arg_q_dict(self) -> dict[Optional[str], dict[str, Q]]:
-        pass
-
-    @abstractmethod
-    def get_method(self) -> str:
-        pass
-
-    def get_contigs(self) -> Optional[set[Contig]]:
-        """ None means we don't know """
-        return None
-
-    def get_other_filters_description(self) -> str:
-        """Variant-level filters applied in addition to per-member zygosity.
-
-        Shown in every member row of the "Other Filters" column on the
-        zygosity table. Empty string means no extra filters.
-        """
-        return ""
 
 
 class SimpleTrioInheritance(AbstractTrioInheritance):
@@ -198,51 +124,12 @@ class TrioAllRecessive(AbstractTrioInheritance):
         return "XLR branch: Chr X only"
 
 
-class CompHet(AbstractTrioInheritance):
+class CompHet(AbstractCompHetInheritance, AbstractTrioInheritance):
     def _mum_but_not_dad(self):
         return {Zygosity.HET}, self.NO_VARIANT, {Zygosity.HET}
 
     def _dad_but_not_mum(self):
         return self.NO_VARIANT, {Zygosity.HET}, {Zygosity.HET}
-
-    @cache_memoize(DAY_SECS, args_rewrite=lambda s: (s.node.pk, s.node.version))
-    def _get_comp_het_q_and_two_hit_genes(self):
-        cohort_genotype_collection = self.node.trio.cohort.cohort_genotype_collection
-
-        parent = self.node.get_single_parent()
-        mum_but_not_dad = self._get_zyg_q(cohort_genotype_collection, self._mum_but_not_dad())
-        dad_but_not_mum = self._get_zyg_q(cohort_genotype_collection, self._dad_but_not_mum())
-        comp_het_q = mum_but_not_dad | dad_but_not_mum
-
-        # Need to pass in kwargs in case we have parent (eg Venn node) that doesn't have same cohort annotation kwargs
-        annotation_kwargs = self.node.get_annotation_kwargs()
-
-        # Gene overlaps (not transcript annotation) - a long SV is skipped by VEP so its only
-        # record of the genes it crosses is VariantGeneOverlap @see issue #940
-        def get_parent_genes(q):
-            qs = parent.get_queryset(q, extra_annotation_kwargs=annotation_kwargs)
-            return qs.values_list("variantgeneoverlap__gene", flat=True).distinct()
-
-        # This ends up doing 3 queries (where we call set() - to work out what Q we need to return)
-        common_genes = set(get_parent_genes(mum_but_not_dad)) & set(get_parent_genes(dad_but_not_mum))
-        variant_annotation_version = self.node.analysis.annotation_version.variant_annotation_version
-        q_in_genes = VariantTranscriptAnnotation.get_overlapping_genes_q(variant_annotation_version, common_genes)
-        parent_genes_qs = parent.get_queryset(q_in_genes, extra_annotation_kwargs=annotation_kwargs)
-        parent_genes_qs = parent_genes_qs.values_list("variantgeneoverlap__gene")
-        two_hits = parent_genes_qs.annotate(gene_count=Count("pk")).filter(gene_count__gte=2)
-        two_hit_genes = set(two_hits.values_list("variantgeneoverlap__gene", flat=True).distinct())
-        return comp_het_q, two_hit_genes
-
-    def get_arg_q_dict(self) -> dict[Optional[str], dict[str, Q]]:
-        comp_het_q, two_hit_genes = self._get_comp_het_q_and_two_hit_genes()
-        variant_annotation_version = self.node.analysis.annotation_version.variant_annotation_version
-        comp_het_genes = VariantTranscriptAnnotation.get_overlapping_genes_q(variant_annotation_version, two_hit_genes)
-        cgc = self.node.trio.cohort.cohort_genotype_collection
-        q_hash = str(comp_het_q)
-        return {
-            cgc.cohortgenotype_alias: {q_hash: comp_het_q},
-            None: {q_hash: comp_het_genes},
-        }
 
     def get_method(self) -> str:
         mum1, dad1, _ = self._mum_but_not_dad()
@@ -250,15 +137,6 @@ class CompHet(AbstractTrioInheritance):
         mum2, dad2, _ = self._dad_but_not_mum()
         dad_but_not_mum = self.get_zygosities_method(mum2, dad2, set())
         return f"Proband: HET, and >=2 hits from genes where ({mum_but_not_dad}) OR ({dad_but_not_mum})"
-
-    def get_contigs(self) -> Optional[set[Contig]]:
-        _, two_hit_genes = self._get_comp_het_q_and_two_hit_genes()
-        contig_qs = Contig.objects.filter(transcriptversion__genome_build=self.node.trio.genome_build,
-                                          transcriptversion__gene_version__gene__in=two_hit_genes)
-        return set(contig_qs.distinct())
-
-    def get_other_filters_description(self) -> str:
-        return "≥2 hits in same gene, one from mother and one from father"
 
 
 class TrioAnyAffected(AbstractTrioInheritance):
@@ -351,32 +229,13 @@ class TrioNode(AbstractCohortBasedNode):
         return AbstractCohortBasedNode._has_filters_that_affect_label_counts(self)
 
     def _get_cached_label_count(self, label):
-        if self.trio is None:
-            return None
         # Compound het is the only trio mode that takes a parent (max_inputs=1), and its queryset
-        # is intersected with that parent (uses_parent_queryset). The cohort-wide stats cache below
+        # is intersected with that parent (uses_parent_queryset). The cohort-wide stats cache
         # can't represent the parent restriction, so it would over-count (tripping the single-parent
         # check in node_counts()). Fall back to a real DB count of the parent-intersected queryset.
         if self.has_input():
             return None
-        if self._has_filters_that_affect_label_counts():
-            return None
-        filter_code = self.get_filter_code()
-        if filter_code not in (0, 1):
-            return None
-        handler = get_handler_for_node(self)
-        filter_key = handler.filter_key_for_node(self)
-        if filter_key is UNCACHEABLE:
-            return None
-        return get_cached_label_count_for_cohort(
-            cohort=self.trio.cohort,
-            sample=None,
-            filter_key=filter_key,
-            annotation_version=self.analysis.annotation_version,
-            passing_filter=bool(filter_code),
-            zygosities=self._cached_label_count_zygosities(),
-            label=label,
-        )
+        return super()._get_cached_label_count(label)
 
     def modifies_parents(self):
         return self.trio is not None
@@ -437,7 +296,7 @@ class TrioNode(AbstractCohortBasedNode):
         For modes where affected status matters, includes both affected/unaffected variants.
         """
         from types import SimpleNamespace
-        fmt = AbstractTrioInheritance._zygosity_options
+        fmt = AbstractFamilyInheritance._zygosity_options
         members = ['mother', 'father', 'proband']
         stub_node = SimpleNamespace(trio=SimpleNamespace())
 

--- a/analysis/tests/test_trio_node.py
+++ b/analysis/tests/test_trio_node.py
@@ -177,7 +177,7 @@ class TestTrioNodeInheritance(InheritanceNodeTestsMixin, TestCase):
         single-parent check in node_counts(). Regression for comp-het count > parent count."""
         node = self._make_node(TrioInheritance.COMPOUND_HET)
         with mock.patch(
-                "analysis.models.nodes.sources.trio_node.get_cached_label_count_for_cohort",
+                "analysis.models.nodes.sources.cohort_node.get_cached_label_count_for_cohort",
                 return_value=999999) as m:
             self.assertIsNone(node._get_cached_label_count(BuiltInFilters.TOTAL))
             m.assert_not_called()

--- a/analysis/views/views_grid.py
+++ b/analysis/views/views_grid.py
@@ -32,6 +32,8 @@ from library.django_utils.major_operation import TooManyMajorOperationsError, ma
 from library.utils.hash_utils import sha256sum_str
 from snpdb.models import CachedGeneratedFile, Cohort, Sample
 
+EXPORT_TYPES = {"csv", "vcf"}
+
 # What a node grid request may carry, so the cache key and the export params hash are built off a
 # known set. The DataTables client sends start/length/order (@see translate_datatable_params turning
 # them into rows/page/sidx/sord); the engine's own rows/page/sidx/sord names are here too because
@@ -146,41 +148,40 @@ class NodeGridConfig(NodeJSONGetView):
         return ret
 
 
-def cohort_grid_export(request, cohort_id, export_type):
-    EXPORT_TYPES = {"csv", "vcf"}
-    Cohort.get_for_user(request.user, cohort_id)  # Permission check
+def _check_export_type(export_type: str):
     if export_type not in EXPORT_TYPES:
         raise ValueError(f"{export_type} must be one of: {EXPORT_TYPES}")
 
-    params_hash = get_grid_downloadable_file_params_hash(cohort_id, export_type)
-    task = export_cohort_to_downloadable_file.si(cohort_id, export_type)
-    cgf = CachedGeneratedFile.get_or_create_and_launch("export_cohort_to_downloadable_file", params_hash, task)
+
+def _source_grid_export(request, model, obj_id: int, export_type: str, export_task, generator_name: str):
+    """ Launches (or joins) a Celery export of a source node's whole grid and redirects to the
+        CachedGeneratedFile poll URL. generator_name is stored against the cached file, so it stays put """
+    model.get_for_user(request.user, obj_id)  # Permission check
+    _check_export_type(export_type)
+
+    params_hash = get_grid_downloadable_file_params_hash(obj_id, export_type)
+    task = export_task.si(obj_id, export_type)
+    cgf = CachedGeneratedFile.get_or_create_and_launch(generator_name, params_hash, task)
     if cgf.exception:
         raise ValueError(cgf.exception)
     return redirect(cgf)
+
+
+def cohort_grid_export(request, cohort_id, export_type):
+    return _source_grid_export(request, Cohort, cohort_id, export_type,
+                               export_cohort_to_downloadable_file, "export_cohort_to_downloadable_file")
 
 
 def sample_grid_export(request, sample_id, export_type):
-    EXPORT_TYPES = {"csv", "vcf"}
-    Sample.get_for_user(request.user, sample_id)  # Permission check
-    if export_type not in EXPORT_TYPES:
-        raise ValueError(f"{export_type} must be one of: {EXPORT_TYPES}")
-
-    params_hash = get_grid_downloadable_file_params_hash(sample_id, export_type)
-    task = export_sample_to_downloadable_file.si(sample_id, export_type)
-    cgf = CachedGeneratedFile.get_or_create_and_launch("export_sample_to_downloadable_file", params_hash, task)
-    if cgf.exception:
-        raise ValueError(cgf.exception)
-    return redirect(cgf)
+    return _source_grid_export(request, Sample, sample_id, export_type,
+                               export_sample_to_downloadable_file, "export_sample_to_downloadable_file")
 
 
 def node_grid_export(request, analysis_id):
     """ Launches (or joins) a Celery export and redirects to the CachedGeneratedFile poll URL, so a big
         node isn't bound by the gunicorn request timeout (issue #1257) """
-    EXPORT_TYPES = {"csv", "vcf"}
     export_type = request.GET["export_type"]
-    if export_type not in EXPORT_TYPES:
-        raise ValueError(f"{export_type} must be one of: {EXPORT_TYPES}")
+    _check_export_type(export_type)
 
     # Always export the latest version (node.version below) - deliberately don't check the
     # client's version_id, which goes stale whenever the node is updated, eg a tag delete (#789)


### PR DESCRIPTION
🤖 Written by Claude

Addresses #1799. Net -290 lines, no migration (`makemigrations --check` clean).

### `SignificanceFilterNodeMixin`

`ClassificationsNode` and `ClinVarNode` each carried their own copy of `min_inputs`, `max_inputs`, `allele_origin_filter`, `germline_enabled`, `somatic_enabled` and `_selected_values`. They now share a plain mixin, following `CohortMixin` / `GeneCoverageMixin`. Both keep their own fields, so nothing about the schema moves.

### `_get_cached_label_count` up to `AbstractCohortBasedNode`

`CohortNode`, `PedigreeNode` and `TrioNode` had the same guard chain and the same `get_cached_label_count_for_cohort(...)` call three times over, differing only in how each reached its cohort. The shared version goes through `self._get_cohort()`, which all three already implement for `CohortMixin`. `Pedigree.cohort` and `Trio.cohort` are non-null FKs, so `_get_cohort()` returns None exactly when the old `self.pedigree is None` / `self.trio is None` guards fired.

`TrioNode` keeps the guard that is genuinely its own:

```python
def _get_cached_label_count(self, label):
    # Compound het is the only trio mode that takes a parent ...
    if self.has_input():
        return None
    return super()._get_cached_label_count(label)
```

`SampleNode`'s version is left alone — it is per-sample, computes its zygosities inline and has no `UNCACHEABLE` check, so it is a different function that merely looks similar.

### `_source_grid_export`

`cohort_grid_export` and `sample_grid_export` are now two-line calls into a shared helper, and `node_grid_export` shares the `EXPORT_TYPES` validation. The generator name each cached file is stored under stays passed in explicitly and unchanged, since it is a persisted key.

### `_family_inheritance.py`

A new module for what the trio and quad inheritance hierarchies share:

* `AbstractFamilyInheritance` — the zygosity constants, `__init__`, `_zygosity_options`, the two abstract declarations, `get_contigs` and `get_other_filters_description` (whose six-line docstring was previously copied word for word into `AbstractQuadInheritance`). `AbstractTrioInheritance` and `AbstractQuadInheritance` now extend it and keep only their own `_get_zyg_q` and member-shaped helpers.
* `AbstractCompHetInheritance` — `_get_comp_het_q_and_two_hit_genes`, `get_arg_q_dict`, `get_contigs` and `get_other_filters_description`, which were identical in `CompHet` and `QuadCompHet` apart from reaching the family through `.trio` vs `.quad`. Those go through `_get_cohort()` instead, and each subclass is left with just its zygosity tuples and its own `get_method` text.

The three helpers `quad_node` was already importing from `trio_node` (`_build_family_zyg_q`, `_dominant_requires_affected_parent_error`, `_xlinked_recessive_errors`) moved here too, so there is one shared home rather than one family node importing the other.

Node pks are unique across all node types (multi-table inheritance off `AnalysisNode`), so the two comp-het classes sharing one `cache_memoize`-wrapped function cannot collide on its `(node.pk, node.version)` key.

### Left for another day

* **The rest of the trio/quad inheritance hierarchies.** `Recessive`/`QuadRecessive` and friends look parallel, but the sibling's zygosity varies with affected status in ways the trio has no equivalent for. Merging them means threading 3-vs-4-member tuples through the whole hierarchy for very little saving.
* **`get_zygosity_table_data`.** Structurally parallel but the branches differ per family; a parameterised version would read worse than the two copies, and it is node-editor display data rather than filtering logic.

### Testing

* `manage.py test --keepdb analysis` — 471 tests, OK
* `manage.py test --keepdb snpdb classification annotation pedigree patients` — 1048 tests, OK
* `manage.py check` clean, `makemigrations --check` reports no changes, `ruff` shows no new findings on any changed file
* Verified `CompHet` and `QuadCompHet` have empty `__abstractmethods__` (an abstract `_get_zyg_q` on the comp-het base would have shadowed the concrete family one through the MRO)

One test changed: `test_compound_het_does_not_use_cohort_label_cache` patches `get_cached_label_count_for_cohort` where it is now looked up (`cohort_node` rather than `trio_node`). It still guards the trio-specific `has_input()` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKZV4Gh7ZXRjqx7ibPDTSd
