### PR TITLE
Gene page: classification summary counts #1803

### DIFF
--- a/classification/models/classification_grouping.py
+++ b/classification/models/classification_grouping.py
@@ -1,4 +1,5 @@
 import operator
+from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import cached_property, reduce
 from typing import Optional, Self
@@ -8,7 +9,7 @@ from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import PermissionDenied
 from django.db import models, transaction
-from django.db.models import CASCADE, SET_NULL, IntegerChoices, Q, QuerySet, TextChoices
+from django.db.models import CASCADE, SET_NULL, Count, IntegerChoices, Q, QuerySet, TextChoices
 from django.urls import reverse
 from django_extensions.db.models import TimeStampedModel
 from frozendict import frozendict
@@ -28,7 +29,7 @@ from classification.models.evidence_mixin_summary_cache import (
     ClassificationSummaryCacheDictSomatic,
 )
 from genes.models import GeneSymbol
-from library.utils import strip_json
+from library.utils import JsonDataType, strip_json
 from ontology.models import OntologyTerm
 from snpdb.models import Allele, Lab
 
@@ -196,6 +197,31 @@ class AlleleOriginGrouping(TimeStampedModel):
 #                 by_status[key] = ClassificationSubGrouping(latest_modification=mod, count=1)
 #         # FIXME sort
 #         return list(by_status.values())
+
+
+@dataclass(frozen=True)
+class ClassificationGroupingCount:
+    """ How many groupings sit at a single clinical significance value - for the summary above a grouping grid """
+    clinical_significance: Optional[str]
+    count: int
+
+    @property
+    def label(self) -> str:
+        e_key = EvidenceKeyMap.cached_key(SpecialEKeys.CLINICAL_SIGNIFICANCE)
+        return e_key.pretty_value(self.clinical_significance) or "No Data"
+
+    @property
+    def css_class(self) -> str:
+        """ Class for the .c-pill.cs-* rules in global.scss """
+        return f"cs-{self.clinical_significance.lower()}" if self.clinical_significance else "cs-none"
+
+    def to_json(self) -> JsonDataType:
+        return {
+            "clinical_significance": self.clinical_significance,
+            "label": self.label,
+            "css_class": self.css_class,
+            "count": self.count
+        }
 
 
 class ClassificationGroupingPathogenicDifference(IntegerChoices):
@@ -469,6 +495,32 @@ class ClassificationGrouping(TimeStampedModel):
         else:
             # there are no classifications, time to die
             self.delete()
+
+    VUS_SUB_VALUES = frozenset({"VUS_A", "VUS_B", "VUS_C"})
+
+    @staticmethod
+    def clinical_significance_counts(qs: QuerySet['ClassificationGrouping']) -> list['ClassificationGroupingCount']:
+        """
+        Counts groupings by the clinical significance of their latest classification, VUS sub-levels merged into VUS.
+        Ordered by the evidence key's option order, with values it doesn't know about (and No Data) last.
+        :param qs: Groupings to summarise - already filtered for the user
+        """
+        clin_sig_column = "latest_classification_modification__classification__summary__pathogenicity__classification"
+        counts: dict[Optional[str], int] = defaultdict(int)
+        # some filters (e.g. protein position) join through variants, so only count each grouping once
+        for row in qs.order_by().values(clin_sig_column).annotate(count=Count("pk", distinct=True)):
+            clinical_significance = row[clin_sig_column]
+            if clinical_significance in ClassificationGrouping.VUS_SUB_VALUES:
+                clinical_significance = "VUS"
+            counts[clinical_significance] += row["count"]
+
+        def sort_key(grouping_count: ClassificationGroupingCount):
+            sort_order = classification_sort_order(grouping_count.clinical_significance)
+            return not sort_order, sort_order, grouping_count.label
+
+        return sorted(
+            (ClassificationGroupingCount(clinical_significance=clin_sig, count=count) for clin_sig, count in counts.items()),
+            key=sort_key)
 
     def gene_symbols(self):
         terms = set(self.classificationgroupingsearchterm_set.filter(term_type=ClassificationGroupingSearchTermType.GENE_SYMBOL).values_list("term", flat=True))

--- a/classification/templates/classification/tags/classification_groupings.html
+++ b/classification/templates/classification/tags/classification_groupings.html
@@ -7,13 +7,33 @@
 
     function classificationGroupingRedraw() {
         $('#vc-datatable').DataTable().ajax.reload();
+        classificationGroupingSummaryLoad();
     }
     var debounceClassificationGroupingRedraw = debounce(classificationGroupingRedraw);
+
+    function classificationGroupingSummaryLoad() {
+        let summary = $('#classification-grouping-summary');
+        if (!summary.length) {
+            return;
+        }
+        let data = {};
+        classificationGroupingFilter(data);
+        $.getJSON("{% url 'classification_grouping_counts' %}", data, (response) => {
+            summary.empty();
+            for (let entry of response.counts) {
+                $('<div>', {class: 'summary-count'})
+                    .append($('<span>', {class: 'c-pill cs ' + entry.css_class, text: entry.label}))
+                    .append($('<span>', {class: 'count', text: entry.count.toLocaleString()}))
+                    .appendTo(summary);
+            }
+        });
+    }
 
     $(document).ready(() => {
         $('.filter').on("change", function() {
             classificationGroupingRedraw();
         });
+        $('#vc-datatable').on('init.dt', classificationGroupingSummaryLoad);
     });
 
     function classificationGroupingFilter(data) {
@@ -53,6 +73,9 @@
                 <div class="mr-2 mt-1">Allele Origin</div>
                 {% allele_origin_toggle show_label=False %}
             </div>
+        {% endif %}
+        {% if show_summary_counts %}
+            <div id="classification-grouping-summary" class="classification-grouping-summary"></div>
         {% endif %}
         <table id="vc-datatable" data-datatable-data='classificationGroupingFilter' data-datatable-url="{% url 'classification_grouping_datatables' %}?genome_build={{ genome_build.pk }}" class="sticky-header classification-table"></table>
         <div>

--- a/classification/templatetags/classification_tags.py
+++ b/classification/templatetags/classification_tags.py
@@ -167,7 +167,7 @@ def classification_groups(
 
 
 @register.inclusion_tag("classification/tags/classification_groupings.html", takes_context=True)
-def classification_groupings(context, show_allele_origin_filter=True):
+def classification_groupings(context, show_allele_origin_filter=True, show_summary_counts=False):
     """
     Shows the new database based classification grouping table. To filter the data implement a JavaScript method on the page
     <script>
@@ -176,8 +176,14 @@ def classification_groupings(context, show_allele_origin_filter=True):
         }
     </script>
     :param show_allele_origin_filter: True by default, set to False to hardcode the filtering to all records
+    :param show_summary_counts: Set to True to show clinical significance counts above the table, worth it where the
+    table can run to many rows
     """
-    return {"show_allele_origin_filter": show_allele_origin_filter, "genome_build": GenomeBuildManager.get_current_genome_build()}
+    return {
+        "show_allele_origin_filter": show_allele_origin_filter,
+        "show_summary_counts": show_summary_counts,
+        "genome_build": GenomeBuildManager.get_current_genome_build()
+    }
 
 
 def render_ekey(val, key: Optional[str] = None, value_if_none: Optional[str] = None):

--- a/classification/tests/models/test_classification_grouping.py
+++ b/classification/tests/models/test_classification_grouping.py
@@ -1,0 +1,59 @@
+from typing import Optional
+
+from django.test import TestCase
+
+from classification.enums import AlleleOriginBucket, ShareLevel, SubmissionSource
+from classification.models import (
+    AlleleGrouping,
+    AlleleOriginGrouping,
+    Classification,
+    ClassificationGrouping,
+    ClassificationModification,
+)
+from classification.tests.models.test_utils import ClassificationTestUtils
+from snpdb.models import Allele
+
+
+class ClassificationGroupingCountsTestCase(TestCase):
+
+    def setUp(self):
+        ClassificationTestUtils.setUp()
+        self.lab, self.user = ClassificationTestUtils.lab_and_user()
+        self.record_count = 0
+
+    def _grouping(self, clinical_significance: Optional[str]) -> ClassificationGrouping:
+        self.record_count += 1
+        allele_origin_grouping = AlleleOriginGrouping.objects.create(
+            allele_grouping=AlleleGrouping.objects.create(allele=Allele.objects.create()),
+            allele_origin_bucket=AlleleOriginBucket.GERMLINE
+        )
+        classification = Classification.objects.create(
+            lab=self.lab,
+            user=self.user,
+            lab_record_id=f"test_{self.record_count}",
+            summary={"pathogenicity": {"classification": clinical_significance}}
+        )
+        modification = ClassificationModification.objects.create(
+            classification=classification,
+            user=self.user,
+            source=SubmissionSource.API,
+            is_last_published=True
+        )
+        return ClassificationGrouping.objects.create(
+            allele_origin_grouping=allele_origin_grouping,
+            lab=self.lab,
+            allele_origin_bucket=AlleleOriginBucket.GERMLINE,
+            share_level=ShareLevel.ALL_USERS,
+            latest_classification_modification=modification
+        )
+
+    def test_vus_sub_levels_merge_and_no_data_sorts_last(self):
+        for clinical_significance in ["P", "B", "VUS", "VUS_A", "VUS_B", None]:
+            self._grouping(clinical_significance)
+
+        counts = ClassificationGrouping.clinical_significance_counts(ClassificationGrouping.objects.all())
+        self.assertEqual([(count.clinical_significance, count.count) for count in counts],
+                         [("B", 1), ("VUS", 3), ("P", 1), (None, 1)])
+        self.assertEqual([count.css_class for count in counts],
+                         ["cs-b", "cs-vus", "cs-p", "cs-none"])
+        self.assertEqual(counts[-1].label, "No Data")

--- a/classification/tests/utils/test_urls.py
+++ b/classification/tests/utils/test_urls.py
@@ -110,6 +110,7 @@ class Test(URLTestCase):
         URL_NAMES_AND_KWARGS = [
             ("classifications", {}, 200),
             ("classification_groupings", {}, 200),
+            ("classification_grouping_counts", {}, 200),
             ("export_classifications_grid", {}, 200),
             ("export_classifications_grid_redcap", {}, 200),
             ("redcap_data_dictionary", {}, 200),

--- a/classification/urls.py
+++ b/classification/urls.py
@@ -18,7 +18,10 @@ from classification.views.classification_email_view import (
     summary_email_preview_text,
 )
 from classification.views.classification_export_view import ClassificationApiExportView
-from classification.views.classification_grouping_datatables import ClassificationGroupingColumns
+from classification.views.classification_grouping_datatables import (
+    ClassificationGroupingColumns,
+    ClassificationGroupingCountsView,
+)
 from classification.views.classification_overlaps_view import (
     post_clinical_context,
     view_clinical_context,
@@ -264,6 +267,7 @@ urlpatterns = [
     path('api/classifications/export', ClassificationApiExportView.as_view(), name='classification_export_api'),
     path('api/classifications/datatables/', DatabaseTableView.as_view(column_class=ClassificationColumns), name='classification_datatables'),
     path('api/classification/groups/datatables/', DatabaseTableView.as_view(column_class=ClassificationGroupingColumns), name='classification_grouping_datatables'),
+    path('api/classification/groups/counts/', ClassificationGroupingCountsView.as_view(), name='classification_grouping_counts'),
     path('api/classification/allele_groups/datatables/<str:lab_id>', DatabaseTableView.as_view(column_class=AlleleGroupingColumns), name='allele_grouping_datatables'),
 
     path('api/classifications/gene_counts/<lab_id>', LabGeneClassificationCountsView.as_view(),

--- a/classification/views/classification_grouping_datatables.py
+++ b/classification/views/classification_grouping_datatables.py
@@ -6,6 +6,9 @@ from django.conf import settings
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest
 from more_itertools import first
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from classification.enums import (
     AlleleOriginBucket,
@@ -455,3 +458,16 @@ class ClassificationGroupingColumns(DatatableConfig[ClassificationGrouping]):
                 default_sort=SortOrder.DESC
             )
         ]
+
+
+class ClassificationGroupingCountsView(APIView):
+    """
+    Clinical significance counts for exactly the rows the grouping datatable would return, so the summary above
+    a grid stays in step with the filters applied to it.
+    """
+
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        columns = ClassificationGroupingColumns(request)
+        qs = columns.filter_queryset(columns.get_initial_queryset())
+        counts = ClassificationGrouping.clinical_significance_counts(qs)
+        return Response({"counts": [count.to_json() for count in counts]})

--- a/genes/templates/genes/view_gene_symbol.html
+++ b/genes/templates/genes/view_gene_symbol.html
@@ -444,7 +444,7 @@
             {% endmodal %}
         {% endif %}
 
-        {% classification_groupings %}
+        {% classification_groupings show_summary_counts=True %}
     </div>
     <div class="container">
         {% if show_annotation %}

--- a/variantgrid/static_files/default_static/css/global.css
+++ b/variantgrid/static_files/default_static/css/global.css
@@ -2803,6 +2803,32 @@ a .c-hgvs-body .c-hgvs-nomen {
   opacity: 0.5;
 }
 
+.classification-grouping-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.classification-grouping-summary .summary-count {
+  display: flex;
+  align-items: stretch;
+  white-space: nowrap;
+}
+.classification-grouping-summary .summary-count .c-pill {
+  width: auto;
+  min-width: 90px;
+  border-radius: 6px 0 0 6px;
+}
+.classification-grouping-summary .summary-count .count {
+  padding: 4px 10px;
+  border: 1px solid #ddd;
+  border-left: none;
+  border-radius: 0 6px 6px 0;
+  background-color: #fafafa;
+  color: #555;
+  font-weight: 600;
+}
+
 .cs-card {
   text-align: center;
   padding: 0 10px 16px 10px;

--- a/variantgrid/static_files/default_static/css/global.scss
+++ b/variantgrid/static_files/default_static/css/global.scss
@@ -3276,6 +3276,36 @@ a .c-hgvs-body {
 	}
 }
 
+// Clinical significance counts above a classification grouping grid
+.classification-grouping-summary {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-bottom: 8px;
+
+	.summary-count {
+		display: flex;
+		align-items: stretch;
+		white-space: nowrap;
+
+		.c-pill {
+			width: auto;
+			min-width: 90px;
+			border-radius: 6px 0 0 6px;
+		}
+
+		.count {
+			padding: 4px 10px;
+			border: 1px solid #ddd;
+			border-left: none;
+			border-radius: 0 6px 6px 0;
+			background-color: #fafafa;
+			color: #555;
+			font-weight: 600;
+		}
+	}
+}
+
 .cs-card {
 	text-align: center;
 	padding: 0 10px 16px 10px;


### PR DESCRIPTION
🤖 Written by Claude

Adds a clinical significance summary row above the classification groupings grid on the gene symbol page, for #1803.

### Decisions on the issue's open question

- **What's counted:** groupings (ie grid rows), using each grouping's `latest_classification_modification`. So the summary counts the same units as the rows below it.
- **Granularity:** clinical significance values (Benign / Likely Benign / VUS / Likely Pathogenic / Pathogenic, plus Oncogenic, Drug Response etc where present), with VUS_A/VUS_B/VUS_C merged into VUS. No Data sorts last.
- **Allele origin:** the counts follow the page's germline/somatic toggle, via an endpoint rather than a static server-rendered row.

### How it works

`ClassificationGroupingCountsView` instantiates `ClassificationGroupingColumns` and runs `filter_queryset(get_initial_queryset())` — the grid's own filter pipeline. The summary therefore matches whatever the table is showing: `filter_for_user` share levels, gene symbol (including aliases), the allele origin toggle, lab, and the hotspot graph's protein position filter. `ClassificationGrouping.clinical_significance_counts()` then does a single grouped query over `summary__pathogenicity__classification`, counting distinct groupings since the protein position filter joins through variants.

The summary reloads on `init.dt` and on every `classificationGroupingRedraw()`. It's opt-in per page: `{% classification_groupings show_summary_counts=True %}`, enabled on the gene symbol page only.

### Note on auth

`PUBLIC_PATHS` exempts `^/classification/api/.*` from `GlobalLoginRequiredMiddleware`, so a plain Django `View` there would be anonymously reachable. The new endpoint is a DRF `APIView` and picks up `IsAuthenticated` (401 for anonymous, confirmed against a running server).

### Testing

- New `classification/tests/models/test_classification_grouping.py` — VUS sub-level merging, evidence-key ordering, No Data last.
- The endpoint added to the classification URL tests.
- Ran against a dev database over HTTP: gene page renders the summary container; `?gene_symbol=CFTR` returns the filtered counts vs the unfiltered set; anonymous request returns 401.
- Pylint clean on the changed files.

Not visually checked in a browser — chromium wouldn't launch on this box (missing `libatk-1.0.so.0`). The new CSS is a flexbox row of `.c-pill` chips with a count appended; worth an eye before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKZV4Gh7ZXRjqx7ibPDTSd
