### PR TITLE
Read HPO's 2023 phenotype_to_genes.txt and backfill HPO to gene relations #1862

### DIFF
--- a/claude/plans/1862_hpo_phenotype_to_genes_format_plan.md
+++ b/claude/plans/1862_hpo_phenotype_to_genes_format_plan.md
@@ -1,7 +1,7 @@
 # #1862 — HPO terms not pulling associated genes
 
 Written by Claude Fable 5.1 (claude-fable-5-1), 2026-09-11
-Status: draft
+Status: in progress - implemented; backfill reuses the latest version's import (no new OntologyVersion) rather than step 4's fresh import
 
 [#1862](https://github.com/SACGF/variantgrid/issues/1862): every HPO term on a phenotype node warns "have no
 associated genes" and the node passes all variants through.

--- a/claude/research/ontology.md
+++ b/claude/research/ontology.md
@@ -36,7 +36,13 @@ per (term, other term) in priority order (exact, related, xref - one edge per pa
 traversal), and axioms and edges become `is_a` edges between MONDO terms and gene edges to HGNC nodes named by the RO
 relations in `GENE_RELATIONS`. `load_hpo` reads hp.owl through pronto for terms and
 `is_a` edges; `load_phenotype_to_genes` reads HPO's phenotype_to_genes.txt for HPO->OMIM associations and
-OMIM->gene `mim2gene` edges, deleting the relations of the older `OMIM_ALL_FREQUENCIES` file it replaced. `load_omim`
+OMIM->gene `mim2gene` edges, deleting the relations of the older `OMIM_ALL_FREQUENCIES` file it replaced. HPO changed
+that file in 2023 from seven columns behind a `#Format:` comment (`source` column, `mim2gene` rows kept) to five columns
+with a header row (`disease_id`, OMIM rows kept); the loader tells them apart by the first line and raises if the frame
+comes out empty, because the 2023 file once imported as zero relations and left every HPO term without genes (#1862).
+`ontology/management/commands/backfill_phenotype_to_genes.py` repairs such a deployment in place: it loads the file
+into the import the latest `OntologyVersion` already points at (`OntologyBuilder(existing_import=...)`), so no new
+version or gene annotation build follows. `load_omim`
 reads mimTitles.txt as the primary source for OMIM names and aliases and marks gene and removed entries
 `NON_CONDITION`; deployments without an OMIM licence use `load_biomart` instead, which fills the same terms from
 Ensembl BioMart's morbid descriptions. `sync_hgnc` mirrors the genes app's HGNC table into HGNC terms (previous

--- a/ontology/management/commands/backfill_phenotype_to_genes.py
+++ b/ontology/management/commands/backfill_phenotype_to_genes.py
@@ -1,0 +1,67 @@
+"""
+Backfill HPO -> OMIM -> gene relations into the latest OntologyVersion's phenotype_to_genes import (#1862).
+
+HPO changed phenotype_to_genes.txt to a five column format in 2023 and the loader silently imported nothing from
+it, so phenotype nodes found no genes for any HPO term. Rather than importing afresh (a new OntologyImport means a
+new OntologyVersion, annotation sub-version and gene annotation build), this writes the relations into the import
+the latest version already points at. Downloads the current file from HPO when --phenotype_to_genes is not given.
+"""
+import tempfile
+from pathlib import Path
+
+import requests
+from django.core.management import BaseCommand
+
+from library.constants import MINUTE_SECS
+from ontology.management.commands.ontology_import import load_phenotype_to_genes
+from ontology.models import OntologyTermRelation, OntologyVersion
+
+PHENOTYPE_TO_GENES_URL = "http://purl.obolibrary.org/obo/hp/hpoa/phenotype_to_genes.txt"
+
+
+def phenotype_to_genes_import_is_empty(ontology_version: OntologyVersion) -> bool:
+    return not OntologyTermRelation.objects.filter(from_import_id=ontology_version.hp_phenotype_to_genes_import_id).exists()
+
+
+def download_phenotype_to_genes(directory: str) -> str:
+    filename = Path(directory) / Path(PHENOTYPE_TO_GENES_URL).name
+    print(f"Downloading {PHENOTYPE_TO_GENES_URL}")
+    with requests.get(PHENOTYPE_TO_GENES_URL, stream=True, timeout=5 * MINUTE_SECS) as r:
+        r.raise_for_status()
+        with open(filename, "wb") as f:
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                f.write(chunk)
+    return str(filename)
+
+
+class Command(BaseCommand):
+    category = "maintenance"
+
+    def add_arguments(self, parser):
+        parser.add_argument('--phenotype_to_genes', required=False,
+                            help="phenotype_to_genes.txt to load (downloaded from HPO if not given)")
+        parser.add_argument('--force', action="store_true",
+                            help="Backfill even if the latest version's import already has relations")
+
+    def handle(self, *args, **options):
+        ontology_version = OntologyVersion.objects.order_by("pk").last()
+        if ontology_version is None:
+            print("No OntologyVersion - import the ontology first (see annotation page)")
+            return
+
+        ontology_import = ontology_version.hp_phenotype_to_genes_import
+        if not (options["force"] or phenotype_to_genes_import_is_empty(ontology_version)):
+            print(f"{ontology_version} {ontology_import} already has relations - nothing to do (use --force to reload)")
+            return
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            filename = options["phenotype_to_genes"] or download_phenotype_to_genes(tmp_dir)
+            print(f"Backfilling {ontology_import} from {filename}")
+            load_phenotype_to_genes(filename, force=True, existing_import=ontology_import)
+
+        num_relations = OntologyTermRelation.objects.filter(from_import=ontology_import).count()
+        print(f"{ontology_import} now has {num_relations} relations.")
+        print("Phenotype nodes cache 'no genes' lookups per term for a day (cached_gene_symbols_for_terms_tuple), "
+              "so a term viewed before the backfill may keep its warning until then.")
+        print("Gene annotation HPO/OMIM columns for this ontology version were built without them; rebuild with:")
+        print("python3 manage.py gene_annotation --latest-releases --force")

--- a/ontology/management/commands/ontology_import.py
+++ b/ontology/management/commands/ontology_import.py
@@ -357,20 +357,43 @@ def load_hpo(filename: str, force: bool):
     logging.info("Committing...")
 
 
-def load_phenotype_to_genes(filename: str, force: bool):
+def _read_phenotype_to_genes(filename: str) -> pd.DataFrame:
+    """ HPO changed phenotype_to_genes.txt in 2023 from seven columns behind a '#Format:' comment line to five
+        columns with a header row. Both are read to the same frame, keeping only OMIM diseases (which is what the
+        old file's `source == mim2gene` meant); ORPHA rows are dropped as ORPHA terms are not stored locally. """
+    with open(filename, encoding="utf-8") as f:
+        old_format = f.readline().startswith("#")
+
+    if old_format:
+        df = pd.read_csv(filename, index_col=None, comment='#', sep='\t',
+                         names=['hpo_id', 'hpo_name', 'entrez_gene_id', 'entrez_gene_symbol', 'status', 'source',
+                                'omim_id'])
+        df = df[df.source.isin(["mim2gene"])]
+    else:
+        df = pd.read_csv(filename, index_col=None, header=0, sep='\t')
+        df = df.rename(columns={"ncbi_gene_id": "entrez_gene_id",
+                                "gene_symbol": "entrez_gene_symbol",
+                                "disease_id": "omim_id"})
+    df = df[df.omim_id.str.startswith(f"{OntologyService.OMIM}:", na=False)]
+    if df.empty:
+        raise ValueError(f"{filename} has no HPO/OMIM/gene rows - unrecognised phenotype_to_genes.txt format?")
+    return df
+
+
+def load_phenotype_to_genes(filename: str, force: bool, existing_import: Optional[OntologyImport] = None):
+    """ existing_import: backfill into that import's partition rather than creating a new import - so the
+        OntologyVersion pointing at it gains the relations without a new version (@see backfill_phenotype_to_genes) """
     ontology_builder = OntologyBuilder(
         filename=filename,
         context="phenotype_to_genes",
         import_source=OntologyImportSource.HPO,
-        processor_version=1,
-        force_update=force)
+        processor_version=2,
+        force_update=force,
+        existing_import=existing_import)
     file_hash = file_md5sum(filename)
     ontology_builder.ensure_hash_changed(data_hash=file_hash)  # don't re-import if hash hasn't changed
     ontology_builder.cache_everything()
-    df = pd.read_csv(filename, index_col=None, comment='#', sep='\t',
-                     names=['hpo_id', 'hpo_name', 'entrez_gene_id', 'entrez_gene_symbol', 'status', 'source', 'omim_id'])
-
-    df = df[df.source.isin(["mim2gene"])]
+    df = _read_phenotype_to_genes(filename)
 
     # first kill of old data
     old_imports = OntologyImport.objects.filter(filename="OMIM_ALL_FREQUENCIES_diseases_to_genes_to_phenotypes.txt")

--- a/ontology/migrations/0028_backfill_phenotype_to_genes.py
+++ b/ontology/migrations/0028_backfill_phenotype_to_genes.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+from manual.operations.manual_operations import ManualOperation
+
+
+def _latest_phenotype_to_genes_import_has_no_relations(apps):
+    """ The 2023 phenotype_to_genes.txt format imported as zero relations, so no HPO term reached a gene
+        @see https://github.com/SACGF/variantgrid/issues/1862 """
+    OntologyVersion = apps.get_model("ontology", "OntologyVersion")
+    OntologyTermRelation = apps.get_model("ontology", "OntologyTermRelation")
+    if ontology_version := OntologyVersion.objects.order_by("pk").last():
+        return not OntologyTermRelation.objects.filter(
+            from_import_id=ontology_version.hp_phenotype_to_genes_import_id).exists()
+    return False
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ontology', '0027_alter_ontologyterm_ontology_service'),
+        ('manual', '0003_manualgatesatisfied_manualmigrationtask_requires'),
+    ]
+
+    operations = [
+        ManualOperation.operation_manage(["backfill_phenotype_to_genes"],
+                                         note="Latest OntologyVersion has no HPO -> OMIM -> gene relations; downloads "
+                                              "phenotype_to_genes.txt and loads it into the existing import (#1862)",
+                                         test=_latest_phenotype_to_genes_import_has_no_relations),
+    ]

--- a/ontology/ontology_builder.py
+++ b/ontology/ontology_builder.py
@@ -82,13 +82,16 @@ class CachedObj(Generic[T]):
 
 class OntologyBuilder:
 
-    def __init__(self, filename: str, context: str, import_source: str, processor_version: int = 1, force_update: bool = False, versioned: bool = True):
+    def __init__(self, filename: str, context: str, import_source: str, processor_version: int = 1, force_update: bool = False, versioned: bool = True,
+                 existing_import: Optional[OntologyImport] = None):
         """
         :filename: Name of the resource used, only used for logging purposes
         :context: In what context are we inserting records (e.g. full file context, or partial panel app)
         :ontology_service: Service that sources this data, but import is not restricted to this service
         :force_update: If true, the ensure methods don't raise exceptions
         :versioned: Does the import exist outside of versions (e.g. PanelAppAU that does incremental version updates should have it as False)
+        :existing_import: Write into this OntologyImport (and its relation partition) instead of creating a new one -
+                          for backfilling an import an OntologyVersion already points at, without a new version
         """
         self.start = datetime.now()
         self.filename = filename if ':' in filename else filename.split("/")[-1]
@@ -98,6 +101,7 @@ class OntologyBuilder:
         self.data_hash = None
         self.force_update = force_update
         self.versioned = versioned
+        self.existing_import = existing_import
 
         self.previous_import: Optional[OntologyImport] = OntologyImport.objects.filter(import_source=import_source, context=context, completed=True).order_by('-modified').first()
         if self.previous_import and self.previous_import.processor_version != self.processor_version:
@@ -294,6 +298,12 @@ class OntologyBuilder:
 
     @cached_property
     def _ontology_import(self) -> OntologyImport:
+        if self.existing_import:
+            self.existing_import.processed_date = now
+            self.existing_import.processor_version = self.processor_version
+            self.existing_import.hash = self.data_hash
+            self.existing_import.save()
+            return self.existing_import
         return OntologyImport.objects.create(
             import_source=self.import_source,
             context=self.context,

--- a/ontology/tests/test_data/phenotype_to_genes.txt
+++ b/ontology/tests/test_data/phenotype_to_genes.txt
@@ -1,0 +1,13 @@
+hpo_id	hpo_name	ncbi_gene_id	gene_symbol	disease_id
+HP:0001507	Growth abnormality	593	BCKDHA	OMIM:248600
+HP:0001507	Growth abnormality	594	BCKDHB	OMIM:248600
+HP:0001507	Growth abnormality	4221	MEN1	OMIM:131100
+HP:0001507	Growth abnormality	8029	CUBN	ORPHA:35858
+HP:0004323	Abnormality of body weight	593	BCKDHA	OMIM:248600
+HP:0004323	Abnormality of body weight	8029	CUBN	OMIM:261100
+HP:0004323	Abnormality of body weight	81693	AMN	OMIM:261100
+HP:0004323	Abnormality of body weight	4221	MEN1	ORPHA:652
+HP:0002925	Increased circulating thyroid-stimulating hormone concentration	4221	MEN1	OMIM:131100
+HP:0002925	Increased circulating thyroid-stimulating hormone concentration	8029	CUBN	OMIM:261100
+HP:0001657	Prolonged QT interval	861	RUNX1	OMIM:601399
+HP:0001657	Prolonged QT interval	861	RUNX1	ORPHA:71290

--- a/ontology/tests/test_data_ontology.py
+++ b/ontology/tests/test_data_ontology.py
@@ -4,9 +4,24 @@ from pathlib import Path
 from django.conf import settings
 from django.utils import timezone
 
+from genes.models import GeneSymbol
 from ontology.management.commands import ontology_import
-from ontology.models import OntologyImport, OntologyVersion
+from ontology.models import OntologyImport, OntologyService, OntologyTerm, OntologyVersion
 from ontology.ontology_builder import OntologyBuilderDataUpToDateException
+
+# HGNC terms so phenotype_to_genes.txt can link OMIM -> gene (the other symbols in the file stay unresolved)
+TEST_HGNC_GENE_SYMBOLS = {986: "BCKDHA", 2548: "CUBN", 7010: "MEN1"}
+
+
+def _create_hgnc_test_data():
+    ontology_import, _ = OntologyImport.objects.get_or_create(import_source=OntologyService.HGNC, filename="test_hgnc",
+                                                              context="test", defaults={"processed_date": timezone.now(),
+                                                                                        "completed": True})
+    for hgnc_id, symbol in TEST_HGNC_GENE_SYMBOLS.items():
+        GeneSymbol.objects.get_or_create(symbol=symbol)
+        OntologyTerm.objects.get_or_create(id=f"HGNC:{hgnc_id}", defaults={"ontology_service": OntologyService.HGNC,
+                                                                          "index": hgnc_id, "name": symbol,
+                                                                          "from_import": ontology_import})
 
 
 def create_ontology_test_data():
@@ -17,11 +32,14 @@ def create_ontology_test_data():
         test_data_dir = Path(settings.BASE_DIR) / "ontology" / "tests" / "test_data"
         biomart_filename = test_data_dir / "biomart_omim.tsv"
         hpo_filename = test_data_dir / "small.owl"
+        phenotype_to_genes_filename = test_data_dir / "phenotype_to_genes.txt"
 
+        _create_hgnc_test_data()
         # force=False so a database the test runner already seeded (see VariantGridTestRunner) costs
         # an md5 of the file rather than another pronto parse of the OWL
         for loader, filename in [(ontology_import.load_biomart, biomart_filename),
-                                 (ontology_import.load_hpo, hpo_filename)]:
+                                 (ontology_import.load_hpo, hpo_filename),
+                                 (ontology_import.load_phenotype_to_genes, phenotype_to_genes_filename)]:
             try:
                 loader(str(filename), False)
             except OntologyBuilderDataUpToDateException:
@@ -37,7 +55,7 @@ def create_test_ontology_version() -> OntologyVersion:
         if not oi:
             oi, _ = OntologyImport.objects.get_or_create(import_source=import_source, filename=filename,
                                                          defaults={"processed_date": now})
-            kwargs[field] = oi
+        kwargs[field] = oi
     ontology_version = OntologyVersion.objects.filter(**kwargs).first()
     if ontology_version is None:
         ontology_version, _ = OntologyVersion.objects.get_or_create(**kwargs)

--- a/ontology/tests/test_ontology.py
+++ b/ontology/tests/test_ontology.py
@@ -1,9 +1,27 @@
 from django.test import TestCase
 
-from ontology.tests.test_data_ontology import create_ontology_test_data
+from ontology.tests.test_data_ontology import (
+    create_ontology_test_data,
+    create_test_ontology_version,
+)
 
 
 class Test(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        create_ontology_test_data()
+        cls.ontology_version = create_test_ontology_version()
+
     def test_ontology_import_loaders_run(self):
         """ Smoke test - the fixture loaders build the whole test ontology without raising """
-        create_ontology_test_data()
+        self.assertIsNotNone(self.ontology_version)
+
+    def test_phenotype_to_genes_links_hpo_to_gene_symbols(self):
+        """ Five column phenotype_to_genes.txt (2023 format) - HPO -> OMIM -> HGNC, ORPHA rows dropped (#1862) """
+        def symbols_for(hpo_id):
+            return set(self.ontology_version.gene_symbols_for_terms((hpo_id,)).values_list("symbol", flat=True))
+
+        # CUBN is only ORPHA for this term, BCKDHB has no HGNC term
+        self.assertEqual({"BCKDHA", "MEN1"}, symbols_for("HP:0001507"))
+        # MEN1 is only ORPHA for this term, AMN has no HGNC term
+        self.assertEqual({"BCKDHA", "CUBN"}, symbols_for("HP:0004323"))


### PR DESCRIPTION
Addresses #1862 - every HPO term on a phenotype node warned "have no associated genes".

## Cause
HPO changed phenotype_to_genes.txt in 2023 from seven columns behind a `#Format:` comment to five columns with a header row. `load_phenotype_to_genes` read it with the old column names, the `source == mim2gene` filter emptied the frame, and the import completed with zero relations.

## Changes
- `load_phenotype_to_genes` detects the format from the first line, keeps OMIM rows for either format, and raises if the frame is empty. `processor_version` bumped to 2.
- `OntologyBuilder(existing_import=...)` writes into an existing import's partition instead of creating a new import.
- New `backfill_phenotype_to_genes` command: downloads the current file (or takes `--phenotype_to_genes`) and loads it into the import the latest `OntologyVersion` already points at, so no new OntologyVersion / annotation sub-version / gene annotation build follows. Registered as a manual migration step (`ontology/migrations/0028`) whose test fires only when that import owns no relations.
- Five column test fixture and a test covering format detection, the OMIM filter and the HPO -> OMIM -> HGNC path.
- `create_test_ontology_version` now records imports that already exist (was masked by the seeded test database).
- Format history noted in `claude/research/ontology.md`.

## Verification
- Full suite: 3290 tests OK on a freshly rebuilt `--keepdb` database.
- Backfill run locally against today's HPO download: the existing import went from 0 to 533,001 relations, still one OntologyVersion, and `HP:0004808` resolves to CEBPA, BRCA2, GATA2 and others. A second run is a no-op.

## After deploy
Gene annotation `hpo_terms` / `omim_terms` for the existing ontology version were built without these relations; the command prints `gene_annotation --latest-releases --force` for rebuilding them. Phenotype nodes cache empty term lookups for a day, so a term viewed before the backfill may keep its warning until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtmQtLeDUcDJz5kMdEfhhe